### PR TITLE
fix(tekton): string and schema updates

### DIFF
--- a/cdtektonpipelinev2/cd_tekton_pipeline_v2.go
+++ b/cdtektonpipelinev2/cd_tekton_pipeline_v2.go
@@ -1709,8 +1709,8 @@ func (cdTektonPipeline *CdTektonPipelineV2) ListTektonPipelineTriggersWithContex
 	return
 }
 
-// CreateTektonPipelineTrigger : Create a trigger or duplicate a trigger
-// This request creates a trigger, or duplicates a trigger from an existing trigger identified by `{source_trigger_id}`.
+// CreateTektonPipelineTrigger : Create a trigger
+// This request creates a trigger.
 func (cdTektonPipeline *CdTektonPipelineV2) CreateTektonPipelineTrigger(createTektonPipelineTriggerOptions *CreateTektonPipelineTriggerOptions) (result TriggerIntf, response *core.DetailedResponse, err error) {
 	return cdTektonPipeline.CreateTektonPipelineTriggerWithContext(context.Background(), createTektonPipelineTriggerOptions)
 }
@@ -1953,6 +1953,77 @@ func (cdTektonPipeline *CdTektonPipelineV2) DeleteTektonPipelineTriggerWithConte
 	}
 
 	response, err = cdTektonPipeline.Service.Request(request, nil)
+
+	return
+}
+
+// DuplicateTektonPipelineTrigger : Duplicate a trigger
+// This request duplicates a trigger from an existing trigger identified by `{source_trigger_id}`.
+func (cdTektonPipeline *CdTektonPipelineV2) DuplicateTektonPipelineTrigger(duplicateTektonPipelineTriggerOptions *DuplicateTektonPipelineTriggerOptions) (result TriggerIntf, response *core.DetailedResponse, err error) {
+	return cdTektonPipeline.DuplicateTektonPipelineTriggerWithContext(context.Background(), duplicateTektonPipelineTriggerOptions)
+}
+
+// DuplicateTektonPipelineTriggerWithContext is an alternate form of the DuplicateTektonPipelineTrigger method which supports a Context parameter
+func (cdTektonPipeline *CdTektonPipelineV2) DuplicateTektonPipelineTriggerWithContext(ctx context.Context, duplicateTektonPipelineTriggerOptions *DuplicateTektonPipelineTriggerOptions) (result TriggerIntf, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(duplicateTektonPipelineTriggerOptions, "duplicateTektonPipelineTriggerOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(duplicateTektonPipelineTriggerOptions, "duplicateTektonPipelineTriggerOptions")
+	if err != nil {
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"pipeline_id": *duplicateTektonPipelineTriggerOptions.PipelineID,
+		"source_trigger_id": *duplicateTektonPipelineTriggerOptions.SourceTriggerID,
+	}
+
+	builder := core.NewRequestBuilder(core.POST)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = cdTektonPipeline.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(cdTektonPipeline.Service.Options.URL, `/tekton_pipelines/{pipeline_id}/triggers/{source_trigger_id}/duplicate`, pathParamsMap)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range duplicateTektonPipelineTriggerOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("cd_tekton_pipeline", "V2", "DuplicateTektonPipelineTrigger")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+	builder.AddHeader("Content-Type", "application/json")
+
+	body := make(map[string]interface{})
+	if duplicateTektonPipelineTriggerOptions.Name != nil {
+		body["name"] = duplicateTektonPipelineTriggerOptions.Name
+	}
+	_, err = builder.SetBodyContentJSON(body)
+	if err != nil {
+		return
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = cdTektonPipeline.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalTrigger)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
 
 	return
 }
@@ -3096,6 +3167,53 @@ func (options *DeleteTektonPipelineTriggerPropertyOptions) SetHeaders(param map[
 	return options
 }
 
+// DuplicateTektonPipelineTriggerOptions : The DuplicateTektonPipelineTrigger options.
+type DuplicateTektonPipelineTriggerOptions struct {
+	// The Tekton pipeline ID.
+	PipelineID *string `json:"pipeline_id" validate:"required,ne="`
+
+	// The ID of the trigger to duplicate.
+	SourceTriggerID *string `json:"source_trigger_id" validate:"required,ne="`
+
+	// Trigger name.
+	Name *string `json:"name,omitempty"`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// NewDuplicateTektonPipelineTriggerOptions : Instantiate DuplicateTektonPipelineTriggerOptions
+func (*CdTektonPipelineV2) NewDuplicateTektonPipelineTriggerOptions(pipelineID string, sourceTriggerID string) *DuplicateTektonPipelineTriggerOptions {
+	return &DuplicateTektonPipelineTriggerOptions{
+		PipelineID: core.StringPtr(pipelineID),
+		SourceTriggerID: core.StringPtr(sourceTriggerID),
+	}
+}
+
+// SetPipelineID : Allow user to set PipelineID
+func (_options *DuplicateTektonPipelineTriggerOptions) SetPipelineID(pipelineID string) *DuplicateTektonPipelineTriggerOptions {
+	_options.PipelineID = core.StringPtr(pipelineID)
+	return _options
+}
+
+// SetSourceTriggerID : Allow user to set SourceTriggerID
+func (_options *DuplicateTektonPipelineTriggerOptions) SetSourceTriggerID(sourceTriggerID string) *DuplicateTektonPipelineTriggerOptions {
+	_options.SourceTriggerID = core.StringPtr(sourceTriggerID)
+	return _options
+}
+
+// SetName : Allow user to set Name
+func (_options *DuplicateTektonPipelineTriggerOptions) SetName(name string) *DuplicateTektonPipelineTriggerOptions {
+	_options.Name = core.StringPtr(name)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *DuplicateTektonPipelineTriggerOptions) SetHeaders(param map[string]string) *DuplicateTektonPipelineTriggerOptions {
+	options.Headers = param
+	return options
+}
+
 // Events : Only needed for Git triggers. Events object defines the events to which this Git trigger listens.
 type Events struct {
 	// If true, the trigger listens for 'push' Git webhook events.
@@ -3629,8 +3747,8 @@ type ListTektonPipelineRunsOptions struct {
 	// The Tekton pipeline ID.
 	PipelineID *string `json:"pipeline_id" validate:"required,ne="`
 
-	// Token that specifies the pipeline run to start the page on or after. This value is computed and included as a query
-	// param on the `next` link in the response body. Cannot be used in combination with `offset`.
+	// A page token that identifies the start point of the list of pipeline runs. This value is computed and included in
+	// the response body. Cannot be used in combination with `offset`.
 	Start *string `json:"start,omitempty"`
 
 	// The number of pipeline runs to return, sorted by creation time, most recent first.
@@ -4102,12 +4220,12 @@ type PipelineRunsCollection struct {
 	// First page of pipeline runs.
 	First *PipelineRunsCollectionFirst `json:"first" validate:"required"`
 
-	// Next page of pipeline runs relative to the `start` and `limit`, or relative to the `offset` and `limit`, depending
-	// on whether `start` or `offset` params were used in the request.
+	// Next page of pipeline runs relative to the `start` and `limit` params, or relative to the `offset` and `limit`
+	// params, depending on which of `start` or `offset` were used in the request.
 	Next *PipelineRunsCollectionNext `json:"next,omitempty"`
 
-	// Last page of pipeline runs relative to the `start` and `limit`, or relative to the `offset` and `limit`, depending
-	// on whether `start` or `offset` params were used in the request.
+	// Last page of pipeline runs relative to the `start` and `limit` params, or relative to the `offset` and `limit`
+	// params, depending on which of `start` or `offset` were used in the request.
 	Last *PipelineRunsCollectionLast `json:"last,omitempty"`
 }
 
@@ -4171,8 +4289,8 @@ func UnmarshalPipelineRunsCollectionFirst(m map[string]json.RawMessage, result i
 	return
 }
 
-// PipelineRunsCollectionLast : Last page of pipeline runs relative to the `start` and `limit`, or relative to the `offset` and `limit`, depending on
-// whether `start` or `offset` params were used in the request.
+// PipelineRunsCollectionLast : Last page of pipeline runs relative to the `start` and `limit` params, or relative to the `offset` and `limit`
+// params, depending on which of `start` or `offset` were used in the request.
 type PipelineRunsCollectionLast struct {
 	// General href URL.
 	Href *string `json:"href" validate:"required"`
@@ -4189,8 +4307,8 @@ func UnmarshalPipelineRunsCollectionLast(m map[string]json.RawMessage, result in
 	return
 }
 
-// PipelineRunsCollectionNext : Next page of pipeline runs relative to the `start` and `limit`, or relative to the `offset` and `limit`, depending on
-// whether `start` or `offset` params were used in the request.
+// PipelineRunsCollectionNext : Next page of pipeline runs relative to the `start` and `limit` params, or relative to the `offset` and `limit`
+// params, depending on which of `start` or `offset` were used in the request.
 type PipelineRunsCollectionNext struct {
 	// General href URL.
 	Href *string `json:"href" validate:"required"`
@@ -4942,20 +5060,16 @@ func UnmarshalToolchain(m map[string]json.RawMessage, result interface{}) (err e
 
 // Trigger : Tekton pipeline trigger.
 // Models which "extend" this model:
-// - TriggerDuplicateTrigger
 // - TriggerManualTrigger
 // - TriggerScmTrigger
 // - TriggerTimerTrigger
 // - TriggerGenericTrigger
 type Trigger struct {
-	// ID of the trigger to duplicate. Only needed when duplicating a trigger.
-	SourceTriggerID *string `json:"source_trigger_id,omitempty"`
+	// Trigger type.
+	Type *string `json:"type,omitempty"`
 
 	// Trigger name.
 	Name *string `json:"name,omitempty"`
-
-	// Trigger type.
-	Type *string `json:"type,omitempty"`
 
 	// API URL for interacting with the trigger.
 	Href *string `json:"href,omitempty"`
@@ -5008,15 +5122,11 @@ type TriggerIntf interface {
 // UnmarshalTrigger unmarshals an instance of Trigger from the specified map of raw messages.
 func UnmarshalTrigger(m map[string]json.RawMessage, result interface{}) (err error) {
 	obj := new(Trigger)
-	err = core.UnmarshalPrimitive(m, "source_trigger_id", &obj.SourceTriggerID)
+	err = core.UnmarshalPrimitive(m, "type", &obj.Type)
 	if err != nil {
 		return
 	}
 	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "type", &obj.Type)
 	if err != nil {
 		return
 	}
@@ -5943,45 +6053,6 @@ func (*CdTektonPipelineV2) NewWorkerWithID(id string) (_model *WorkerWithID, err
 func UnmarshalWorkerWithID(m map[string]json.RawMessage, result interface{}) (err error) {
 	obj := new(WorkerWithID)
 	err = core.UnmarshalPrimitive(m, "id", &obj.ID)
-	if err != nil {
-		return
-	}
-	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
-	return
-}
-
-// TriggerDuplicateTrigger : Duplicate an existing trigger.
-// This model "extends" Trigger
-type TriggerDuplicateTrigger struct {
-	// ID of the trigger to duplicate. Only needed when duplicating a trigger.
-	SourceTriggerID *string `json:"source_trigger_id" validate:"required"`
-
-	// Trigger name.
-	Name *string `json:"name" validate:"required"`
-}
-
-// NewTriggerDuplicateTrigger : Instantiate TriggerDuplicateTrigger (Generic Model Constructor)
-func (*CdTektonPipelineV2) NewTriggerDuplicateTrigger(sourceTriggerID string, name string) (_model *TriggerDuplicateTrigger, err error) {
-	_model = &TriggerDuplicateTrigger{
-		SourceTriggerID: core.StringPtr(sourceTriggerID),
-		Name: core.StringPtr(name),
-	}
-	err = core.ValidateStruct(_model, "required parameters")
-	return
-}
-
-func (*TriggerDuplicateTrigger) isaTrigger() bool {
-	return true
-}
-
-// UnmarshalTriggerDuplicateTrigger unmarshals an instance of TriggerDuplicateTrigger from the specified map of raw messages.
-func UnmarshalTriggerDuplicateTrigger(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(TriggerDuplicateTrigger)
-	err = core.UnmarshalPrimitive(m, "source_trigger_id", &obj.SourceTriggerID)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
 	if err != nil {
 		return
 	}

--- a/cdtektonpipelinev2/cd_tekton_pipeline_v2.go
+++ b/cdtektonpipelinev2/cd_tekton_pipeline_v2.go
@@ -180,10 +180,10 @@ func (cdTektonPipeline *CdTektonPipelineV2) DisableRetries() {
 	cdTektonPipeline.Service.DisableRetries()
 }
 
-// CreateTektonPipeline : Create tekton pipeline
-// This request creates a tekton pipeline for a tekton pipeline toolchain integration, user has to use the toolchain
-// endpoint to create the tekton pipeline toolchain integration first and then use the generated UUID to create the
-// tekton pipeline with or without a specified worker.
+// CreateTektonPipeline : Create Tekton pipeline
+// This request creates a Tekton pipeline for a Tekton pipeline toolchain integration. User must use the toolchain
+// endpoint to create the Tekton pipeline toolchain integration first, and then use the generated UUID to create the
+// Tekton pipeline.
 func (cdTektonPipeline *CdTektonPipelineV2) CreateTektonPipeline(createTektonPipelineOptions *CreateTektonPipelineOptions) (result *TektonPipeline, response *core.DetailedResponse, err error) {
 	return cdTektonPipeline.CreateTektonPipelineWithContext(context.Background(), createTektonPipelineOptions)
 }
@@ -247,8 +247,8 @@ func (cdTektonPipeline *CdTektonPipelineV2) CreateTektonPipelineWithContext(ctx 
 	return
 }
 
-// GetTektonPipeline : Get tekton pipeline data
-// This request retrieves whole tekton pipeline data.
+// GetTektonPipeline : Get Tekton pipeline data
+// This request retrieves the Tekton pipeline data for the pipeline identified by `{id}`.
 func (cdTektonPipeline *CdTektonPipelineV2) GetTektonPipeline(getTektonPipelineOptions *GetTektonPipelineOptions) (result *TektonPipeline, response *core.DetailedResponse, err error) {
 	return cdTektonPipeline.GetTektonPipelineWithContext(context.Background(), getTektonPipelineOptions)
 }
@@ -307,9 +307,9 @@ func (cdTektonPipeline *CdTektonPipelineV2) GetTektonPipelineWithContext(ctx con
 	return
 }
 
-// UpdateTektonPipeline : Update tekton pipeline data
-// This request updates tekton pipeline data, but you can only change worker ID in this endpoint. Use other endpoints
-// such as /definitions, /triggers, and /properties for detailed updated.
+// UpdateTektonPipeline : Update Tekton pipeline data
+// This request updates Tekton pipeline data, but you can only change worker ID in this endpoint. Use other endpoints
+// such as /definitions, /triggers, and /properties for other configuration updates.
 func (cdTektonPipeline *CdTektonPipelineV2) UpdateTektonPipeline(updateTektonPipelineOptions *UpdateTektonPipelineOptions) (result *TektonPipeline, response *core.DetailedResponse, err error) {
 	return cdTektonPipeline.UpdateTektonPipelineWithContext(context.Background(), updateTektonPipelineOptions)
 }
@@ -378,8 +378,8 @@ func (cdTektonPipeline *CdTektonPipelineV2) UpdateTektonPipelineWithContext(ctx 
 	return
 }
 
-// DeleteTektonPipeline : Delete tekton pipeline instance
-// This request deletes tekton pipeline instance that associated with the pipeline toolchain integration.
+// DeleteTektonPipeline : Delete Tekton pipeline instance
+// This request deletes Tekton pipeline instance that is associated with the pipeline toolchain integration.
 func (cdTektonPipeline *CdTektonPipelineV2) DeleteTektonPipeline(deleteTektonPipelineOptions *DeleteTektonPipelineOptions) (response *core.DetailedResponse, err error) {
 	return cdTektonPipeline.DeleteTektonPipelineWithContext(context.Background(), deleteTektonPipelineOptions)
 }
@@ -427,14 +427,14 @@ func (cdTektonPipeline *CdTektonPipelineV2) DeleteTektonPipelineWithContext(ctx 
 }
 
 // ListTektonPipelineRuns : List pipeline run records
-// This request list pipeline run records, which has data of that run, such as status, user_info, trigger and other
+// This request lists pipeline run records, which has data about the runs, such as status, user_info, trigger and other
 // information. Default limit is 50.
-func (cdTektonPipeline *CdTektonPipelineV2) ListTektonPipelineRuns(listTektonPipelineRunsOptions *ListTektonPipelineRunsOptions) (result *PipelineRuns, response *core.DetailedResponse, err error) {
+func (cdTektonPipeline *CdTektonPipelineV2) ListTektonPipelineRuns(listTektonPipelineRunsOptions *ListTektonPipelineRunsOptions) (result *PipelineRunsCollection, response *core.DetailedResponse, err error) {
 	return cdTektonPipeline.ListTektonPipelineRunsWithContext(context.Background(), listTektonPipelineRunsOptions)
 }
 
 // ListTektonPipelineRunsWithContext is an alternate form of the ListTektonPipelineRuns method which supports a Context parameter
-func (cdTektonPipeline *CdTektonPipelineV2) ListTektonPipelineRunsWithContext(ctx context.Context, listTektonPipelineRunsOptions *ListTektonPipelineRunsOptions) (result *PipelineRuns, response *core.DetailedResponse, err error) {
+func (cdTektonPipeline *CdTektonPipelineV2) ListTektonPipelineRunsWithContext(ctx context.Context, listTektonPipelineRunsOptions *ListTektonPipelineRunsOptions) (result *PipelineRunsCollection, response *core.DetailedResponse, err error) {
 	err = core.ValidateNotNil(listTektonPipelineRunsOptions, "listTektonPipelineRunsOptions cannot be nil")
 	if err != nil {
 		return
@@ -490,7 +490,7 @@ func (cdTektonPipeline *CdTektonPipelineV2) ListTektonPipelineRunsWithContext(ct
 		return
 	}
 	if rawResponse != nil {
-		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalPipelineRuns)
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalPipelineRunsCollection)
 		if err != nil {
 			return
 		}
@@ -500,8 +500,8 @@ func (cdTektonPipeline *CdTektonPipelineV2) ListTektonPipelineRunsWithContext(ct
 	return
 }
 
-// CreateTektonPipelineRun : Start a trigger to create a pipelineRun
-// This request executes a trigger to create a pipelineRun.
+// CreateTektonPipelineRun : Trigger a pipeline run
+// Trigger a new pipeline run using the named trigger, using the provided additional or override properties.
 func (cdTektonPipeline *CdTektonPipelineV2) CreateTektonPipelineRun(createTektonPipelineRunOptions *CreateTektonPipelineRunOptions) (result *PipelineRun, response *core.DetailedResponse, err error) {
 	return cdTektonPipeline.CreateTektonPipelineRunWithContext(context.Background(), createTektonPipelineRunOptions)
 }
@@ -583,8 +583,8 @@ func (cdTektonPipeline *CdTektonPipelineV2) CreateTektonPipelineRunWithContext(c
 }
 
 // GetTektonPipelineRun : Get a pipeline run record
-// This request retrieves detail of requested pipeline run, to get Kubernetes Resources List of this pipeline run use
-// endpoint /tekton_pipelines/{pipeline_id}/tekton_pipelinerun_resource_list/{id}.
+// This request retrieves details of the pipeline run identified by `{id}`. To get the Kubernetes resource list of this
+// pipeline run use the endpoint `/tekton_pipelines/{pipeline_id}/tekton_pipelinerun_resource_list/{id}`.
 func (cdTektonPipeline *CdTektonPipelineV2) GetTektonPipelineRun(getTektonPipelineRunOptions *GetTektonPipelineRunOptions) (result *PipelineRun, response *core.DetailedResponse, err error) {
 	return cdTektonPipeline.GetTektonPipelineRunWithContext(context.Background(), getTektonPipelineRunOptions)
 }
@@ -649,7 +649,7 @@ func (cdTektonPipeline *CdTektonPipelineV2) GetTektonPipelineRunWithContext(ctx 
 }
 
 // DeleteTektonPipelineRun : Delete a pipeline run record
-// This request deletes the requested pipeline run record.
+// This request deletes the pipeline run record identified by `{id}`.
 func (cdTektonPipeline *CdTektonPipelineV2) DeleteTektonPipelineRun(deleteTektonPipelineRunOptions *DeleteTektonPipelineRunOptions) (response *core.DetailedResponse, err error) {
 	return cdTektonPipeline.DeleteTektonPipelineRunWithContext(context.Background(), deleteTektonPipelineRunOptions)
 }
@@ -698,7 +698,8 @@ func (cdTektonPipeline *CdTektonPipelineV2) DeleteTektonPipelineRunWithContext(c
 }
 
 // CancelTektonPipelineRun : Cancel a pipeline run
-// This request cancels a running pipeline run, use 'force' payload in case you can't cancel a pipeline run normally.
+// This request cancels a running pipeline run identified by `{id}`. Use `force: true` in the body if the pipeline run
+// can't be cancelled normally.
 func (cdTektonPipeline *CdTektonPipelineV2) CancelTektonPipelineRun(cancelTektonPipelineRunOptions *CancelTektonPipelineRunOptions) (result *PipelineRun, response *core.DetailedResponse, err error) {
 	return cdTektonPipeline.CancelTektonPipelineRunWithContext(context.Background(), cancelTektonPipelineRunOptions)
 }
@@ -769,7 +770,8 @@ func (cdTektonPipeline *CdTektonPipelineV2) CancelTektonPipelineRunWithContext(c
 }
 
 // RerunTektonPipelineRun : Rerun a pipeline run
-// This request reruns a past pipeline run with same data. Request body isn't allowed.
+// This request reruns a past pipeline run, which is identified by `{id}`, with the same data. Request body isn't
+// allowed.
 func (cdTektonPipeline *CdTektonPipelineV2) RerunTektonPipelineRun(rerunTektonPipelineRunOptions *RerunTektonPipelineRunOptions) (result *PipelineRun, response *core.DetailedResponse, err error) {
 	return cdTektonPipeline.RerunTektonPipelineRunWithContext(context.Background(), rerunTektonPipelineRunOptions)
 }
@@ -830,13 +832,13 @@ func (cdTektonPipeline *CdTektonPipelineV2) RerunTektonPipelineRunWithContext(ct
 }
 
 // GetTektonPipelineRunLogs : Get a list of pipeline run log IDs
-// This request fetches list of log IDs of a pipeline run.
-func (cdTektonPipeline *CdTektonPipelineV2) GetTektonPipelineRunLogs(getTektonPipelineRunLogsOptions *GetTektonPipelineRunLogsOptions) (result *PipelineRunLogs, response *core.DetailedResponse, err error) {
+// This request fetches the list of log IDs for a pipeline run identified by `{id}`.
+func (cdTektonPipeline *CdTektonPipelineV2) GetTektonPipelineRunLogs(getTektonPipelineRunLogsOptions *GetTektonPipelineRunLogsOptions) (result *LogsCollection, response *core.DetailedResponse, err error) {
 	return cdTektonPipeline.GetTektonPipelineRunLogsWithContext(context.Background(), getTektonPipelineRunLogsOptions)
 }
 
 // GetTektonPipelineRunLogsWithContext is an alternate form of the GetTektonPipelineRunLogs method which supports a Context parameter
-func (cdTektonPipeline *CdTektonPipelineV2) GetTektonPipelineRunLogsWithContext(ctx context.Context, getTektonPipelineRunLogsOptions *GetTektonPipelineRunLogsOptions) (result *PipelineRunLogs, response *core.DetailedResponse, err error) {
+func (cdTektonPipeline *CdTektonPipelineV2) GetTektonPipelineRunLogsWithContext(ctx context.Context, getTektonPipelineRunLogsOptions *GetTektonPipelineRunLogsOptions) (result *LogsCollection, response *core.DetailedResponse, err error) {
 	err = core.ValidateNotNil(getTektonPipelineRunLogsOptions, "getTektonPipelineRunLogsOptions cannot be nil")
 	if err != nil {
 		return
@@ -880,7 +882,7 @@ func (cdTektonPipeline *CdTektonPipelineV2) GetTektonPipelineRunLogsWithContext(
 		return
 	}
 	if rawResponse != nil {
-		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalPipelineRunLogs)
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalLogsCollection)
 		if err != nil {
 			return
 		}
@@ -890,15 +892,15 @@ func (cdTektonPipeline *CdTektonPipelineV2) GetTektonPipelineRunLogsWithContext(
 	return
 }
 
-// GetTektonPipelineRunLogContent : Get the log content of a pipeline run step by using the step log ID
-// This request retrieves log content of a pipeline run step, to get the log ID use endpoint
-// /tekton_pipelines/{pipeline_id}/pipeline_runs/{id}/logs.
-func (cdTektonPipeline *CdTektonPipelineV2) GetTektonPipelineRunLogContent(getTektonPipelineRunLogContentOptions *GetTektonPipelineRunLogContentOptions) (result *StepLog, response *core.DetailedResponse, err error) {
+// GetTektonPipelineRunLogContent : Get the log content of a pipeline run step
+// This request retrieves the log content of a pipeline run step, where the step is identified by `{id}`. To get the log
+// ID use the endpoint `/tekton_pipelines/{pipeline_id}/pipeline_runs/{id}/logs`.
+func (cdTektonPipeline *CdTektonPipelineV2) GetTektonPipelineRunLogContent(getTektonPipelineRunLogContentOptions *GetTektonPipelineRunLogContentOptions) (result *Log, response *core.DetailedResponse, err error) {
 	return cdTektonPipeline.GetTektonPipelineRunLogContentWithContext(context.Background(), getTektonPipelineRunLogContentOptions)
 }
 
 // GetTektonPipelineRunLogContentWithContext is an alternate form of the GetTektonPipelineRunLogContent method which supports a Context parameter
-func (cdTektonPipeline *CdTektonPipelineV2) GetTektonPipelineRunLogContentWithContext(ctx context.Context, getTektonPipelineRunLogContentOptions *GetTektonPipelineRunLogContentOptions) (result *StepLog, response *core.DetailedResponse, err error) {
+func (cdTektonPipeline *CdTektonPipelineV2) GetTektonPipelineRunLogContentWithContext(ctx context.Context, getTektonPipelineRunLogContentOptions *GetTektonPipelineRunLogContentOptions) (result *Log, response *core.DetailedResponse, err error) {
 	err = core.ValidateNotNil(getTektonPipelineRunLogContentOptions, "getTektonPipelineRunLogContentOptions cannot be nil")
 	if err != nil {
 		return
@@ -943,7 +945,7 @@ func (cdTektonPipeline *CdTektonPipelineV2) GetTektonPipelineRunLogContentWithCo
 		return
 	}
 	if rawResponse != nil {
-		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalStepLog)
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalLog)
 		if err != nil {
 			return
 		}
@@ -954,14 +956,14 @@ func (cdTektonPipeline *CdTektonPipelineV2) GetTektonPipelineRunLogContentWithCo
 }
 
 // ListTektonPipelineDefinitions : List pipeline definitions
-// This request fetches pipeline definitions, which is the a collection of individual definition entries, each entry is
-// a composition of a repo url, a repo branch and a repo path.
-func (cdTektonPipeline *CdTektonPipelineV2) ListTektonPipelineDefinitions(listTektonPipelineDefinitionsOptions *ListTektonPipelineDefinitionsOptions) (result *Definitions, response *core.DetailedResponse, err error) {
+// This request fetches pipeline definitions, which is a collection of individual definition entries. Each entry
+// consists of a repository url, a repository branch and a repository path.
+func (cdTektonPipeline *CdTektonPipelineV2) ListTektonPipelineDefinitions(listTektonPipelineDefinitionsOptions *ListTektonPipelineDefinitionsOptions) (result *DefinitionsCollection, response *core.DetailedResponse, err error) {
 	return cdTektonPipeline.ListTektonPipelineDefinitionsWithContext(context.Background(), listTektonPipelineDefinitionsOptions)
 }
 
 // ListTektonPipelineDefinitionsWithContext is an alternate form of the ListTektonPipelineDefinitions method which supports a Context parameter
-func (cdTektonPipeline *CdTektonPipelineV2) ListTektonPipelineDefinitionsWithContext(ctx context.Context, listTektonPipelineDefinitionsOptions *ListTektonPipelineDefinitionsOptions) (result *Definitions, response *core.DetailedResponse, err error) {
+func (cdTektonPipeline *CdTektonPipelineV2) ListTektonPipelineDefinitionsWithContext(ctx context.Context, listTektonPipelineDefinitionsOptions *ListTektonPipelineDefinitionsOptions) (result *DefinitionsCollection, response *core.DetailedResponse, err error) {
 	err = core.ValidateNotNil(listTektonPipelineDefinitionsOptions, "listTektonPipelineDefinitionsOptions cannot be nil")
 	if err != nil {
 		return
@@ -1004,7 +1006,7 @@ func (cdTektonPipeline *CdTektonPipelineV2) ListTektonPipelineDefinitionsWithCon
 		return
 	}
 	if rawResponse != nil {
-		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalDefinitions)
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalDefinitionsCollection)
 		if err != nil {
 			return
 		}
@@ -1058,6 +1060,12 @@ func (cdTektonPipeline *CdTektonPipelineV2) CreateTektonPipelineDefinitionWithCo
 	if createTektonPipelineDefinitionOptions.ScmSource != nil {
 		body["scm_source"] = createTektonPipelineDefinitionOptions.ScmSource
 	}
+	if createTektonPipelineDefinitionOptions.ServiceInstanceID != nil {
+		body["service_instance_id"] = createTektonPipelineDefinitionOptions.ServiceInstanceID
+	}
+	if createTektonPipelineDefinitionOptions.ID != nil {
+		body["id"] = createTektonPipelineDefinitionOptions.ID
+	}
 	_, err = builder.SetBodyContentJSON(body)
 	if err != nil {
 		return
@@ -1085,8 +1093,7 @@ func (cdTektonPipeline *CdTektonPipelineV2) CreateTektonPipelineDefinitionWithCo
 }
 
 // GetTektonPipelineDefinition : Retrieve a single definition entry
-// This request fetches a single definition entry, which is a composition of the definition repo's url, branch and
-// directory path.
+// This request fetches a single definition entry, which consists of the definition repository URL, branch/tag and path.
 func (cdTektonPipeline *CdTektonPipelineV2) GetTektonPipelineDefinition(getTektonPipelineDefinitionOptions *GetTektonPipelineDefinitionOptions) (result *Definition, response *core.DetailedResponse, err error) {
 	return cdTektonPipeline.GetTektonPipelineDefinitionWithContext(context.Background(), getTektonPipelineDefinitionOptions)
 }
@@ -1147,8 +1154,8 @@ func (cdTektonPipeline *CdTektonPipelineV2) GetTektonPipelineDefinitionWithConte
 }
 
 // ReplaceTektonPipelineDefinition : Edit a single definition entry
-// This request replaces a single definition's repo directory path or repo branch. Its scm_source.url and
-// service_instance_id are immutable.
+// This request updates a definition entry identified by `{definition_id}`. The service_instance_id property is
+// immutable.
 func (cdTektonPipeline *CdTektonPipelineV2) ReplaceTektonPipelineDefinition(replaceTektonPipelineDefinitionOptions *ReplaceTektonPipelineDefinitionOptions) (result *Definition, response *core.DetailedResponse, err error) {
 	return cdTektonPipeline.ReplaceTektonPipelineDefinitionWithContext(context.Background(), replaceTektonPipelineDefinitionOptions)
 }
@@ -1225,7 +1232,7 @@ func (cdTektonPipeline *CdTektonPipelineV2) ReplaceTektonPipelineDefinitionWithC
 }
 
 // DeleteTektonPipelineDefinition : Delete a single definition entry
-// This request deletes a single definition from definition list.
+// This request deletes a single definition from the definition list.
 func (cdTektonPipeline *CdTektonPipelineV2) DeleteTektonPipelineDefinition(deleteTektonPipelineDefinitionOptions *DeleteTektonPipelineDefinitionOptions) (response *core.DetailedResponse, err error) {
 	return cdTektonPipeline.DeleteTektonPipelineDefinitionWithContext(context.Background(), deleteTektonPipelineDefinitionOptions)
 }
@@ -1273,14 +1280,14 @@ func (cdTektonPipeline *CdTektonPipelineV2) DeleteTektonPipelineDefinitionWithCo
 	return
 }
 
-// ListTektonPipelineProperties : List pipeline environment properties
-// This request lists the pipeline environment properties which every pipelineRun execution has access to.
-func (cdTektonPipeline *CdTektonPipelineV2) ListTektonPipelineProperties(listTektonPipelinePropertiesOptions *ListTektonPipelinePropertiesOptions) (result *EnvProperties, response *core.DetailedResponse, err error) {
+// ListTektonPipelineProperties : List the pipeline's environment properties
+// This request lists the environment properties the pipeline identified by `{pipeline_id}`.
+func (cdTektonPipeline *CdTektonPipelineV2) ListTektonPipelineProperties(listTektonPipelinePropertiesOptions *ListTektonPipelinePropertiesOptions) (result *PropertiesCollection, response *core.DetailedResponse, err error) {
 	return cdTektonPipeline.ListTektonPipelinePropertiesWithContext(context.Background(), listTektonPipelinePropertiesOptions)
 }
 
 // ListTektonPipelinePropertiesWithContext is an alternate form of the ListTektonPipelineProperties method which supports a Context parameter
-func (cdTektonPipeline *CdTektonPipelineV2) ListTektonPipelinePropertiesWithContext(ctx context.Context, listTektonPipelinePropertiesOptions *ListTektonPipelinePropertiesOptions) (result *EnvProperties, response *core.DetailedResponse, err error) {
+func (cdTektonPipeline *CdTektonPipelineV2) ListTektonPipelinePropertiesWithContext(ctx context.Context, listTektonPipelinePropertiesOptions *ListTektonPipelinePropertiesOptions) (result *PropertiesCollection, response *core.DetailedResponse, err error) {
 	err = core.ValidateNotNil(listTektonPipelinePropertiesOptions, "listTektonPipelinePropertiesOptions cannot be nil")
 	if err != nil {
 		return
@@ -1333,7 +1340,7 @@ func (cdTektonPipeline *CdTektonPipelineV2) ListTektonPipelinePropertiesWithCont
 		return
 	}
 	if rawResponse != nil {
-		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalEnvProperties)
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalPropertiesCollection)
 		if err != nil {
 			return
 		}
@@ -1343,8 +1350,8 @@ func (cdTektonPipeline *CdTektonPipelineV2) ListTektonPipelinePropertiesWithCont
 	return
 }
 
-// CreateTektonPipelineProperties : Create pipeline environment property
-// This request creates a single pipeline environment property.
+// CreateTektonPipelineProperties : Create a pipeline environment property
+// This request creates an environment property.
 func (cdTektonPipeline *CdTektonPipelineV2) CreateTektonPipelineProperties(createTektonPipelinePropertiesOptions *CreateTektonPipelinePropertiesOptions) (result *Property, response *core.DetailedResponse, err error) {
 	return cdTektonPipeline.CreateTektonPipelinePropertiesWithContext(context.Background(), createTektonPipelinePropertiesOptions)
 }
@@ -1428,8 +1435,8 @@ func (cdTektonPipeline *CdTektonPipelineV2) CreateTektonPipelinePropertiesWithCo
 	return
 }
 
-// GetTektonPipelineProperty : Get a single pipeline environment property
-// This request gets a single pipeline environment property data.
+// GetTektonPipelineProperty : Get a pipeline environment property
+// This request gets the data of an environment property identified by `{property_name}`.
 func (cdTektonPipeline *CdTektonPipelineV2) GetTektonPipelineProperty(getTektonPipelinePropertyOptions *GetTektonPipelinePropertyOptions) (result *Property, response *core.DetailedResponse, err error) {
 	return cdTektonPipeline.GetTektonPipelinePropertyWithContext(context.Background(), getTektonPipelinePropertyOptions)
 }
@@ -1489,9 +1496,9 @@ func (cdTektonPipeline *CdTektonPipelineV2) GetTektonPipelinePropertyWithContext
 	return
 }
 
-// ReplaceTektonPipelineProperty : Replace a single pipeline environment property value
-// This request updates a single pipeline environment property value, its type or name are immutable. For any property
-// type, the entered value replaces the existing value.
+// ReplaceTektonPipelineProperty : Replace the value of an environment property
+// This request updates the value of an environment property identified by `{property_name}`, its type or name are
+// immutable.
 func (cdTektonPipeline *CdTektonPipelineV2) ReplaceTektonPipelineProperty(replaceTektonPipelinePropertyOptions *ReplaceTektonPipelinePropertyOptions) (result *Property, response *core.DetailedResponse, err error) {
 	return cdTektonPipeline.ReplaceTektonPipelinePropertyWithContext(context.Background(), replaceTektonPipelinePropertyOptions)
 }
@@ -1626,13 +1633,13 @@ func (cdTektonPipeline *CdTektonPipelineV2) DeleteTektonPipelinePropertyWithCont
 }
 
 // ListTektonPipelineTriggers : List pipeline triggers
-// This request lists pipeline triggers.
-func (cdTektonPipeline *CdTektonPipelineV2) ListTektonPipelineTriggers(listTektonPipelineTriggersOptions *ListTektonPipelineTriggersOptions) (result *Triggers, response *core.DetailedResponse, err error) {
+// This request lists pipeline triggers for the pipeline identified by `{pipeline_id}`.
+func (cdTektonPipeline *CdTektonPipelineV2) ListTektonPipelineTriggers(listTektonPipelineTriggersOptions *ListTektonPipelineTriggersOptions) (result *TriggersCollection, response *core.DetailedResponse, err error) {
 	return cdTektonPipeline.ListTektonPipelineTriggersWithContext(context.Background(), listTektonPipelineTriggersOptions)
 }
 
 // ListTektonPipelineTriggersWithContext is an alternate form of the ListTektonPipelineTriggers method which supports a Context parameter
-func (cdTektonPipeline *CdTektonPipelineV2) ListTektonPipelineTriggersWithContext(ctx context.Context, listTektonPipelineTriggersOptions *ListTektonPipelineTriggersOptions) (result *Triggers, response *core.DetailedResponse, err error) {
+func (cdTektonPipeline *CdTektonPipelineV2) ListTektonPipelineTriggersWithContext(ctx context.Context, listTektonPipelineTriggersOptions *ListTektonPipelineTriggersOptions) (result *TriggersCollection, response *core.DetailedResponse, err error) {
 	err = core.ValidateNotNil(listTektonPipelineTriggersOptions, "listTektonPipelineTriggersOptions cannot be nil")
 	if err != nil {
 		return
@@ -1697,7 +1704,7 @@ func (cdTektonPipeline *CdTektonPipelineV2) ListTektonPipelineTriggersWithContex
 		return
 	}
 	if rawResponse != nil {
-		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalTriggers)
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalTriggersCollection)
 		if err != nil {
 			return
 		}
@@ -1708,7 +1715,7 @@ func (cdTektonPipeline *CdTektonPipelineV2) ListTektonPipelineTriggersWithContex
 }
 
 // CreateTektonPipelineTrigger : Create a trigger or duplicate a trigger
-// This request creates a trigger or duplicate a trigger from an existing trigger.
+// This request creates a trigger, or duplicates a trigger from an existing trigger identified by `{source_trigger_id}`.
 func (cdTektonPipeline *CdTektonPipelineV2) CreateTektonPipelineTrigger(createTektonPipelineTriggerOptions *CreateTektonPipelineTriggerOptions) (result TriggerIntf, response *core.DetailedResponse, err error) {
 	return cdTektonPipeline.CreateTektonPipelineTriggerWithContext(context.Background(), createTektonPipelineTriggerOptions)
 }
@@ -1776,7 +1783,7 @@ func (cdTektonPipeline *CdTektonPipelineV2) CreateTektonPipelineTriggerWithConte
 }
 
 // GetTektonPipelineTrigger : Get a single trigger
-// This request retrieves a single trigger detail.
+// This request retrieves a single trigger identified by `{trigger_id}`.
 func (cdTektonPipeline *CdTektonPipelineV2) GetTektonPipelineTrigger(getTektonPipelineTriggerOptions *GetTektonPipelineTriggerOptions) (result TriggerIntf, response *core.DetailedResponse, err error) {
 	return cdTektonPipeline.GetTektonPipelineTriggerWithContext(context.Background(), getTektonPipelineTriggerOptions)
 }
@@ -1836,9 +1843,9 @@ func (cdTektonPipeline *CdTektonPipelineV2) GetTektonPipelineTriggerWithContext(
 	return
 }
 
-// UpdateTektonPipelineTrigger : Edit a single trigger entry
-// This request changes a single field or many fields of a trigger, note that some fields are immutable, and use
-// /properties to update trigger properties.
+// UpdateTektonPipelineTrigger : Edit a trigger
+// This request changes a single field or many fields of the trigger identified by `{trigger_id}`. Note that some fields
+// are immutable, and use `/properties` endpoint to update trigger properties.
 func (cdTektonPipeline *CdTektonPipelineV2) UpdateTektonPipelineTrigger(updateTektonPipelineTriggerOptions *UpdateTektonPipelineTriggerOptions) (result TriggerIntf, response *core.DetailedResponse, err error) {
 	return cdTektonPipeline.UpdateTektonPipelineTriggerWithContext(context.Background(), updateTektonPipelineTriggerOptions)
 }
@@ -1894,8 +1901,8 @@ func (cdTektonPipeline *CdTektonPipelineV2) UpdateTektonPipelineTriggerWithConte
 	if updateTektonPipelineTriggerOptions.Worker != nil {
 		body["worker"] = updateTektonPipelineTriggerOptions.Worker
 	}
-	if updateTektonPipelineTriggerOptions.Concurrency != nil {
-		body["concurrency"] = updateTektonPipelineTriggerOptions.Concurrency
+	if updateTektonPipelineTriggerOptions.MaxConcurrentRuns != nil {
+		body["max_concurrent_runs"] = updateTektonPipelineTriggerOptions.MaxConcurrentRuns
 	}
 	if updateTektonPipelineTriggerOptions.Disabled != nil {
 		body["disabled"] = updateTektonPipelineTriggerOptions.Disabled
@@ -1942,7 +1949,7 @@ func (cdTektonPipeline *CdTektonPipelineV2) UpdateTektonPipelineTriggerWithConte
 }
 
 // DeleteTektonPipelineTrigger : Delete a single trigger
-// This request deletes a single trigger.
+// This request deletes the trigger identified by `{trigger_id}`.
 func (cdTektonPipeline *CdTektonPipelineV2) DeleteTektonPipelineTrigger(deleteTektonPipelineTriggerOptions *DeleteTektonPipelineTriggerOptions) (response *core.DetailedResponse, err error) {
 	return cdTektonPipeline.DeleteTektonPipelineTriggerWithContext(context.Background(), deleteTektonPipelineTriggerOptions)
 }
@@ -1990,14 +1997,14 @@ func (cdTektonPipeline *CdTektonPipelineV2) DeleteTektonPipelineTriggerWithConte
 	return
 }
 
-// ListTektonPipelineTriggerProperties : List trigger environment properties
-// This request lists trigger environment properties.
-func (cdTektonPipeline *CdTektonPipelineV2) ListTektonPipelineTriggerProperties(listTektonPipelineTriggerPropertiesOptions *ListTektonPipelineTriggerPropertiesOptions) (result *TriggerProperties, response *core.DetailedResponse, err error) {
+// ListTektonPipelineTriggerProperties : List trigger properties
+// This request lists trigger properties for the trigger identified by `{trigger_id}`.
+func (cdTektonPipeline *CdTektonPipelineV2) ListTektonPipelineTriggerProperties(listTektonPipelineTriggerPropertiesOptions *ListTektonPipelineTriggerPropertiesOptions) (result *TriggerPropertiesCollection, response *core.DetailedResponse, err error) {
 	return cdTektonPipeline.ListTektonPipelineTriggerPropertiesWithContext(context.Background(), listTektonPipelineTriggerPropertiesOptions)
 }
 
 // ListTektonPipelineTriggerPropertiesWithContext is an alternate form of the ListTektonPipelineTriggerProperties method which supports a Context parameter
-func (cdTektonPipeline *CdTektonPipelineV2) ListTektonPipelineTriggerPropertiesWithContext(ctx context.Context, listTektonPipelineTriggerPropertiesOptions *ListTektonPipelineTriggerPropertiesOptions) (result *TriggerProperties, response *core.DetailedResponse, err error) {
+func (cdTektonPipeline *CdTektonPipelineV2) ListTektonPipelineTriggerPropertiesWithContext(ctx context.Context, listTektonPipelineTriggerPropertiesOptions *ListTektonPipelineTriggerPropertiesOptions) (result *TriggerPropertiesCollection, response *core.DetailedResponse, err error) {
 	err = core.ValidateNotNil(listTektonPipelineTriggerPropertiesOptions, "listTektonPipelineTriggerPropertiesOptions cannot be nil")
 	if err != nil {
 		return
@@ -2045,7 +2052,7 @@ func (cdTektonPipeline *CdTektonPipelineV2) ListTektonPipelineTriggerPropertiesW
 		return
 	}
 	if rawResponse != nil {
-		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalTriggerProperties)
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalTriggerPropertiesCollection)
 		if err != nil {
 			return
 		}
@@ -2055,8 +2062,8 @@ func (cdTektonPipeline *CdTektonPipelineV2) ListTektonPipelineTriggerPropertiesW
 	return
 }
 
-// CreateTektonPipelineTriggerProperties : Create trigger's environment property
-// This request creates a trigger's property.
+// CreateTektonPipelineTriggerProperties : Create a trigger property
+// This request creates a property in the trigger identified by `{trigger_id}`.
 func (cdTektonPipeline *CdTektonPipelineV2) CreateTektonPipelineTriggerProperties(createTektonPipelineTriggerPropertiesOptions *CreateTektonPipelineTriggerPropertiesOptions) (result *TriggerProperty, response *core.DetailedResponse, err error) {
 	return cdTektonPipeline.CreateTektonPipelineTriggerPropertiesWithContext(context.Background(), createTektonPipelineTriggerPropertiesOptions)
 }
@@ -2141,8 +2148,8 @@ func (cdTektonPipeline *CdTektonPipelineV2) CreateTektonPipelineTriggerPropertie
 	return
 }
 
-// GetTektonPipelineTriggerProperty : Get a trigger's environment property
-// This request retrieves a trigger's environment property.
+// GetTektonPipelineTriggerProperty : Get a trigger property
+// This request retrieves a trigger property.
 func (cdTektonPipeline *CdTektonPipelineV2) GetTektonPipelineTriggerProperty(getTektonPipelineTriggerPropertyOptions *GetTektonPipelineTriggerPropertyOptions) (result *TriggerProperty, response *core.DetailedResponse, err error) {
 	return cdTektonPipeline.GetTektonPipelineTriggerPropertyWithContext(context.Background(), getTektonPipelineTriggerPropertyOptions)
 }
@@ -2203,9 +2210,8 @@ func (cdTektonPipeline *CdTektonPipelineV2) GetTektonPipelineTriggerPropertyWith
 	return
 }
 
-// ReplaceTektonPipelineTriggerProperty : Replace a trigger's environment property value
-// This request updates a trigger's environment property value, its type or name are immutable. For any property type,
-// the entered value replaces the existing value.
+// ReplaceTektonPipelineTriggerProperty : Replace a trigger property value
+// This request updates a trigger property value, type and name are immutable.
 func (cdTektonPipeline *CdTektonPipelineV2) ReplaceTektonPipelineTriggerProperty(replaceTektonPipelineTriggerPropertyOptions *ReplaceTektonPipelineTriggerPropertyOptions) (result *TriggerProperty, response *core.DetailedResponse, err error) {
 	return cdTektonPipeline.ReplaceTektonPipelineTriggerPropertyWithContext(context.Background(), replaceTektonPipelineTriggerPropertyOptions)
 }
@@ -2291,8 +2297,8 @@ func (cdTektonPipeline *CdTektonPipelineV2) ReplaceTektonPipelineTriggerProperty
 	return
 }
 
-// DeleteTektonPipelineTriggerProperty : Delete a trigger's property
-// this request deletes a trigger's property.
+// DeleteTektonPipelineTriggerProperty : Delete a trigger property
+// This request deletes a trigger property.
 func (cdTektonPipeline *CdTektonPipelineV2) DeleteTektonPipelineTriggerProperty(deleteTektonPipelineTriggerPropertyOptions *DeleteTektonPipelineTriggerPropertyOptions) (response *core.DetailedResponse, err error) {
 	return cdTektonPipeline.DeleteTektonPipelineTriggerPropertyWithContext(context.Background(), deleteTektonPipelineTriggerPropertyOptions)
 }
@@ -2343,7 +2349,7 @@ func (cdTektonPipeline *CdTektonPipelineV2) DeleteTektonPipelineTriggerPropertyW
 
 // CancelTektonPipelineRunOptions : The CancelTektonPipelineRun options.
 type CancelTektonPipelineRunOptions struct {
-	// The tekton pipeline ID.
+	// The Tekton pipeline ID.
 	PipelineID *string `json:"pipeline_id" validate:"required,ne="`
 
 	// ID of current instance.
@@ -2388,30 +2394,19 @@ func (options *CancelTektonPipelineRunOptions) SetHeaders(param map[string]strin
 	return options
 }
 
-// Concurrency : Concurrency object.
-type Concurrency struct {
-	// Defines the maximum number of concurrent runs for this trigger.
-	MaxConcurrentRuns *int64 `json:"max_concurrent_runs,omitempty"`
-}
-
-// UnmarshalConcurrency unmarshals an instance of Concurrency from the specified map of raw messages.
-func UnmarshalConcurrency(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(Concurrency)
-	err = core.UnmarshalPrimitive(m, "max_concurrent_runs", &obj.MaxConcurrentRuns)
-	if err != nil {
-		return
-	}
-	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
-	return
-}
-
 // CreateTektonPipelineDefinitionOptions : The CreateTektonPipelineDefinition options.
 type CreateTektonPipelineDefinitionOptions struct {
-	// The tekton pipeline ID.
+	// The Tekton pipeline ID.
 	PipelineID *string `json:"pipeline_id" validate:"required,ne="`
 
-	// Scm source for tekton pipeline defintion.
+	// SCM source for Tekton pipeline definition.
 	ScmSource *DefinitionScmSource `json:"scm_source,omitempty"`
+
+	// ID of the SCM repository service instance.
+	ServiceInstanceID *string `json:"service_instance_id,omitempty"`
+
+	// UUID.
+	ID *string `json:"id,omitempty"`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -2436,6 +2431,18 @@ func (_options *CreateTektonPipelineDefinitionOptions) SetScmSource(scmSource *D
 	return _options
 }
 
+// SetServiceInstanceID : Allow user to set ServiceInstanceID
+func (_options *CreateTektonPipelineDefinitionOptions) SetServiceInstanceID(serviceInstanceID string) *CreateTektonPipelineDefinitionOptions {
+	_options.ServiceInstanceID = core.StringPtr(serviceInstanceID)
+	return _options
+}
+
+// SetID : Allow user to set ID
+func (_options *CreateTektonPipelineDefinitionOptions) SetID(id string) *CreateTektonPipelineDefinitionOptions {
+	_options.ID = core.StringPtr(id)
+	return _options
+}
+
 // SetHeaders : Allow user to set Headers
 func (options *CreateTektonPipelineDefinitionOptions) SetHeaders(param map[string]string) *CreateTektonPipelineDefinitionOptions {
 	options.Headers = param
@@ -2447,7 +2454,7 @@ type CreateTektonPipelineOptions struct {
 	// UUID.
 	ID *string `json:"id,omitempty"`
 
-	// Worker object with worker ID only.
+	// Worker object containing worker ID only. If omitted the IBM Managed shared workers are used by default.
 	Worker *WorkerWithID `json:"worker,omitempty"`
 
 	// Allows users to set headers on API requests
@@ -2479,25 +2486,25 @@ func (options *CreateTektonPipelineOptions) SetHeaders(param map[string]string) 
 
 // CreateTektonPipelinePropertiesOptions : The CreateTektonPipelineProperties options.
 type CreateTektonPipelinePropertiesOptions struct {
-	// The tekton pipeline ID.
+	// The Tekton pipeline ID.
 	PipelineID *string `json:"pipeline_id" validate:"required,ne="`
 
 	// Property name.
 	Name *string `json:"name,omitempty"`
 
-	// String format property value.
+	// Property value.
 	Value *string `json:"value,omitempty"`
 
-	// Options for SINGLE_SELECT property type.
+	// Options for SINGLE_SELECT property type. Only needed when using SINGLE_SELECT property type.
 	Enum []string `json:"enum,omitempty"`
 
-	// Default option for SINGLE_SELECT property type.
+	// Default option for SINGLE_SELECT property type. Only needed when using SINGLE_SELECT property type.
 	Default *string `json:"default,omitempty"`
 
 	// Property type.
 	Type *string `json:"type,omitempty"`
 
-	// property path for INTEGRATION type properties.
+	// A dot notation path for INTEGRATION type properties to select a value from the tool integration.
 	Path *string `json:"path,omitempty"`
 
 	// Allows users to set headers on API requests
@@ -2571,25 +2578,25 @@ func (options *CreateTektonPipelinePropertiesOptions) SetHeaders(param map[strin
 
 // CreateTektonPipelineRunOptions : The CreateTektonPipelineRun options.
 type CreateTektonPipelineRunOptions struct {
-	// The tekton pipeline ID.
+	// The Tekton pipeline ID.
 	PipelineID *string `json:"pipeline_id" validate:"required,ne="`
 
 	// Trigger name.
 	TriggerName *string `json:"trigger_name,omitempty"`
 
-	// A valid single dictionary object containing string values only to provide extra TEXT trigger properties or override
-	// defined TEXT type trigger properties.
+	// An object containing string values only that provides additional TEXT properties, or overrides existing
+	// pipeline/trigger properties.
 	TriggerProperties map[string]interface{} `json:"trigger_properties,omitempty"`
 
-	// A valid single dictionary object containing string values only to provide extra SECURE type trigger properties or
-	// override defined SECURE type trigger properties.
+	// An object containing string values only that provides additional SECURE properties, or overrides existing SECURE
+	// pipeline/trigger properties.
 	SecureTriggerProperties map[string]interface{} `json:"secure_trigger_properties,omitempty"`
 
-	// A valid single dictionary object with only string values to provide header, use $(header.header_key_name) to access
-	// it in triggerBinding.
+	// An object containing string values only that provides the trigger header. Use $(header.header_key_name) to access it
+	// in triggerBinding.
 	TriggerHeader map[string]interface{} `json:"trigger_header,omitempty"`
 
-	// A valid object to provide body, use $(body.body_key_name) to access it in triggerBinding.
+	// An object that provides the trigger body. Use $(body.body_key_name) to access it in triggerBinding.
 	TriggerBody map[string]interface{} `json:"trigger_body,omitempty"`
 
 	// Allows users to set headers on API requests
@@ -2647,10 +2654,10 @@ func (options *CreateTektonPipelineRunOptions) SetHeaders(param map[string]strin
 
 // CreateTektonPipelineTriggerOptions : The CreateTektonPipelineTrigger options.
 type CreateTektonPipelineTriggerOptions struct {
-	// The tekton pipeline ID.
+	// The Tekton pipeline ID.
 	PipelineID *string `json:"pipeline_id" validate:"required,ne="`
 
-	// Tekton pipeline trigger object.
+	// Tekton pipeline trigger.
 	Trigger TriggerIntf `json:"Trigger,omitempty"`
 
 	// Allows users to set headers on API requests
@@ -2684,7 +2691,7 @@ func (options *CreateTektonPipelineTriggerOptions) SetHeaders(param map[string]s
 
 // CreateTektonPipelineTriggerPropertiesOptions : The CreateTektonPipelineTriggerProperties options.
 type CreateTektonPipelineTriggerPropertiesOptions struct {
-	// The tekton pipeline ID.
+	// The Tekton pipeline ID.
 	PipelineID *string `json:"pipeline_id" validate:"required,ne="`
 
 	// The trigger ID.
@@ -2693,19 +2700,20 @@ type CreateTektonPipelineTriggerPropertiesOptions struct {
 	// Property name.
 	Name *string `json:"name,omitempty"`
 
-	// String format property value.
+	// Property value. Can be empty and should be omitted for SINGLE_SELECT property type.
 	Value *string `json:"value,omitempty"`
 
-	// Options for SINGLE_SELECT property type.
+	// Options for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
 	Enum []string `json:"enum,omitempty"`
 
-	// Default option for SINGLE_SELECT property type.
+	// Default option for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
 	Default *string `json:"default,omitempty"`
 
 	// Property type.
 	Type *string `json:"type,omitempty"`
 
-	// property path for INTEGRATION type properties.
+	// A dot notation path for INTEGRATION type properties to select a value from the tool integration. If left blank the
+	// full tool integration JSON will be selected.
 	Path *string `json:"path,omitempty"`
 
 	// Allows users to set headers on API requests
@@ -2786,24 +2794,14 @@ func (options *CreateTektonPipelineTriggerPropertiesOptions) SetHeaders(param ma
 
 // Definition : Tekton pipeline definition entry object.
 type Definition struct {
-	// Scm source for tekton pipeline defintion.
+	// SCM source for Tekton pipeline definition.
 	ScmSource *DefinitionScmSource `json:"scm_source" validate:"required"`
 
-	// UUID.
+	// ID of the SCM repository service instance.
 	ServiceInstanceID *string `json:"service_instance_id" validate:"required"`
 
 	// UUID.
 	ID *string `json:"id,omitempty"`
-}
-
-// NewDefinition : Instantiate Definition (Generic Model Constructor)
-func (*CdTektonPipelineV2) NewDefinition(scmSource *DefinitionScmSource, serviceInstanceID string) (_model *Definition, err error) {
-	_model = &Definition{
-		ScmSource: scmSource,
-		ServiceInstanceID: core.StringPtr(serviceInstanceID),
-	}
-	err = core.ValidateStruct(_model, "required parameters")
-	return
 }
 
 // UnmarshalDefinition unmarshals an instance of Definition from the specified map of raw messages.
@@ -2825,18 +2823,18 @@ func UnmarshalDefinition(m map[string]json.RawMessage, result interface{}) (err 
 	return
 }
 
-// DefinitionScmSource : Scm source for tekton pipeline defintion.
+// DefinitionScmSource : SCM source for Tekton pipeline definition.
 type DefinitionScmSource struct {
-	// General href URL.
+	// URL of the definition repository.
 	URL *string `json:"url" validate:"required"`
 
-	// A branch of the repo, branch field doesn't coexist with tag field.
+	// A branch from the repo. One of branch or tag must be specified, but only one or the other.
 	Branch *string `json:"branch,omitempty"`
 
-	// A tag of the repo.
+	// A tag from the repo. One of branch or tag must be specified, but only one or the other.
 	Tag *string `json:"tag,omitempty"`
 
-	// The path to the definitions yaml files.
+	// The path to the definition's yaml files.
 	Path *string `json:"path" validate:"required"`
 }
 
@@ -2873,17 +2871,17 @@ func UnmarshalDefinitionScmSource(m map[string]json.RawMessage, result interface
 	return
 }
 
-// Definitions : Pipeline definitions is a collection of individual definition entries, each entry is a composition of a repo url,
-// repo branch/tag and a certain directory path.
-type Definitions struct {
+// DefinitionsCollection : Pipeline definitions is a collection of individual definition entries, each entry consists of a repository URL,
+// branch/tag and path.
+type DefinitionsCollection struct {
 	// Definition list.
-	Definitions []DefinitionsDefinitionsItem `json:"definitions" validate:"required"`
+	Definitions []DefinitionsCollectionDefinitionsItem `json:"definitions" validate:"required"`
 }
 
-// UnmarshalDefinitions unmarshals an instance of Definitions from the specified map of raw messages.
-func UnmarshalDefinitions(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(Definitions)
-	err = core.UnmarshalModel(m, "definitions", &obj.Definitions, UnmarshalDefinitionsDefinitionsItem)
+// UnmarshalDefinitionsCollection unmarshals an instance of DefinitionsCollection from the specified map of raw messages.
+func UnmarshalDefinitionsCollection(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(DefinitionsCollection)
+	err = core.UnmarshalModel(m, "definitions", &obj.Definitions, UnmarshalDefinitionsCollectionDefinitionsItem)
 	if err != nil {
 		return
 	}
@@ -2891,24 +2889,24 @@ func UnmarshalDefinitions(m map[string]json.RawMessage, result interface{}) (err
 	return
 }
 
-// DefinitionsDefinitionsItem : Tekton pipeline definition entry object.
-type DefinitionsDefinitionsItem struct {
-	// Scm source for tekton pipeline defintion.
+// DefinitionsCollectionDefinitionsItem : Tekton pipeline definition entry object.
+type DefinitionsCollectionDefinitionsItem struct {
+	// SCM source for Tekton pipeline definition.
 	ScmSource *DefinitionScmSource `json:"scm_source" validate:"required"`
 
-	// UUID.
+	// ID of the SCM repository service instance.
 	ServiceInstanceID *string `json:"service_instance_id" validate:"required"`
 
 	// UUID.
 	ID *string `json:"id,omitempty"`
 
-	// General href URL.
+	// URL of the definition repository.
 	Href *string `json:"href,omitempty"`
 }
 
-// UnmarshalDefinitionsDefinitionsItem unmarshals an instance of DefinitionsDefinitionsItem from the specified map of raw messages.
-func UnmarshalDefinitionsDefinitionsItem(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(DefinitionsDefinitionsItem)
+// UnmarshalDefinitionsCollectionDefinitionsItem unmarshals an instance of DefinitionsCollectionDefinitionsItem from the specified map of raw messages.
+func UnmarshalDefinitionsCollectionDefinitionsItem(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(DefinitionsCollectionDefinitionsItem)
 	err = core.UnmarshalModel(m, "scm_source", &obj.ScmSource, UnmarshalDefinitionScmSource)
 	if err != nil {
 		return
@@ -2931,7 +2929,7 @@ func UnmarshalDefinitionsDefinitionsItem(m map[string]json.RawMessage, result in
 
 // DeleteTektonPipelineDefinitionOptions : The DeleteTektonPipelineDefinition options.
 type DeleteTektonPipelineDefinitionOptions struct {
-	// The tekton pipeline ID.
+	// The Tekton pipeline ID.
 	PipelineID *string `json:"pipeline_id" validate:"required,ne="`
 
 	// The definition ID.
@@ -2997,10 +2995,10 @@ func (options *DeleteTektonPipelineOptions) SetHeaders(param map[string]string) 
 
 // DeleteTektonPipelinePropertyOptions : The DeleteTektonPipelineProperty options.
 type DeleteTektonPipelinePropertyOptions struct {
-	// The tekton pipeline ID.
+	// The Tekton pipeline ID.
 	PipelineID *string `json:"pipeline_id" validate:"required,ne="`
 
-	// The property's name.
+	// The property name.
 	PropertyName *string `json:"property_name" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
@@ -3035,7 +3033,7 @@ func (options *DeleteTektonPipelinePropertyOptions) SetHeaders(param map[string]
 
 // DeleteTektonPipelineRunOptions : The DeleteTektonPipelineRun options.
 type DeleteTektonPipelineRunOptions struct {
-	// The tekton pipeline ID.
+	// The Tekton pipeline ID.
 	PipelineID *string `json:"pipeline_id" validate:"required,ne="`
 
 	// ID of current instance.
@@ -3073,7 +3071,7 @@ func (options *DeleteTektonPipelineRunOptions) SetHeaders(param map[string]strin
 
 // DeleteTektonPipelineTriggerOptions : The DeleteTektonPipelineTrigger options.
 type DeleteTektonPipelineTriggerOptions struct {
-	// The tekton pipeline ID.
+	// The Tekton pipeline ID.
 	PipelineID *string `json:"pipeline_id" validate:"required,ne="`
 
 	// The trigger ID.
@@ -3111,13 +3109,13 @@ func (options *DeleteTektonPipelineTriggerOptions) SetHeaders(param map[string]s
 
 // DeleteTektonPipelineTriggerPropertyOptions : The DeleteTektonPipelineTriggerProperty options.
 type DeleteTektonPipelineTriggerPropertyOptions struct {
-	// The tekton pipeline ID.
+	// The Tekton pipeline ID.
 	PipelineID *string `json:"pipeline_id" validate:"required,ne="`
 
 	// The trigger ID.
 	TriggerID *string `json:"trigger_id" validate:"required,ne="`
 
-	// The property's name.
+	// The property name.
 	PropertyName *string `json:"property_name" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
@@ -3157,33 +3155,15 @@ func (options *DeleteTektonPipelineTriggerPropertyOptions) SetHeaders(param map[
 	return options
 }
 
-// EnvProperties : Pipeline properties object.
-type EnvProperties struct {
-	// Pipeline properties list.
-	Properties []Property `json:"properties" validate:"required"`
-}
-
-// UnmarshalEnvProperties unmarshals an instance of EnvProperties from the specified map of raw messages.
-func UnmarshalEnvProperties(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(EnvProperties)
-	err = core.UnmarshalModel(m, "properties", &obj.Properties, UnmarshalProperty)
-	if err != nil {
-		return
-	}
-	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
-	return
-}
-
-// Events : Needed only for git trigger type. Events object defines the events this git trigger listening to.
+// Events : Only needed for Git triggers. Events object defines the events to which this Git trigger listens.
 type Events struct {
-	// If true, the trigger starts when tekton pipeline service receive a repo's 'push' git webhook event.
+	// If true, the trigger listens for 'push' Git webhook events.
 	Push *bool `json:"push,omitempty"`
 
-	// If true, the trigger starts when tekton pipeline service receive a repo pull reqeust's 'close' git webhook event.
+	// If true, the trigger listens for 'close pull request' Git webhook events.
 	PullRequestClosed *bool `json:"pull_request_closed,omitempty"`
 
-	// If true, the trigger starts when tekton pipeline service receive a repo pull reqeust's 'open' or 'update' git
-	// webhook event.
+	// If true, the trigger listens for 'open pull request' or 'update pull request' Git webhook events.
 	PullRequest *bool `json:"pull_request,omitempty"`
 }
 
@@ -3206,7 +3186,7 @@ func UnmarshalEvents(m map[string]json.RawMessage, result interface{}) (err erro
 	return
 }
 
-// GenericSecret : Needed only for generic trigger type. Secret used to start generic trigger.
+// GenericSecret : Only needed for generic webhook trigger type. Secret used to start generic webhook trigger.
 type GenericSecret struct {
 	// Secret type.
 	Type *string `json:"type,omitempty"`
@@ -3220,7 +3200,7 @@ type GenericSecret struct {
 	// Secret name, not needed if type is "internalValidation".
 	KeyName *string `json:"key_name,omitempty"`
 
-	// Algorithm used for "digestMatches" secret type.
+	// Algorithm used for "digestMatches" secret type. Only needed for "digestMatches" secret type.
 	Algorithm *string `json:"algorithm,omitempty"`
 }
 
@@ -3241,7 +3221,7 @@ const (
 )
 
 // Constants associated with the GenericSecret.Algorithm property.
-// Algorithm used for "digestMatches" secret type.
+// Algorithm used for "digestMatches" secret type. Only needed for "digestMatches" secret type.
 const (
 	GenericSecretAlgorithmMd4Const = "md4"
 	GenericSecretAlgorithmMd5Const = "md5"
@@ -3283,7 +3263,7 @@ func UnmarshalGenericSecret(m map[string]json.RawMessage, result interface{}) (e
 
 // GetTektonPipelineDefinitionOptions : The GetTektonPipelineDefinition options.
 type GetTektonPipelineDefinitionOptions struct {
-	// The tekton pipeline ID.
+	// The Tekton pipeline ID.
 	PipelineID *string `json:"pipeline_id" validate:"required,ne="`
 
 	// The definition ID.
@@ -3349,10 +3329,10 @@ func (options *GetTektonPipelineOptions) SetHeaders(param map[string]string) *Ge
 
 // GetTektonPipelinePropertyOptions : The GetTektonPipelineProperty options.
 type GetTektonPipelinePropertyOptions struct {
-	// The tekton pipeline ID.
+	// The Tekton pipeline ID.
 	PipelineID *string `json:"pipeline_id" validate:"required,ne="`
 
-	// The property's name.
+	// The property name.
 	PropertyName *string `json:"property_name" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
@@ -3387,10 +3367,10 @@ func (options *GetTektonPipelinePropertyOptions) SetHeaders(param map[string]str
 
 // GetTektonPipelineRunLogContentOptions : The GetTektonPipelineRunLogContent options.
 type GetTektonPipelineRunLogContentOptions struct {
-	// The tekton pipeline ID.
+	// The Tekton pipeline ID.
 	PipelineID *string `json:"pipeline_id" validate:"required,ne="`
 
-	// The tekton pipeline run ID.
+	// The Tekton pipeline run ID.
 	PipelineRunID *string `json:"pipeline_run_id" validate:"required,ne="`
 
 	// ID of current instance.
@@ -3435,7 +3415,7 @@ func (options *GetTektonPipelineRunLogContentOptions) SetHeaders(param map[strin
 
 // GetTektonPipelineRunLogsOptions : The GetTektonPipelineRunLogs options.
 type GetTektonPipelineRunLogsOptions struct {
-	// The tekton pipeline ID.
+	// The Tekton pipeline ID.
 	PipelineID *string `json:"pipeline_id" validate:"required,ne="`
 
 	// ID of current instance.
@@ -3473,7 +3453,7 @@ func (options *GetTektonPipelineRunLogsOptions) SetHeaders(param map[string]stri
 
 // GetTektonPipelineRunOptions : The GetTektonPipelineRun options.
 type GetTektonPipelineRunOptions struct {
-	// The tekton pipeline ID.
+	// The Tekton pipeline ID.
 	PipelineID *string `json:"pipeline_id" validate:"required,ne="`
 
 	// ID of current instance.
@@ -3526,7 +3506,7 @@ func (options *GetTektonPipelineRunOptions) SetHeaders(param map[string]string) 
 
 // GetTektonPipelineTriggerOptions : The GetTektonPipelineTrigger options.
 type GetTektonPipelineTriggerOptions struct {
-	// The tekton pipeline ID.
+	// The Tekton pipeline ID.
 	PipelineID *string `json:"pipeline_id" validate:"required,ne="`
 
 	// The trigger ID.
@@ -3564,13 +3544,13 @@ func (options *GetTektonPipelineTriggerOptions) SetHeaders(param map[string]stri
 
 // GetTektonPipelineTriggerPropertyOptions : The GetTektonPipelineTriggerProperty options.
 type GetTektonPipelineTriggerPropertyOptions struct {
-	// The tekton pipeline ID.
+	// The Tekton pipeline ID.
 	PipelineID *string `json:"pipeline_id" validate:"required,ne="`
 
 	// The trigger ID.
 	TriggerID *string `json:"trigger_id" validate:"required,ne="`
 
-	// The property's name.
+	// The property name.
 	PropertyName *string `json:"property_name" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
@@ -3612,7 +3592,7 @@ func (options *GetTektonPipelineTriggerPropertyOptions) SetHeaders(param map[str
 
 // ListTektonPipelineDefinitionsOptions : The ListTektonPipelineDefinitions options.
 type ListTektonPipelineDefinitionsOptions struct {
-	// The tekton pipeline ID.
+	// The Tekton pipeline ID.
 	PipelineID *string `json:"pipeline_id" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
@@ -3640,7 +3620,7 @@ func (options *ListTektonPipelineDefinitionsOptions) SetHeaders(param map[string
 
 // ListTektonPipelinePropertiesOptions : The ListTektonPipelineProperties options.
 type ListTektonPipelinePropertiesOptions struct {
-	// The tekton pipeline ID.
+	// The Tekton pipeline ID.
 	PipelineID *string `json:"pipeline_id" validate:"required,ne="`
 
 	// Filters the collection to resources with the specified property name.
@@ -3649,8 +3629,7 @@ type ListTektonPipelinePropertiesOptions struct {
 	// Filters the collection to resources with the specified property type.
 	Type []string `json:"type,omitempty"`
 
-	// Sorts the returned properties by a property field, for properties you can sort them alphabetically by "name" in
-	// ascending order or with "-name" in descending order.
+	// Sorts the returned properties by name, in ascending order using "name" or in descending order using "-name".
 	Sort *string `json:"sort,omitempty"`
 
 	// Allows users to set headers on API requests
@@ -3706,7 +3685,7 @@ func (options *ListTektonPipelinePropertiesOptions) SetHeaders(param map[string]
 
 // ListTektonPipelineRunsOptions : The ListTektonPipelineRuns options.
 type ListTektonPipelineRunsOptions struct {
-	// The tekton pipeline ID.
+	// The Tekton pipeline ID.
 	PipelineID *string `json:"pipeline_id" validate:"required,ne="`
 
 	// The number of pipeline runs to return, sorted by creation time, most recent first.
@@ -3784,20 +3763,19 @@ func (options *ListTektonPipelineRunsOptions) SetHeaders(param map[string]string
 
 // ListTektonPipelineTriggerPropertiesOptions : The ListTektonPipelineTriggerProperties options.
 type ListTektonPipelineTriggerPropertiesOptions struct {
-	// The tekton pipeline ID.
+	// The Tekton pipeline ID.
 	PipelineID *string `json:"pipeline_id" validate:"required,ne="`
 
 	// The trigger ID.
 	TriggerID *string `json:"trigger_id" validate:"required,ne="`
 
-	// filter properties by the name of property.
+	// Filter properties by "name".
 	Name *string `json:"name" validate:"required"`
 
-	// filter properties by the type of property, avaialble types are
-	// "SECURE","TEXT","INTEGRATION","SINGLE_SELECT","APPCONFIG".
+	// Filter properties by "type". Valid types are "SECURE", "TEXT", "INTEGRATION", "SINGLE_SELECT", "APPCONFIG".
 	Type *string `json:"type" validate:"required"`
 
-	// sort properties by the a property field, for properties you can only sort them by "name" or "-name".
+	// Sort properties by name. They can be sorted in ascending order using "name" or in descending order using "-name".
 	Sort *string `json:"sort" validate:"required"`
 
 	// Allows users to set headers on API requests
@@ -3853,28 +3831,30 @@ func (options *ListTektonPipelineTriggerPropertiesOptions) SetHeaders(param map[
 
 // ListTektonPipelineTriggersOptions : The ListTektonPipelineTriggers options.
 type ListTektonPipelineTriggersOptions struct {
-	// The tekton pipeline ID.
+	// The Tekton pipeline ID.
 	PipelineID *string `json:"pipeline_id" validate:"required,ne="`
 
-	// filter the triggers by trigger "type", possible values are "manual", "scm", "generic", "timer".
+	// Filter the triggers by "type", accepts a comma separated list of types. Valid types are "manual", "scm", "generic",
+	// and "timer".
 	Type *string `json:"type,omitempty"`
 
-	// filter the triggers by trigger "name", accept single string value.
+	// Filter the triggers by "name", accepts a single string value.
 	Name *string `json:"name,omitempty"`
 
-	// filter the triggers by trigger "event_listener", accept single string value.
+	// Filter the triggers by "event_listener", accepts a single string value.
 	EventListener *string `json:"event_listener,omitempty"`
 
-	// filter the triggers by trigger "worker.id", accept single string value.
+	// Filter the triggers by "worker.id", accepts a single string value.
 	WorkerID *string `json:"worker.id,omitempty"`
 
-	// filter the triggers by trigger "worker.name", accept single string value.
+	// Filter the triggers by "worker.name", accepts a single string value.
 	WorkerName *string `json:"worker.name,omitempty"`
 
-	// filter the triggers by trigger "disabled" flag, possbile state are "true" and "false".
+	// Filter the triggers by "disabled" flag, possible values are "true" or "false".
 	Disabled *string `json:"disabled,omitempty"`
 
-	// filter the triggers by trigger "tags", the response lists triggers if it has one matching tag.
+	// Filter the triggers by "tags", accepts a comma separated list of tags. The response lists triggers having at least
+	// one matching tag.
 	Tags *string `json:"tags,omitempty"`
 
 	// Allows users to set headers on API requests
@@ -3942,7 +3922,78 @@ func (options *ListTektonPipelineTriggersOptions) SetHeaders(param map[string]st
 	return options
 }
 
-// PipelineRun : Single tekton pipeline run object.
+// Log : Log object for Tekton pipeline run step.
+type Log struct {
+	// Step log ID.
+	ID *string `json:"id" validate:"required"`
+
+	// The raw log content of step.
+	Data *string `json:"data" validate:"required"`
+}
+
+// UnmarshalLog unmarshals an instance of Log from the specified map of raw messages.
+func UnmarshalLog(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(Log)
+	err = core.UnmarshalPrimitive(m, "id", &obj.ID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "data", &obj.Data)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// LogID : Pipeline run log ID object.
+type LogID struct {
+	// <podName>/<containerName> of this log.
+	Name *string `json:"name,omitempty"`
+
+	// Generated log ID.
+	ID *string `json:"id,omitempty"`
+
+	// API for getting log content.
+	Href *string `json:"href,omitempty"`
+}
+
+// UnmarshalLogID unmarshals an instance of LogID from the specified map of raw messages.
+func UnmarshalLogID(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(LogID)
+	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "id", &obj.ID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "href", &obj.Href)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// LogsCollection : List of pipeline run log IDs.
+type LogsCollection struct {
+	Logs []LogID `json:"logs,omitempty"`
+}
+
+// UnmarshalLogsCollection unmarshals an instance of LogsCollection from the specified map of raw messages.
+func UnmarshalLogsCollection(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(LogsCollection)
+	err = core.UnmarshalModel(m, "logs", &obj.Logs, UnmarshalLogID)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// PipelineRun : Single Tekton pipeline run object.
 type PipelineRun struct {
 	// UUID.
 	ID *string `json:"id" validate:"required"`
@@ -3953,10 +4004,10 @@ type PipelineRun struct {
 	// Status of the pipeline run.
 	Status *string `json:"status" validate:"required"`
 
-	// The aggregated definition ID used for this pipelineRun.
+	// The aggregated definition ID used for this pipeline run.
 	DefinitionID *string `json:"definition_id" validate:"required"`
 
-	// worker details used in this pipelineRun.
+	// worker details used in this pipeline run.
 	Worker *PipelineRunWorker `json:"worker" validate:"required"`
 
 	// UUID.
@@ -3965,26 +4016,26 @@ type PipelineRun struct {
 	// Listener name used to start the run.
 	ListenerName *string `json:"listener_name" validate:"required"`
 
-	// Tekton pipeline trigger object.
+	// Tekton pipeline trigger.
 	Trigger TriggerIntf `json:"trigger" validate:"required"`
 
 	// Event parameters object passed to this pipeline run in String format, the contents depends on the type of trigger,
-	// for example, for git trigger it includes the git event payload.
+	// for example, for Git trigger it includes the Git event payload.
 	EventParamsBlob *string `json:"event_params_blob" validate:"required"`
 
-	// Heads passed to this pipeline run in String format, tekton pipeline service can't control the shape of the contents.
+	// Headers passed to this pipeline run in String format.
 	EventHeaderParamsBlob *string `json:"event_header_params_blob,omitempty"`
 
-	// Properties used in this tekton pipeline run.
+	// Properties used in this Tekton pipeline run.
 	Properties []Property `json:"properties,omitempty"`
 
 	// Standard RFC 3339 Date Time String.
-	Created *strfmt.DateTime `json:"created" validate:"required"`
+	CreatedAt *strfmt.DateTime `json:"created_at,omitempty"`
 
 	// Standard RFC 3339 Date Time String.
-	Updated *strfmt.DateTime `json:"updated,omitempty"`
+	UpdatedAt *strfmt.DateTime `json:"updated_at,omitempty"`
 
-	// Dashboard URL for this pipeline run.
+	// URL for this pipeline run.
 	HTMLURL *string `json:"html_url" validate:"required"`
 }
 
@@ -4049,11 +4100,11 @@ func UnmarshalPipelineRun(m map[string]json.RawMessage, result interface{}) (err
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalPrimitive(m, "created", &obj.Created)
+	err = core.UnmarshalPrimitive(m, "created_at", &obj.CreatedAt)
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalPrimitive(m, "updated", &obj.Updated)
+	err = core.UnmarshalPrimitive(m, "updated_at", &obj.UpdatedAt)
 	if err != nil {
 		return
 	}
@@ -4065,62 +4116,15 @@ func UnmarshalPipelineRun(m map[string]json.RawMessage, result interface{}) (err
 	return
 }
 
-// PipelineRunLog : Pipeline run logId object.
-type PipelineRunLog struct {
-	// <podName>/<containerName> of this log.
-	Name *string `json:"name,omitempty"`
-
-	// Generated log ID.
-	ID *string `json:"id,omitempty"`
-
-	// API for getting log content.
-	Href *string `json:"href,omitempty"`
-}
-
-// UnmarshalPipelineRunLog unmarshals an instance of PipelineRunLog from the specified map of raw messages.
-func UnmarshalPipelineRunLog(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(PipelineRunLog)
-	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "id", &obj.ID)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "href", &obj.Href)
-	if err != nil {
-		return
-	}
-	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
-	return
-}
-
-// PipelineRunLogs : List of pipeline run log ID object.
-type PipelineRunLogs struct {
-	Logs []PipelineRunLog `json:"logs,omitempty"`
-}
-
-// UnmarshalPipelineRunLogs unmarshals an instance of PipelineRunLogs from the specified map of raw messages.
-func UnmarshalPipelineRunLogs(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(PipelineRunLogs)
-	err = core.UnmarshalModel(m, "logs", &obj.Logs, UnmarshalPipelineRunLog)
-	if err != nil {
-		return
-	}
-	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
-	return
-}
-
-// PipelineRunWorker : worker details used in this pipelineRun.
+// PipelineRunWorker : worker details used in this pipeline run.
 type PipelineRunWorker struct {
-	// Worker name.
+	// Name of the worker. Computed based on the worker ID.
 	Name *string `json:"name,omitempty"`
 
-	// The agent ID of the corresponding private worker integration used for this pipelineRun.
+	// The agent ID of the corresponding private worker integration used for this pipeline run.
 	Agent *string `json:"agent,omitempty"`
 
-	// The Service ID of the corresponding private worker integration used for this pipelineRun.
+	// The Service ID of the corresponding private worker integration used for this pipeline run.
 	ServiceID *string `json:"service_id,omitempty"`
 
 	// UUID.
@@ -4150,10 +4154,10 @@ func UnmarshalPipelineRunWorker(m map[string]json.RawMessage, result interface{}
 	return
 }
 
-// PipelineRuns : Tekton pipeline runs object.
-type PipelineRuns struct {
+// PipelineRunsCollection : Tekton pipeline runs object.
+type PipelineRunsCollection struct {
 	// Tekton pipeline runs list.
-	PipelineRuns []PipelineRunsPipelineRunsItem `json:"pipeline_runs" validate:"required"`
+	PipelineRuns []PipelineRunsCollectionPipelineRunsItem `json:"pipeline_runs" validate:"required"`
 
 	// Skip a specified number of pipeline runs.
 	Offset *int64 `json:"offset" validate:"required"`
@@ -4162,16 +4166,16 @@ type PipelineRuns struct {
 	Limit *int64 `json:"limit" validate:"required"`
 
 	// First page of pipeline runs.
-	First *PipelineRunsFirst `json:"first" validate:"required"`
+	First *PipelineRunsCollectionFirst `json:"first" validate:"required"`
 
 	// Next page of pipeline runs relative to the offset and limit.
-	Next *PipelineRunsNext `json:"next,omitempty"`
+	Next *PipelineRunsCollectionNext `json:"next,omitempty"`
 }
 
-// UnmarshalPipelineRuns unmarshals an instance of PipelineRuns from the specified map of raw messages.
-func UnmarshalPipelineRuns(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(PipelineRuns)
-	err = core.UnmarshalModel(m, "pipeline_runs", &obj.PipelineRuns, UnmarshalPipelineRunsPipelineRunsItem)
+// UnmarshalPipelineRunsCollection unmarshals an instance of PipelineRunsCollection from the specified map of raw messages.
+func UnmarshalPipelineRunsCollection(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(PipelineRunsCollection)
+	err = core.UnmarshalModel(m, "pipeline_runs", &obj.PipelineRuns, UnmarshalPipelineRunsCollectionPipelineRunsItem)
 	if err != nil {
 		return
 	}
@@ -4183,11 +4187,11 @@ func UnmarshalPipelineRuns(m map[string]json.RawMessage, result interface{}) (er
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalModel(m, "first", &obj.First, UnmarshalPipelineRunsFirst)
+	err = core.UnmarshalModel(m, "first", &obj.First, UnmarshalPipelineRunsCollectionFirst)
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalModel(m, "next", &obj.Next, UnmarshalPipelineRunsNext)
+	err = core.UnmarshalModel(m, "next", &obj.Next, UnmarshalPipelineRunsCollectionNext)
 	if err != nil {
 		return
 	}
@@ -4196,7 +4200,7 @@ func UnmarshalPipelineRuns(m map[string]json.RawMessage, result interface{}) (er
 }
 
 // Retrieve the value to be passed to a request to access the next page of results
-func (resp *PipelineRuns) GetNextOffset() (*int64, error) {
+func (resp *PipelineRunsCollection) GetNextOffset() (*int64, error) {
 	if core.IsNil(resp.Next) {
 		return nil, nil
 	}
@@ -4212,15 +4216,15 @@ func (resp *PipelineRuns) GetNextOffset() (*int64, error) {
 	return core.Int64Ptr(offsetValue), nil
 }
 
-// PipelineRunsFirst : First page of pipeline runs.
-type PipelineRunsFirst struct {
+// PipelineRunsCollectionFirst : First page of pipeline runs.
+type PipelineRunsCollectionFirst struct {
 	// General href URL.
 	Href *string `json:"href" validate:"required"`
 }
 
-// UnmarshalPipelineRunsFirst unmarshals an instance of PipelineRunsFirst from the specified map of raw messages.
-func UnmarshalPipelineRunsFirst(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(PipelineRunsFirst)
+// UnmarshalPipelineRunsCollectionFirst unmarshals an instance of PipelineRunsCollectionFirst from the specified map of raw messages.
+func UnmarshalPipelineRunsCollectionFirst(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(PipelineRunsCollectionFirst)
 	err = core.UnmarshalPrimitive(m, "href", &obj.Href)
 	if err != nil {
 		return
@@ -4229,15 +4233,15 @@ func UnmarshalPipelineRunsFirst(m map[string]json.RawMessage, result interface{}
 	return
 }
 
-// PipelineRunsNext : Next page of pipeline runs relative to the offset and limit.
-type PipelineRunsNext struct {
+// PipelineRunsCollectionNext : Next page of pipeline runs relative to the offset and limit.
+type PipelineRunsCollectionNext struct {
 	// General href URL.
 	Href *string `json:"href" validate:"required"`
 }
 
-// UnmarshalPipelineRunsNext unmarshals an instance of PipelineRunsNext from the specified map of raw messages.
-func UnmarshalPipelineRunsNext(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(PipelineRunsNext)
+// UnmarshalPipelineRunsCollectionNext unmarshals an instance of PipelineRunsCollectionNext from the specified map of raw messages.
+func UnmarshalPipelineRunsCollectionNext(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(PipelineRunsCollectionNext)
 	err = core.UnmarshalPrimitive(m, "href", &obj.Href)
 	if err != nil {
 		return
@@ -4246,8 +4250,8 @@ func UnmarshalPipelineRunsNext(m map[string]json.RawMessage, result interface{})
 	return
 }
 
-// PipelineRunsPipelineRunsItem : Single tekton pipeline run object.
-type PipelineRunsPipelineRunsItem struct {
+// PipelineRunsCollectionPipelineRunsItem : Single Tekton pipeline run object.
+type PipelineRunsCollectionPipelineRunsItem struct {
 	// UUID.
 	ID *string `json:"id" validate:"required"`
 
@@ -4257,10 +4261,10 @@ type PipelineRunsPipelineRunsItem struct {
 	// Status of the pipeline run.
 	Status *string `json:"status" validate:"required"`
 
-	// The aggregated definition ID used for this pipelineRun.
+	// The aggregated definition ID used for this pipeline run.
 	DefinitionID *string `json:"definition_id" validate:"required"`
 
-	// worker details used in this pipelineRun.
+	// worker details used in this pipeline run.
 	Worker *PipelineRunWorker `json:"worker" validate:"required"`
 
 	// UUID.
@@ -4269,49 +4273,49 @@ type PipelineRunsPipelineRunsItem struct {
 	// Listener name used to start the run.
 	ListenerName *string `json:"listener_name" validate:"required"`
 
-	// Tekton pipeline trigger object.
+	// Tekton pipeline trigger.
 	Trigger TriggerIntf `json:"trigger" validate:"required"`
 
 	// Event parameters object passed to this pipeline run in String format, the contents depends on the type of trigger,
-	// for example, for git trigger it includes the git event payload.
+	// for example, for Git trigger it includes the Git event payload.
 	EventParamsBlob *string `json:"event_params_blob" validate:"required"`
 
-	// Heads passed to this pipeline run in String format, tekton pipeline service can't control the shape of the contents.
+	// Headers passed to this pipeline run in String format.
 	EventHeaderParamsBlob *string `json:"event_header_params_blob,omitempty"`
 
-	// Properties used in this tekton pipeline run.
+	// Properties used in this Tekton pipeline run.
 	Properties []Property `json:"properties,omitempty"`
 
 	// Standard RFC 3339 Date Time String.
-	Created *strfmt.DateTime `json:"created" validate:"required"`
+	CreatedAt *strfmt.DateTime `json:"created_at,omitempty"`
 
 	// Standard RFC 3339 Date Time String.
-	Updated *strfmt.DateTime `json:"updated,omitempty"`
+	UpdatedAt *strfmt.DateTime `json:"updated_at,omitempty"`
 
-	// Dashboard URL for this pipeline run.
+	// URL for this pipeline run.
 	HTMLURL *string `json:"html_url" validate:"required"`
 
-	// General href URL.
+	// API URL for interacting with the pipeline run.
 	Href *string `json:"href,omitempty"`
 }
 
-// Constants associated with the PipelineRunsPipelineRunsItem.Status property.
+// Constants associated with the PipelineRunsCollectionPipelineRunsItem.Status property.
 // Status of the pipeline run.
 const (
-	PipelineRunsPipelineRunsItemStatusCancelledConst = "cancelled"
-	PipelineRunsPipelineRunsItemStatusCancellingConst = "cancelling"
-	PipelineRunsPipelineRunsItemStatusErrorConst = "error"
-	PipelineRunsPipelineRunsItemStatusFailedConst = "failed"
-	PipelineRunsPipelineRunsItemStatusPendingConst = "pending"
-	PipelineRunsPipelineRunsItemStatusQueuedConst = "queued"
-	PipelineRunsPipelineRunsItemStatusRunningConst = "running"
-	PipelineRunsPipelineRunsItemStatusSucceededConst = "succeeded"
-	PipelineRunsPipelineRunsItemStatusWaitingConst = "waiting"
+	PipelineRunsCollectionPipelineRunsItemStatusCancelledConst = "cancelled"
+	PipelineRunsCollectionPipelineRunsItemStatusCancellingConst = "cancelling"
+	PipelineRunsCollectionPipelineRunsItemStatusErrorConst = "error"
+	PipelineRunsCollectionPipelineRunsItemStatusFailedConst = "failed"
+	PipelineRunsCollectionPipelineRunsItemStatusPendingConst = "pending"
+	PipelineRunsCollectionPipelineRunsItemStatusQueuedConst = "queued"
+	PipelineRunsCollectionPipelineRunsItemStatusRunningConst = "running"
+	PipelineRunsCollectionPipelineRunsItemStatusSucceededConst = "succeeded"
+	PipelineRunsCollectionPipelineRunsItemStatusWaitingConst = "waiting"
 )
 
-// UnmarshalPipelineRunsPipelineRunsItem unmarshals an instance of PipelineRunsPipelineRunsItem from the specified map of raw messages.
-func UnmarshalPipelineRunsPipelineRunsItem(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(PipelineRunsPipelineRunsItem)
+// UnmarshalPipelineRunsCollectionPipelineRunsItem unmarshals an instance of PipelineRunsCollectionPipelineRunsItem from the specified map of raw messages.
+func UnmarshalPipelineRunsCollectionPipelineRunsItem(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(PipelineRunsCollectionPipelineRunsItem)
 	err = core.UnmarshalPrimitive(m, "id", &obj.ID)
 	if err != nil {
 		return
@@ -4356,11 +4360,11 @@ func UnmarshalPipelineRunsPipelineRunsItem(m map[string]json.RawMessage, result 
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalPrimitive(m, "created", &obj.Created)
+	err = core.UnmarshalPrimitive(m, "created_at", &obj.CreatedAt)
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalPrimitive(m, "updated", &obj.Updated)
+	err = core.UnmarshalPrimitive(m, "updated_at", &obj.UpdatedAt)
 	if err != nil {
 		return
 	}
@@ -4376,24 +4380,41 @@ func UnmarshalPipelineRunsPipelineRunsItem(m map[string]json.RawMessage, result 
 	return
 }
 
+// PropertiesCollection : Pipeline properties object.
+type PropertiesCollection struct {
+	// Pipeline properties list.
+	Properties []Property `json:"properties" validate:"required"`
+}
+
+// UnmarshalPropertiesCollection unmarshals an instance of PropertiesCollection from the specified map of raw messages.
+func UnmarshalPropertiesCollection(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(PropertiesCollection)
+	err = core.UnmarshalModel(m, "properties", &obj.Properties, UnmarshalProperty)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
 // Property : Property object.
 type Property struct {
 	// Property name.
 	Name *string `json:"name" validate:"required"`
 
-	// String format property value.
+	// Property value.
 	Value *string `json:"value,omitempty"`
 
-	// Options for SINGLE_SELECT property type.
+	// Options for SINGLE_SELECT property type. Only needed when using SINGLE_SELECT property type.
 	Enum []string `json:"enum,omitempty"`
 
-	// Default option for SINGLE_SELECT property type.
+	// Default option for SINGLE_SELECT property type. Only needed when using SINGLE_SELECT property type.
 	Default *string `json:"default,omitempty"`
 
 	// Property type.
 	Type *string `json:"type" validate:"required"`
 
-	// property path for INTEGRATION type properties.
+	// A dot notation path for INTEGRATION type properties to select a value from the tool integration.
 	Path *string `json:"path,omitempty"`
 }
 
@@ -4406,16 +4427,6 @@ const (
 	PropertyTypeSingleSelectConst = "SINGLE_SELECT"
 	PropertyTypeTextConst = "TEXT"
 )
-
-// NewProperty : Instantiate Property (Generic Model Constructor)
-func (*CdTektonPipelineV2) NewProperty(name string, typeVar string) (_model *Property, err error) {
-	_model = &Property{
-		Name: core.StringPtr(name),
-		Type: core.StringPtr(typeVar),
-	}
-	err = core.ValidateStruct(_model, "required parameters")
-	return
-}
 
 // UnmarshalProperty unmarshals an instance of Property from the specified map of raw messages.
 func UnmarshalProperty(m map[string]json.RawMessage, result interface{}) (err error) {
@@ -4450,16 +4461,16 @@ func UnmarshalProperty(m map[string]json.RawMessage, result interface{}) (err er
 
 // ReplaceTektonPipelineDefinitionOptions : The ReplaceTektonPipelineDefinition options.
 type ReplaceTektonPipelineDefinitionOptions struct {
-	// The tekton pipeline ID.
+	// The Tekton pipeline ID.
 	PipelineID *string `json:"pipeline_id" validate:"required,ne="`
 
 	// The definition ID.
 	DefinitionID *string `json:"definition_id" validate:"required,ne="`
 
-	// Scm source for tekton pipeline defintion.
+	// SCM source for Tekton pipeline definition.
 	ScmSource *DefinitionScmSource `json:"scm_source,omitempty"`
 
-	// UUID.
+	// ID of the SCM repository service instance.
 	ServiceInstanceID *string `json:"service_instance_id,omitempty"`
 
 	// UUID.
@@ -4515,28 +4526,28 @@ func (options *ReplaceTektonPipelineDefinitionOptions) SetHeaders(param map[stri
 
 // ReplaceTektonPipelinePropertyOptions : The ReplaceTektonPipelineProperty options.
 type ReplaceTektonPipelinePropertyOptions struct {
-	// The tekton pipeline ID.
+	// The Tekton pipeline ID.
 	PipelineID *string `json:"pipeline_id" validate:"required,ne="`
 
-	// The property's name.
+	// The property name.
 	PropertyName *string `json:"property_name" validate:"required,ne="`
 
 	// Property name.
 	Name *string `json:"name,omitempty"`
 
-	// String format property value.
+	// Property value.
 	Value *string `json:"value,omitempty"`
 
-	// Options for SINGLE_SELECT property type.
+	// Options for SINGLE_SELECT property type. Only needed when using SINGLE_SELECT property type.
 	Enum []string `json:"enum,omitempty"`
 
-	// Default option for SINGLE_SELECT property type.
+	// Default option for SINGLE_SELECT property type. Only needed when using SINGLE_SELECT property type.
 	Default *string `json:"default,omitempty"`
 
 	// Property type.
 	Type *string `json:"type,omitempty"`
 
-	// property path for INTEGRATION type properties.
+	// A dot notation path for INTEGRATION type properties to select a value from the tool integration.
 	Path *string `json:"path,omitempty"`
 
 	// Allows users to set headers on API requests
@@ -4617,31 +4628,32 @@ func (options *ReplaceTektonPipelinePropertyOptions) SetHeaders(param map[string
 
 // ReplaceTektonPipelineTriggerPropertyOptions : The ReplaceTektonPipelineTriggerProperty options.
 type ReplaceTektonPipelineTriggerPropertyOptions struct {
-	// The tekton pipeline ID.
+	// The Tekton pipeline ID.
 	PipelineID *string `json:"pipeline_id" validate:"required,ne="`
 
 	// The trigger ID.
 	TriggerID *string `json:"trigger_id" validate:"required,ne="`
 
-	// The property's name.
+	// The property name.
 	PropertyName *string `json:"property_name" validate:"required,ne="`
 
 	// Property name.
 	Name *string `json:"name,omitempty"`
 
-	// String format property value.
+	// Property value. Can be empty and should be omitted for SINGLE_SELECT property type.
 	Value *string `json:"value,omitempty"`
 
-	// Options for SINGLE_SELECT property type.
+	// Options for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
 	Enum []string `json:"enum,omitempty"`
 
-	// Default option for SINGLE_SELECT property type.
+	// Default option for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
 	Default *string `json:"default,omitempty"`
 
 	// Property type.
 	Type *string `json:"type,omitempty"`
 
-	// property path for INTEGRATION type properties.
+	// A dot notation path for INTEGRATION type properties to select a value from the tool integration. If left blank the
+	// full tool integration JSON will be selected.
 	Path *string `json:"path,omitempty"`
 
 	// Allows users to set headers on API requests
@@ -4729,7 +4741,7 @@ func (options *ReplaceTektonPipelineTriggerPropertyOptions) SetHeaders(param map
 
 // RerunTektonPipelineRunOptions : The RerunTektonPipelineRun options.
 type RerunTektonPipelineRunOptions struct {
-	// The tekton pipeline ID.
+	// The Tekton pipeline ID.
 	PipelineID *string `json:"pipeline_id" validate:"required,ne="`
 
 	// ID of current instance.
@@ -4765,30 +4777,6 @@ func (options *RerunTektonPipelineRunOptions) SetHeaders(param map[string]string
 	return options
 }
 
-// StepLog : Log object for tekton pipeline run step.
-type StepLog struct {
-	// Step log ID.
-	ID *string `json:"id" validate:"required"`
-
-	// The raw log content of step.
-	Data *string `json:"data" validate:"required"`
-}
-
-// UnmarshalStepLog unmarshals an instance of StepLog from the specified map of raw messages.
-func UnmarshalStepLog(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(StepLog)
-	err = core.UnmarshalPrimitive(m, "id", &obj.ID)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "data", &obj.Data)
-	if err != nil {
-		return
-	}
-	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
-	return
-}
-
 // TektonPipeline : Tekton pipeline object.
 type TektonPipeline struct {
 	// String.
@@ -4813,13 +4801,12 @@ type TektonPipeline struct {
 	Properties []Property `json:"properties" validate:"required"`
 
 	// Standard RFC 3339 Date Time String.
-	UpdatedAt *strfmt.DateTime `json:"updated_at" validate:"required"`
+	UpdatedAt *strfmt.DateTime `json:"updated_at,omitempty"`
 
 	// Standard RFC 3339 Date Time String.
-	Created *strfmt.DateTime `json:"created" validate:"required"`
+	CreatedAt *strfmt.DateTime `json:"created_at,omitempty"`
 
-	// Tekton pipeline definition document detail object. If this property is absent, the pipeline has no definitions
-	// added.
+	// Tekton pipeline definition object. If this property is absent or empty, the pipeline has no definitions added.
 	PipelineDefinition *TektonPipelinePipelineDefinition `json:"pipeline_definition,omitempty"`
 
 	// Tekton pipeline triggers list.
@@ -4831,10 +4818,10 @@ type TektonPipeline struct {
 	// Dashboard URL of this pipeline.
 	HTMLURL *string `json:"html_url" validate:"required"`
 
-	// The latest pipeline run build number. If this property is absent, the pipeline hasn't had any pipelineRuns.
+	// The latest pipeline run build number. If this property is absent, the pipeline hasn't had any pipeline runs.
 	BuildNumber *int64 `json:"build_number,omitempty"`
 
-	// Flag whether this pipeline enabled.
+	// Flag whether this pipeline is enabled.
 	Enabled *bool `json:"enabled" validate:"required"`
 }
 
@@ -4880,7 +4867,7 @@ func UnmarshalTektonPipeline(m map[string]json.RawMessage, result interface{}) (
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalPrimitive(m, "created", &obj.Created)
+	err = core.UnmarshalPrimitive(m, "created_at", &obj.CreatedAt)
 	if err != nil {
 		return
 	}
@@ -4912,9 +4899,9 @@ func UnmarshalTektonPipeline(m map[string]json.RawMessage, result interface{}) (
 	return
 }
 
-// TektonPipelinePipelineDefinition : Tekton pipeline definition document detail object. If this property is absent, the pipeline has no definitions added.
+// TektonPipelinePipelineDefinition : Tekton pipeline definition object. If this property is absent or empty, the pipeline has no definitions added.
 type TektonPipelinePipelineDefinition struct {
-	// The state of pipeline definition status.
+	// The pipeline definition status.
 	Status *string `json:"status,omitempty"`
 
 	// UUID.
@@ -4922,7 +4909,7 @@ type TektonPipelinePipelineDefinition struct {
 }
 
 // Constants associated with the TektonPipelinePipelineDefinition.Status property.
-// The state of pipeline definition status.
+// The pipeline definition status.
 const (
 	TektonPipelinePipelineDefinitionStatusFailedConst = "failed"
 	TektonPipelinePipelineDefinitionStatusOutdatedConst = "outdated"
@@ -4950,7 +4937,7 @@ type Toolchain struct {
 	// UUID.
 	ID *string `json:"id" validate:"required"`
 
-	// The CRN for the toolchain that containing the tekton pipeline.
+	// The CRN for the toolchain that contains the Tekton pipeline.
 	CRN *string `json:"crn" validate:"required"`
 }
 
@@ -4969,7 +4956,7 @@ func UnmarshalToolchain(m map[string]json.RawMessage, result interface{}) (err e
 	return
 }
 
-// Trigger : Tekton pipeline trigger object.
+// Trigger : Tekton pipeline trigger.
 // Models which "extend" this model:
 // - TriggerDuplicateTrigger
 // - TriggerManualTrigger
@@ -4977,19 +4964,22 @@ func UnmarshalToolchain(m map[string]json.RawMessage, result interface{}) (err e
 // - TriggerTimerTrigger
 // - TriggerGenericTrigger
 type Trigger struct {
-	// source trigger ID to clone from.
+	// ID of the trigger to duplicate. Only needed when duplicating a trigger.
 	SourceTriggerID *string `json:"source_trigger_id,omitempty"`
 
-	// name of the duplicated trigger.
+	// Trigger name.
 	Name *string `json:"name,omitempty"`
 
 	// Trigger type.
 	Type *string `json:"type,omitempty"`
 
+	// API URL for interacting with the trigger.
+	Href *string `json:"href,omitempty"`
+
 	// Event listener name.
 	EventListener *string `json:"event_listener,omitempty"`
 
-	// Id.
+	// ID.
 	ID *string `json:"id,omitempty"`
 
 	// Trigger properties.
@@ -4998,32 +4988,31 @@ type Trigger struct {
 	// Trigger tags array.
 	Tags []string `json:"tags,omitempty"`
 
-	// Trigger worker used to run the trigger, the trigger worker overrides the default pipeline worker.If not exist, this
-	// trigger uses default pipeline worker.
+	// Worker used to run the trigger. If not specified the trigger will use the default pipeline worker.
 	Worker *Worker `json:"worker,omitempty"`
 
-	// Concurrency object.
-	Concurrency *Concurrency `json:"concurrency,omitempty"`
+	// Defines the maximum number of concurrent runs for this trigger. Omit this property to disable the concurrency limit.
+	MaxConcurrentRuns *int64 `json:"max_concurrent_runs,omitempty"`
 
-	// flag whether the trigger is disabled.
+	// Flag whether the trigger is disabled. If omitted the trigger is enabled by default.
 	Disabled *bool `json:"disabled,omitempty"`
 
-	// Scm source for git type tekton pipeline trigger.
+	// SCM source repository for a Git trigger. Only needed for Git triggers.
 	ScmSource *TriggerScmSource `json:"scm_source,omitempty"`
 
-	// Needed only for git trigger type. Events object defines the events this git trigger listening to.
+	// Only needed for Git triggers. Events object defines the events to which this Git trigger listens.
 	Events *Events `json:"events,omitempty"`
 
-	// UUID.
+	// ID of the repository service instance.
 	ServiceInstanceID *string `json:"service_instance_id,omitempty"`
 
-	// Needed only for timer trigger type. Cron expression for timer trigger. Maximum frequency is every 5 minutes.
+	// Only needed for timer triggers. Cron expression for timer trigger. Maximum frequency is every 5 minutes.
 	Cron *string `json:"cron,omitempty"`
 
-	// Needed only for timer trigger type. Timezones for timer trigger.
+	// Only needed for timer triggers. Timezone for timer trigger.
 	Timezone *string `json:"timezone,omitempty"`
 
-	// Needed only for generic trigger type. Secret used to start generic trigger.
+	// Only needed for generic webhook trigger type. Secret used to start generic webhook trigger.
 	Secret *GenericSecret `json:"secret,omitempty"`
 }
 func (*Trigger) isaTrigger() bool {
@@ -5049,6 +5038,10 @@ func UnmarshalTrigger(m map[string]json.RawMessage, result interface{}) (err err
 	if err != nil {
 		return
 	}
+	err = core.UnmarshalPrimitive(m, "href", &obj.Href)
+	if err != nil {
+		return
+	}
 	err = core.UnmarshalPrimitive(m, "event_listener", &obj.EventListener)
 	if err != nil {
 		return
@@ -5069,7 +5062,7 @@ func UnmarshalTrigger(m map[string]json.RawMessage, result interface{}) (err err
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalModel(m, "concurrency", &obj.Concurrency, UnmarshalConcurrency)
+	err = core.UnmarshalPrimitive(m, "max_concurrent_runs", &obj.MaxConcurrentRuns)
 	if err != nil {
 		return
 	}
@@ -5105,27 +5098,28 @@ func UnmarshalTrigger(m map[string]json.RawMessage, result interface{}) (err err
 	return
 }
 
-// TriggerGenericTriggerPropertiesItem : Trigger Property object.
+// TriggerGenericTriggerPropertiesItem : Trigger property object.
 type TriggerGenericTriggerPropertiesItem struct {
 	// Property name.
 	Name *string `json:"name" validate:"required"`
 
-	// String format property value.
+	// Property value. Can be empty and should be omitted for SINGLE_SELECT property type.
 	Value *string `json:"value,omitempty"`
 
-	// Options for SINGLE_SELECT property type.
+	// Options for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
 	Enum []string `json:"enum,omitempty"`
 
-	// Default option for SINGLE_SELECT property type.
+	// Default option for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
 	Default *string `json:"default,omitempty"`
 
 	// Property type.
 	Type *string `json:"type" validate:"required"`
 
-	// property path for INTEGRATION type properties.
+	// A dot notation path for INTEGRATION type properties to select a value from the tool integration. If left blank the
+	// full tool integration JSON will be selected.
 	Path *string `json:"path,omitempty"`
 
-	// General href URL.
+	// API URL for interacting with the trigger property.
 	Href *string `json:"href,omitempty"`
 }
 
@@ -5184,27 +5178,28 @@ func UnmarshalTriggerGenericTriggerPropertiesItem(m map[string]json.RawMessage, 
 	return
 }
 
-// TriggerManualTriggerPropertiesItem : Trigger Property object.
+// TriggerManualTriggerPropertiesItem : Trigger property object.
 type TriggerManualTriggerPropertiesItem struct {
 	// Property name.
 	Name *string `json:"name" validate:"required"`
 
-	// String format property value.
+	// Property value. Can be empty and should be omitted for SINGLE_SELECT property type.
 	Value *string `json:"value,omitempty"`
 
-	// Options for SINGLE_SELECT property type.
+	// Options for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
 	Enum []string `json:"enum,omitempty"`
 
-	// Default option for SINGLE_SELECT property type.
+	// Default option for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
 	Default *string `json:"default,omitempty"`
 
 	// Property type.
 	Type *string `json:"type" validate:"required"`
 
-	// property path for INTEGRATION type properties.
+	// A dot notation path for INTEGRATION type properties to select a value from the tool integration. If left blank the
+	// full tool integration JSON will be selected.
 	Path *string `json:"path,omitempty"`
 
-	// General href URL.
+	// API URL for interacting with the trigger property.
 	Href *string `json:"href,omitempty"`
 }
 
@@ -5263,16 +5258,16 @@ func UnmarshalTriggerManualTriggerPropertiesItem(m map[string]json.RawMessage, r
 	return
 }
 
-// TriggerProperties : Trigger properties object.
-type TriggerProperties struct {
+// TriggerPropertiesCollection : Trigger properties object.
+type TriggerPropertiesCollection struct {
 	// Trigger properties list.
-	Properties []TriggerPropertiesPropertiesItem `json:"properties" validate:"required"`
+	Properties []TriggerPropertiesCollectionPropertiesItem `json:"properties" validate:"required"`
 }
 
-// UnmarshalTriggerProperties unmarshals an instance of TriggerProperties from the specified map of raw messages.
-func UnmarshalTriggerProperties(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(TriggerProperties)
-	err = core.UnmarshalModel(m, "properties", &obj.Properties, UnmarshalTriggerPropertiesPropertiesItem)
+// UnmarshalTriggerPropertiesCollection unmarshals an instance of TriggerPropertiesCollection from the specified map of raw messages.
+func UnmarshalTriggerPropertiesCollection(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(TriggerPropertiesCollection)
+	err = core.UnmarshalModel(m, "properties", &obj.Properties, UnmarshalTriggerPropertiesCollectionPropertiesItem)
 	if err != nil {
 		return
 	}
@@ -5280,27 +5275,98 @@ func UnmarshalTriggerProperties(m map[string]json.RawMessage, result interface{}
 	return
 }
 
-// TriggerPropertiesItem : Trigger Property object.
-type TriggerPropertiesItem struct {
+// TriggerPropertiesCollectionPropertiesItem : Trigger property object.
+type TriggerPropertiesCollectionPropertiesItem struct {
 	// Property name.
 	Name *string `json:"name" validate:"required"`
 
-	// String format property value.
+	// Property value. Can be empty and should be omitted for SINGLE_SELECT property type.
 	Value *string `json:"value,omitempty"`
 
-	// Options for SINGLE_SELECT property type.
+	// Options for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
 	Enum []string `json:"enum,omitempty"`
 
-	// Default option for SINGLE_SELECT property type.
+	// Default option for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
 	Default *string `json:"default,omitempty"`
 
 	// Property type.
 	Type *string `json:"type" validate:"required"`
 
-	// property path for INTEGRATION type properties.
+	// A dot notation path for INTEGRATION type properties to select a value from the tool integration. If left blank the
+	// full tool integration JSON will be selected.
 	Path *string `json:"path,omitempty"`
 
-	// General href URL.
+	// API URL for interacting with the trigger property.
+	Href *string `json:"href,omitempty"`
+}
+
+// Constants associated with the TriggerPropertiesCollectionPropertiesItem.Type property.
+// Property type.
+const (
+	TriggerPropertiesCollectionPropertiesItemTypeAppconfigConst = "APPCONFIG"
+	TriggerPropertiesCollectionPropertiesItemTypeIntegrationConst = "INTEGRATION"
+	TriggerPropertiesCollectionPropertiesItemTypeSecureConst = "SECURE"
+	TriggerPropertiesCollectionPropertiesItemTypeSingleSelectConst = "SINGLE_SELECT"
+	TriggerPropertiesCollectionPropertiesItemTypeTextConst = "TEXT"
+)
+
+// UnmarshalTriggerPropertiesCollectionPropertiesItem unmarshals an instance of TriggerPropertiesCollectionPropertiesItem from the specified map of raw messages.
+func UnmarshalTriggerPropertiesCollectionPropertiesItem(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(TriggerPropertiesCollectionPropertiesItem)
+	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "value", &obj.Value)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "enum", &obj.Enum)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "default", &obj.Default)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "type", &obj.Type)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "path", &obj.Path)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "href", &obj.Href)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// TriggerPropertiesItem : Trigger property object.
+type TriggerPropertiesItem struct {
+	// Property name.
+	Name *string `json:"name" validate:"required"`
+
+	// Property value. Can be empty and should be omitted for SINGLE_SELECT property type.
+	Value *string `json:"value,omitempty"`
+
+	// Options for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
+	Enum []string `json:"enum,omitempty"`
+
+	// Default option for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
+	Default *string `json:"default,omitempty"`
+
+	// Property type.
+	Type *string `json:"type" validate:"required"`
+
+	// A dot notation path for INTEGRATION type properties to select a value from the tool integration. If left blank the
+	// full tool integration JSON will be selected.
+	Path *string `json:"path,omitempty"`
+
+	// API URL for interacting with the trigger property.
 	Href *string `json:"href,omitempty"`
 }
 
@@ -5359,93 +5425,25 @@ func UnmarshalTriggerPropertiesItem(m map[string]json.RawMessage, result interfa
 	return
 }
 
-// TriggerPropertiesPropertiesItem : Trigger Property object.
-type TriggerPropertiesPropertiesItem struct {
-	// Property name.
-	Name *string `json:"name" validate:"required"`
-
-	// String format property value.
-	Value *string `json:"value,omitempty"`
-
-	// Options for SINGLE_SELECT property type.
-	Enum []string `json:"enum,omitempty"`
-
-	// Default option for SINGLE_SELECT property type.
-	Default *string `json:"default,omitempty"`
-
-	// Property type.
-	Type *string `json:"type" validate:"required"`
-
-	// property path for INTEGRATION type properties.
-	Path *string `json:"path,omitempty"`
-
-	// General href URL.
-	Href *string `json:"href,omitempty"`
-}
-
-// Constants associated with the TriggerPropertiesPropertiesItem.Type property.
-// Property type.
-const (
-	TriggerPropertiesPropertiesItemTypeAppconfigConst = "APPCONFIG"
-	TriggerPropertiesPropertiesItemTypeIntegrationConst = "INTEGRATION"
-	TriggerPropertiesPropertiesItemTypeSecureConst = "SECURE"
-	TriggerPropertiesPropertiesItemTypeSingleSelectConst = "SINGLE_SELECT"
-	TriggerPropertiesPropertiesItemTypeTextConst = "TEXT"
-)
-
-// UnmarshalTriggerPropertiesPropertiesItem unmarshals an instance of TriggerPropertiesPropertiesItem from the specified map of raw messages.
-func UnmarshalTriggerPropertiesPropertiesItem(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(TriggerPropertiesPropertiesItem)
-	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "value", &obj.Value)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "enum", &obj.Enum)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "default", &obj.Default)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "type", &obj.Type)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "path", &obj.Path)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "href", &obj.Href)
-	if err != nil {
-		return
-	}
-	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
-	return
-}
-
-// TriggerProperty : Trigger Property object.
+// TriggerProperty : Trigger property object.
 type TriggerProperty struct {
 	// Property name.
 	Name *string `json:"name" validate:"required"`
 
-	// String format property value.
+	// Property value. Can be empty and should be omitted for SINGLE_SELECT property type.
 	Value *string `json:"value,omitempty"`
 
-	// Options for SINGLE_SELECT property type.
+	// Options for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
 	Enum []string `json:"enum,omitempty"`
 
-	// Default option for SINGLE_SELECT property type.
+	// Default option for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
 	Default *string `json:"default,omitempty"`
 
 	// Property type.
 	Type *string `json:"type" validate:"required"`
 
-	// property path for INTEGRATION type properties.
+	// A dot notation path for INTEGRATION type properties to select a value from the tool integration. If left blank the
+	// full tool integration JSON will be selected.
 	Path *string `json:"path,omitempty"`
 }
 
@@ -5458,16 +5456,6 @@ const (
 	TriggerPropertyTypeSingleSelectConst = "SINGLE_SELECT"
 	TriggerPropertyTypeTextConst = "TEXT"
 )
-
-// NewTriggerProperty : Instantiate TriggerProperty (Generic Model Constructor)
-func (*CdTektonPipelineV2) NewTriggerProperty(name string, typeVar string) (_model *TriggerProperty, err error) {
-	_model = &TriggerProperty{
-		Name: core.StringPtr(name),
-		Type: core.StringPtr(typeVar),
-	}
-	err = core.ValidateStruct(_model, "required parameters")
-	return
-}
 
 // UnmarshalTriggerProperty unmarshals an instance of TriggerProperty from the specified map of raw messages.
 func UnmarshalTriggerProperty(m map[string]json.RawMessage, result interface{}) (err error) {
@@ -5500,22 +5488,22 @@ func UnmarshalTriggerProperty(m map[string]json.RawMessage, result interface{}) 
 	return
 }
 
-// TriggerScmSource : Scm source for git type tekton pipeline trigger.
+// TriggerScmSource : SCM source repository for a Git trigger. Only needed for Git triggers.
 type TriggerScmSource struct {
-	// Needed only for git trigger type. Repo URL that listening to.
+	// URL of the repository to which the trigger is listening.
 	URL *string `json:"url" validate:"required"`
 
-	// Needed only for git trigger type. Branch name of the repo. Branch field doesn't coexist with pattern field.
+	// Name of a branch from the repo. One of branch or tag must be specified, but only one or the other.
 	Branch *string `json:"branch,omitempty"`
 
-	// Needed only for git trigger type. Git branch or tag pattern to listen to. Please refer to
-	// https://github.com/micromatch/micromatch for pattern syntax.
+	// Git branch or tag pattern to listen to. Please refer to https://github.com/micromatch/micromatch for pattern syntax.
 	Pattern *string `json:"pattern,omitempty"`
 
-	// Needed only for git trigger type. Branch name of the repo.
+	// Set this boolean to true if the server is not addressable on the public internet. IBM Cloud will not be able to
+	// validate the connection details you provide. False by default.
 	BlindConnection *bool `json:"blind_connection,omitempty"`
 
-	// Webhook ID.
+	// ID of the webhook from the repo. Computed upon creation of the trigger.
 	HookID *string `json:"hook_id,omitempty"`
 }
 
@@ -5555,27 +5543,28 @@ func UnmarshalTriggerScmSource(m map[string]json.RawMessage, result interface{})
 	return
 }
 
-// TriggerScmTriggerPropertiesItem : Trigger Property object.
+// TriggerScmTriggerPropertiesItem : Trigger property object.
 type TriggerScmTriggerPropertiesItem struct {
 	// Property name.
 	Name *string `json:"name" validate:"required"`
 
-	// String format property value.
+	// Property value. Can be empty and should be omitted for SINGLE_SELECT property type.
 	Value *string `json:"value,omitempty"`
 
-	// Options for SINGLE_SELECT property type.
+	// Options for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
 	Enum []string `json:"enum,omitempty"`
 
-	// Default option for SINGLE_SELECT property type.
+	// Default option for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
 	Default *string `json:"default,omitempty"`
 
 	// Property type.
 	Type *string `json:"type" validate:"required"`
 
-	// property path for INTEGRATION type properties.
+	// A dot notation path for INTEGRATION type properties to select a value from the tool integration. If left blank the
+	// full tool integration JSON will be selected.
 	Path *string `json:"path,omitempty"`
 
-	// General href URL.
+	// API URL for interacting with the trigger property.
 	Href *string `json:"href,omitempty"`
 }
 
@@ -5634,27 +5623,28 @@ func UnmarshalTriggerScmTriggerPropertiesItem(m map[string]json.RawMessage, resu
 	return
 }
 
-// TriggerTimerTriggerPropertiesItem : Trigger Property object.
+// TriggerTimerTriggerPropertiesItem : Trigger property object.
 type TriggerTimerTriggerPropertiesItem struct {
 	// Property name.
 	Name *string `json:"name" validate:"required"`
 
-	// String format property value.
+	// Property value. Can be empty and should be omitted for SINGLE_SELECT property type.
 	Value *string `json:"value,omitempty"`
 
-	// Options for SINGLE_SELECT property type.
+	// Options for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
 	Enum []string `json:"enum,omitempty"`
 
-	// Default option for SINGLE_SELECT property type.
+	// Default option for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
 	Default *string `json:"default,omitempty"`
 
 	// Property type.
 	Type *string `json:"type" validate:"required"`
 
-	// property path for INTEGRATION type properties.
+	// A dot notation path for INTEGRATION type properties to select a value from the tool integration. If left blank the
+	// full tool integration JSON will be selected.
 	Path *string `json:"path,omitempty"`
 
-	// General href URL.
+	// API URL for interacting with the trigger property.
 	Href *string `json:"href,omitempty"`
 }
 
@@ -5713,435 +5703,16 @@ func UnmarshalTriggerTimerTriggerPropertiesItem(m map[string]json.RawMessage, re
 	return
 }
 
-// Triggers : Tekton pipeline triggers object.
-type Triggers struct {
+// TriggersCollection : Tekton pipeline triggers object.
+type TriggersCollection struct {
 	// Tekton pipeline triggers list.
-	Triggers []TriggersTriggersItemIntf `json:"triggers" validate:"required"`
+	Triggers []TriggerIntf `json:"triggers" validate:"required"`
 }
 
-// UnmarshalTriggers unmarshals an instance of Triggers from the specified map of raw messages.
-func UnmarshalTriggers(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(Triggers)
-	err = core.UnmarshalModel(m, "triggers", &obj.Triggers, UnmarshalTriggersTriggersItem)
-	if err != nil {
-		return
-	}
-	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
-	return
-}
-
-// TriggersTriggersItem : Tekton pipeline trigger object.
-// Models which "extend" this model:
-// - TriggersTriggersItemTriggerDuplicateTrigger
-// - TriggersTriggersItemTriggerManualTrigger
-// - TriggersTriggersItemTriggerScmTrigger
-// - TriggersTriggersItemTriggerTimerTrigger
-// - TriggersTriggersItemTriggerGenericTrigger
-type TriggersTriggersItem struct {
-	// source trigger ID to clone from.
-	SourceTriggerID *string `json:"source_trigger_id,omitempty"`
-
-	// name of the duplicated trigger.
-	Name *string `json:"name,omitempty"`
-
-	// Trigger type.
-	Type *string `json:"type,omitempty"`
-
-	// Event listener name.
-	EventListener *string `json:"event_listener,omitempty"`
-
-	// Id.
-	ID *string `json:"id,omitempty"`
-
-	// Trigger properties.
-	Properties []TriggerPropertiesItem `json:"properties,omitempty"`
-
-	// Trigger tags array.
-	Tags []string `json:"tags,omitempty"`
-
-	// Trigger worker used to run the trigger, the trigger worker overrides the default pipeline worker.If not exist, this
-	// trigger uses default pipeline worker.
-	Worker *Worker `json:"worker,omitempty"`
-
-	// Concurrency object.
-	Concurrency *Concurrency `json:"concurrency,omitempty"`
-
-	// flag whether the trigger is disabled.
-	Disabled *bool `json:"disabled,omitempty"`
-
-	// Scm source for git type tekton pipeline trigger.
-	ScmSource *TriggerScmSource `json:"scm_source,omitempty"`
-
-	// Needed only for git trigger type. Events object defines the events this git trigger listening to.
-	Events *Events `json:"events,omitempty"`
-
-	// UUID.
-	ServiceInstanceID *string `json:"service_instance_id,omitempty"`
-
-	// Needed only for timer trigger type. Cron expression for timer trigger. Maximum frequency is every 5 minutes.
-	Cron *string `json:"cron,omitempty"`
-
-	// Needed only for timer trigger type. Timezones for timer trigger.
-	Timezone *string `json:"timezone,omitempty"`
-
-	// Needed only for generic trigger type. Secret used to start generic trigger.
-	Secret *GenericSecret `json:"secret,omitempty"`
-
-	// General href URL.
-	Href *string `json:"href,omitempty"`
-}
-func (*TriggersTriggersItem) isaTriggersTriggersItem() bool {
-	return true
-}
-
-type TriggersTriggersItemIntf interface {
-	isaTriggersTriggersItem() bool
-}
-
-// UnmarshalTriggersTriggersItem unmarshals an instance of TriggersTriggersItem from the specified map of raw messages.
-func UnmarshalTriggersTriggersItem(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(TriggersTriggersItem)
-	err = core.UnmarshalPrimitive(m, "source_trigger_id", &obj.SourceTriggerID)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "type", &obj.Type)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "event_listener", &obj.EventListener)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "id", &obj.ID)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalModel(m, "properties", &obj.Properties, UnmarshalTriggerPropertiesItem)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "tags", &obj.Tags)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalModel(m, "worker", &obj.Worker, UnmarshalWorker)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalModel(m, "concurrency", &obj.Concurrency, UnmarshalConcurrency)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "disabled", &obj.Disabled)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalModel(m, "scm_source", &obj.ScmSource, UnmarshalTriggerScmSource)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalModel(m, "events", &obj.Events, UnmarshalEvents)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "service_instance_id", &obj.ServiceInstanceID)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "cron", &obj.Cron)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "timezone", &obj.Timezone)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalModel(m, "secret", &obj.Secret, UnmarshalGenericSecret)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "href", &obj.Href)
-	if err != nil {
-		return
-	}
-	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
-	return
-}
-
-// TriggersTriggersItemTriggerGenericTriggerPropertiesItem : Trigger Property object.
-type TriggersTriggersItemTriggerGenericTriggerPropertiesItem struct {
-	// Property name.
-	Name *string `json:"name" validate:"required"`
-
-	// String format property value.
-	Value *string `json:"value,omitempty"`
-
-	// Options for SINGLE_SELECT property type.
-	Enum []string `json:"enum,omitempty"`
-
-	// Default option for SINGLE_SELECT property type.
-	Default *string `json:"default,omitempty"`
-
-	// Property type.
-	Type *string `json:"type" validate:"required"`
-
-	// property path for INTEGRATION type properties.
-	Path *string `json:"path,omitempty"`
-
-	// General href URL.
-	Href *string `json:"href,omitempty"`
-}
-
-// Constants associated with the TriggersTriggersItemTriggerGenericTriggerPropertiesItem.Type property.
-// Property type.
-const (
-	TriggersTriggersItemTriggerGenericTriggerPropertiesItemTypeAppconfigConst = "APPCONFIG"
-	TriggersTriggersItemTriggerGenericTriggerPropertiesItemTypeIntegrationConst = "INTEGRATION"
-	TriggersTriggersItemTriggerGenericTriggerPropertiesItemTypeSecureConst = "SECURE"
-	TriggersTriggersItemTriggerGenericTriggerPropertiesItemTypeSingleSelectConst = "SINGLE_SELECT"
-	TriggersTriggersItemTriggerGenericTriggerPropertiesItemTypeTextConst = "TEXT"
-)
-
-// UnmarshalTriggersTriggersItemTriggerGenericTriggerPropertiesItem unmarshals an instance of TriggersTriggersItemTriggerGenericTriggerPropertiesItem from the specified map of raw messages.
-func UnmarshalTriggersTriggersItemTriggerGenericTriggerPropertiesItem(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(TriggersTriggersItemTriggerGenericTriggerPropertiesItem)
-	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "value", &obj.Value)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "enum", &obj.Enum)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "default", &obj.Default)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "type", &obj.Type)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "path", &obj.Path)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "href", &obj.Href)
-	if err != nil {
-		return
-	}
-	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
-	return
-}
-
-// TriggersTriggersItemTriggerManualTriggerPropertiesItem : Trigger Property object.
-type TriggersTriggersItemTriggerManualTriggerPropertiesItem struct {
-	// Property name.
-	Name *string `json:"name" validate:"required"`
-
-	// String format property value.
-	Value *string `json:"value,omitempty"`
-
-	// Options for SINGLE_SELECT property type.
-	Enum []string `json:"enum,omitempty"`
-
-	// Default option for SINGLE_SELECT property type.
-	Default *string `json:"default,omitempty"`
-
-	// Property type.
-	Type *string `json:"type" validate:"required"`
-
-	// property path for INTEGRATION type properties.
-	Path *string `json:"path,omitempty"`
-
-	// General href URL.
-	Href *string `json:"href,omitempty"`
-}
-
-// Constants associated with the TriggersTriggersItemTriggerManualTriggerPropertiesItem.Type property.
-// Property type.
-const (
-	TriggersTriggersItemTriggerManualTriggerPropertiesItemTypeAppconfigConst = "APPCONFIG"
-	TriggersTriggersItemTriggerManualTriggerPropertiesItemTypeIntegrationConst = "INTEGRATION"
-	TriggersTriggersItemTriggerManualTriggerPropertiesItemTypeSecureConst = "SECURE"
-	TriggersTriggersItemTriggerManualTriggerPropertiesItemTypeSingleSelectConst = "SINGLE_SELECT"
-	TriggersTriggersItemTriggerManualTriggerPropertiesItemTypeTextConst = "TEXT"
-)
-
-// UnmarshalTriggersTriggersItemTriggerManualTriggerPropertiesItem unmarshals an instance of TriggersTriggersItemTriggerManualTriggerPropertiesItem from the specified map of raw messages.
-func UnmarshalTriggersTriggersItemTriggerManualTriggerPropertiesItem(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(TriggersTriggersItemTriggerManualTriggerPropertiesItem)
-	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "value", &obj.Value)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "enum", &obj.Enum)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "default", &obj.Default)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "type", &obj.Type)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "path", &obj.Path)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "href", &obj.Href)
-	if err != nil {
-		return
-	}
-	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
-	return
-}
-
-// TriggersTriggersItemTriggerScmTriggerPropertiesItem : Trigger Property object.
-type TriggersTriggersItemTriggerScmTriggerPropertiesItem struct {
-	// Property name.
-	Name *string `json:"name" validate:"required"`
-
-	// String format property value.
-	Value *string `json:"value,omitempty"`
-
-	// Options for SINGLE_SELECT property type.
-	Enum []string `json:"enum,omitempty"`
-
-	// Default option for SINGLE_SELECT property type.
-	Default *string `json:"default,omitempty"`
-
-	// Property type.
-	Type *string `json:"type" validate:"required"`
-
-	// property path for INTEGRATION type properties.
-	Path *string `json:"path,omitempty"`
-
-	// General href URL.
-	Href *string `json:"href,omitempty"`
-}
-
-// Constants associated with the TriggersTriggersItemTriggerScmTriggerPropertiesItem.Type property.
-// Property type.
-const (
-	TriggersTriggersItemTriggerScmTriggerPropertiesItemTypeAppconfigConst = "APPCONFIG"
-	TriggersTriggersItemTriggerScmTriggerPropertiesItemTypeIntegrationConst = "INTEGRATION"
-	TriggersTriggersItemTriggerScmTriggerPropertiesItemTypeSecureConst = "SECURE"
-	TriggersTriggersItemTriggerScmTriggerPropertiesItemTypeSingleSelectConst = "SINGLE_SELECT"
-	TriggersTriggersItemTriggerScmTriggerPropertiesItemTypeTextConst = "TEXT"
-)
-
-// UnmarshalTriggersTriggersItemTriggerScmTriggerPropertiesItem unmarshals an instance of TriggersTriggersItemTriggerScmTriggerPropertiesItem from the specified map of raw messages.
-func UnmarshalTriggersTriggersItemTriggerScmTriggerPropertiesItem(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(TriggersTriggersItemTriggerScmTriggerPropertiesItem)
-	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "value", &obj.Value)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "enum", &obj.Enum)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "default", &obj.Default)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "type", &obj.Type)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "path", &obj.Path)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "href", &obj.Href)
-	if err != nil {
-		return
-	}
-	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
-	return
-}
-
-// TriggersTriggersItemTriggerTimerTriggerPropertiesItem : Trigger Property object.
-type TriggersTriggersItemTriggerTimerTriggerPropertiesItem struct {
-	// Property name.
-	Name *string `json:"name" validate:"required"`
-
-	// String format property value.
-	Value *string `json:"value,omitempty"`
-
-	// Options for SINGLE_SELECT property type.
-	Enum []string `json:"enum,omitempty"`
-
-	// Default option for SINGLE_SELECT property type.
-	Default *string `json:"default,omitempty"`
-
-	// Property type.
-	Type *string `json:"type" validate:"required"`
-
-	// property path for INTEGRATION type properties.
-	Path *string `json:"path,omitempty"`
-
-	// General href URL.
-	Href *string `json:"href,omitempty"`
-}
-
-// Constants associated with the TriggersTriggersItemTriggerTimerTriggerPropertiesItem.Type property.
-// Property type.
-const (
-	TriggersTriggersItemTriggerTimerTriggerPropertiesItemTypeAppconfigConst = "APPCONFIG"
-	TriggersTriggersItemTriggerTimerTriggerPropertiesItemTypeIntegrationConst = "INTEGRATION"
-	TriggersTriggersItemTriggerTimerTriggerPropertiesItemTypeSecureConst = "SECURE"
-	TriggersTriggersItemTriggerTimerTriggerPropertiesItemTypeSingleSelectConst = "SINGLE_SELECT"
-	TriggersTriggersItemTriggerTimerTriggerPropertiesItemTypeTextConst = "TEXT"
-)
-
-// UnmarshalTriggersTriggersItemTriggerTimerTriggerPropertiesItem unmarshals an instance of TriggersTriggersItemTriggerTimerTriggerPropertiesItem from the specified map of raw messages.
-func UnmarshalTriggersTriggersItemTriggerTimerTriggerPropertiesItem(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(TriggersTriggersItemTriggerTimerTriggerPropertiesItem)
-	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "value", &obj.Value)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "enum", &obj.Enum)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "default", &obj.Default)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "type", &obj.Type)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "path", &obj.Path)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "href", &obj.Href)
+// UnmarshalTriggersCollection unmarshals an instance of TriggersCollection from the specified map of raw messages.
+func UnmarshalTriggersCollection(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(TriggersCollection)
+	err = core.UnmarshalModel(m, "triggers", &obj.Triggers, UnmarshalTrigger)
 	if err != nil {
 		return
 	}
@@ -6154,7 +5725,7 @@ type UpdateTektonPipelineOptions struct {
 	// ID of current instance.
 	ID *string `json:"id" validate:"required,ne="`
 
-	// Worker object with worker ID only.
+	// Worker object containing worker ID only. If omitted the IBM Managed shared workers are used by default.
 	Worker *WorkerWithID `json:"worker,omitempty"`
 
 	// Allows users to set headers on API requests
@@ -6188,7 +5759,7 @@ func (options *UpdateTektonPipelineOptions) SetHeaders(param map[string]string) 
 
 // UpdateTektonPipelineTriggerOptions : The UpdateTektonPipelineTrigger options.
 type UpdateTektonPipelineTriggerOptions struct {
-	// The tekton pipeline ID.
+	// The Tekton pipeline ID.
 	PipelineID *string `json:"pipeline_id" validate:"required,ne="`
 
 	// The trigger ID.
@@ -6203,31 +5774,31 @@ type UpdateTektonPipelineTriggerOptions struct {
 	// Event listener name.
 	EventListener *string `json:"event_listener,omitempty"`
 
-	// Trigger tags array.
+	// Trigger tags array. Optional tags for the trigger.
 	Tags []string `json:"tags,omitempty"`
 
-	// Trigger worker used to run the trigger, the trigger worker overrides the default pipeline worker.
+	// Worker used to run the trigger. If not specified the trigger will use the default pipeline worker.
 	Worker *Worker `json:"worker,omitempty"`
 
-	// Concurrency object.
-	Concurrency *Concurrency `json:"concurrency,omitempty"`
+	// Defines the maximum number of concurrent runs for this trigger. Omit this property to disable the concurrency limit.
+	MaxConcurrentRuns *int64 `json:"max_concurrent_runs,omitempty"`
 
 	// Defines if this trigger is disabled.
 	Disabled *bool `json:"disabled,omitempty"`
 
-	// Needed only for generic trigger type. Secret used to start generic trigger.
+	// Only needed for generic webhook trigger type. Secret used to start generic webhook trigger.
 	Secret *GenericSecret `json:"secret,omitempty"`
 
-	// Needed only for timer trigger type. Cron expression for timer trigger.
+	// Only needed for timer triggers. Cron expression for timer trigger.
 	Cron *string `json:"cron,omitempty"`
 
-	// Needed only for timer trigger type. Timezones for timer trigger.
+	// Only needed for timer triggers. Timezone for timer trigger.
 	Timezone *string `json:"timezone,omitempty"`
 
-	// Scm source for git type tekton pipeline trigger.
+	// SCM source repository for a Git trigger. Only needed for Git triggers.
 	ScmSource *TriggerScmSource `json:"scm_source,omitempty"`
 
-	// Needed only for git trigger type. Events object defines the events this git trigger listening to.
+	// Only needed for Git triggers. Events object defines the events to which this Git trigger listens.
 	Events *Events `json:"events,omitempty"`
 
 	// Allows users to set headers on API requests
@@ -6293,9 +5864,9 @@ func (_options *UpdateTektonPipelineTriggerOptions) SetWorker(worker *Worker) *U
 	return _options
 }
 
-// SetConcurrency : Allow user to set Concurrency
-func (_options *UpdateTektonPipelineTriggerOptions) SetConcurrency(concurrency *Concurrency) *UpdateTektonPipelineTriggerOptions {
-	_options.Concurrency = concurrency
+// SetMaxConcurrentRuns : Allow user to set MaxConcurrentRuns
+func (_options *UpdateTektonPipelineTriggerOptions) SetMaxConcurrentRuns(maxConcurrentRuns int64) *UpdateTektonPipelineTriggerOptions {
+	_options.MaxConcurrentRuns = core.Int64Ptr(maxConcurrentRuns)
 	return _options
 }
 
@@ -6346,7 +5917,7 @@ type UserInfo struct {
 	// IBM Cloud IAM ID.
 	IamID *string `json:"iam_id" validate:"required"`
 
-	// User Email address.
+	// User email address.
 	Sub *string `json:"sub" validate:"required"`
 }
 
@@ -6367,18 +5938,18 @@ func UnmarshalUserInfo(m map[string]json.RawMessage, result interface{}) (err er
 
 // Worker : Default pipeline worker used to run the pipeline.
 type Worker struct {
-	// worker name.
+	// Name of the worker. Computed based on the worker ID.
 	Name *string `json:"name,omitempty"`
 
-	// worker type.
+	// Type of the worker. Computed based on the worker ID.
 	Type *string `json:"type,omitempty"`
 
-	// Id.
+	// ID of the worker.
 	ID *string `json:"id" validate:"required"`
 }
 
 // Constants associated with the Worker.Type property.
-// worker type.
+// Type of the worker. Computed based on the worker ID.
 const (
 	WorkerTypePrivateConst = "private"
 	WorkerTypePublicConst = "public"
@@ -6412,7 +5983,7 @@ func UnmarshalWorker(m map[string]json.RawMessage, result interface{}) (err erro
 	return
 }
 
-// WorkerWithID : Worker object with worker ID only.
+// WorkerWithID : Worker object containing worker ID only. If omitted the IBM Managed shared workers are used by default.
 type WorkerWithID struct {
 	ID *string `json:"id" validate:"required"`
 }
@@ -6437,13 +6008,13 @@ func UnmarshalWorkerWithID(m map[string]json.RawMessage, result interface{}) (er
 	return
 }
 
-// TriggerDuplicateTrigger : request body to duplicate trigger.
+// TriggerDuplicateTrigger : Duplicate an existing trigger.
 // This model "extends" Trigger
 type TriggerDuplicateTrigger struct {
-	// source trigger ID to clone from.
+	// ID of the trigger to duplicate. Only needed when duplicating a trigger.
 	SourceTriggerID *string `json:"source_trigger_id" validate:"required"`
 
-	// name of the duplicated trigger.
+	// Trigger name.
 	Name *string `json:"name" validate:"required"`
 }
 
@@ -6476,7 +6047,8 @@ func UnmarshalTriggerDuplicateTrigger(m map[string]json.RawMessage, result inter
 	return
 }
 
-// TriggerGenericTrigger : Generic trigger, which triggers pipeline when tekton pipeline service receive a valie POST event with secrets.
+// TriggerGenericTrigger : Generic webhook trigger, which triggers a pipeline run when the Tekton Pipeline Service receives a POST event with
+// secrets.
 // This model "extends" Trigger
 type TriggerGenericTrigger struct {
 	// Trigger type.
@@ -6485,10 +6057,13 @@ type TriggerGenericTrigger struct {
 	// Trigger name.
 	Name *string `json:"name" validate:"required"`
 
+	// API URL for interacting with the trigger.
+	Href *string `json:"href,omitempty"`
+
 	// Event listener name.
 	EventListener *string `json:"event_listener" validate:"required"`
 
-	// Id.
+	// ID.
 	ID *string `json:"id,omitempty"`
 
 	// Trigger properties.
@@ -6497,17 +6072,16 @@ type TriggerGenericTrigger struct {
 	// Trigger tags array.
 	Tags []string `json:"tags,omitempty"`
 
-	// Trigger worker used to run the trigger, the trigger worker overrides the default pipeline worker.If not exist, this
-	// trigger uses default pipeline worker.
+	// Worker used to run the trigger. If not specified the trigger will use the default pipeline worker.
 	Worker *Worker `json:"worker,omitempty"`
 
-	// Concurrency object.
-	Concurrency *Concurrency `json:"concurrency,omitempty"`
+	// Defines the maximum number of concurrent runs for this trigger. Omit this property to disable the concurrency limit.
+	MaxConcurrentRuns *int64 `json:"max_concurrent_runs,omitempty"`
 
-	// flag whether the trigger is disabled.
+	// Flag whether the trigger is disabled. If omitted the trigger is enabled by default.
 	Disabled *bool `json:"disabled" validate:"required"`
 
-	// Needed only for generic trigger type. Secret used to start generic trigger.
+	// Only needed for generic webhook trigger type. Secret used to start generic webhook trigger.
 	Secret *GenericSecret `json:"secret,omitempty"`
 }
 
@@ -6538,6 +6112,10 @@ func UnmarshalTriggerGenericTrigger(m map[string]json.RawMessage, result interfa
 	if err != nil {
 		return
 	}
+	err = core.UnmarshalPrimitive(m, "href", &obj.Href)
+	if err != nil {
+		return
+	}
 	err = core.UnmarshalPrimitive(m, "event_listener", &obj.EventListener)
 	if err != nil {
 		return
@@ -6558,7 +6136,7 @@ func UnmarshalTriggerGenericTrigger(m map[string]json.RawMessage, result interfa
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalModel(m, "concurrency", &obj.Concurrency, UnmarshalConcurrency)
+	err = core.UnmarshalPrimitive(m, "max_concurrent_runs", &obj.MaxConcurrentRuns)
 	if err != nil {
 		return
 	}
@@ -6583,10 +6161,13 @@ type TriggerManualTrigger struct {
 	// Trigger name.
 	Name *string `json:"name" validate:"required"`
 
+	// API URL for interacting with the trigger.
+	Href *string `json:"href,omitempty"`
+
 	// Event listener name.
 	EventListener *string `json:"event_listener" validate:"required"`
 
-	// Id.
+	// ID.
 	ID *string `json:"id,omitempty"`
 
 	// Trigger properties.
@@ -6595,14 +6176,13 @@ type TriggerManualTrigger struct {
 	// Trigger tags array.
 	Tags []string `json:"tags,omitempty"`
 
-	// Trigger worker used to run the trigger, the trigger worker overrides the default pipeline worker.If not exist, this
-	// trigger uses default pipeline worker.
+	// Worker used to run the trigger. If not specified the trigger will use the default pipeline worker.
 	Worker *Worker `json:"worker,omitempty"`
 
-	// Concurrency object.
-	Concurrency *Concurrency `json:"concurrency,omitempty"`
+	// Defines the maximum number of concurrent runs for this trigger. Omit this property to disable the concurrency limit.
+	MaxConcurrentRuns *int64 `json:"max_concurrent_runs,omitempty"`
 
-	// flag whether the trigger is disabled.
+	// Flag whether the trigger is disabled. If omitted the trigger is enabled by default.
 	Disabled *bool `json:"disabled" validate:"required"`
 }
 
@@ -6633,6 +6213,10 @@ func UnmarshalTriggerManualTrigger(m map[string]json.RawMessage, result interfac
 	if err != nil {
 		return
 	}
+	err = core.UnmarshalPrimitive(m, "href", &obj.Href)
+	if err != nil {
+		return
+	}
 	err = core.UnmarshalPrimitive(m, "event_listener", &obj.EventListener)
 	if err != nil {
 		return
@@ -6653,7 +6237,7 @@ func UnmarshalTriggerManualTrigger(m map[string]json.RawMessage, result interfac
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalModel(m, "concurrency", &obj.Concurrency, UnmarshalConcurrency)
+	err = core.UnmarshalPrimitive(m, "max_concurrent_runs", &obj.MaxConcurrentRuns)
 	if err != nil {
 		return
 	}
@@ -6665,8 +6249,8 @@ func UnmarshalTriggerManualTrigger(m map[string]json.RawMessage, result interfac
 	return
 }
 
-// TriggerScmTrigger : Git type trigger, which automatically triggers pipelineRun when tekton pipeline service receive a valid corresponding
-// git event.
+// TriggerScmTrigger : Git type trigger, which automatically triggers a pipeline run when the Tekton Pipeline Service receives a
+// corresponding Git webhook event.
 // This model "extends" Trigger
 type TriggerScmTrigger struct {
 	// Trigger type.
@@ -6675,10 +6259,13 @@ type TriggerScmTrigger struct {
 	// Trigger name.
 	Name *string `json:"name" validate:"required"`
 
+	// API URL for interacting with the trigger.
+	Href *string `json:"href,omitempty"`
+
 	// Event listener name.
 	EventListener *string `json:"event_listener" validate:"required"`
 
-	// Id.
+	// ID.
 	ID *string `json:"id,omitempty"`
 
 	// Trigger properties.
@@ -6687,23 +6274,22 @@ type TriggerScmTrigger struct {
 	// Trigger tags array.
 	Tags []string `json:"tags,omitempty"`
 
-	// Trigger worker used to run the trigger, the trigger worker overrides the default pipeline worker.If not exist, this
-	// trigger uses default pipeline worker.
+	// Worker used to run the trigger. If not specified the trigger will use the default pipeline worker.
 	Worker *Worker `json:"worker,omitempty"`
 
-	// Concurrency object.
-	Concurrency *Concurrency `json:"concurrency,omitempty"`
+	// Defines the maximum number of concurrent runs for this trigger. Omit this property to disable the concurrency limit.
+	MaxConcurrentRuns *int64 `json:"max_concurrent_runs,omitempty"`
 
-	// flag whether the trigger is disabled.
+	// Flag whether the trigger is disabled. If omitted the trigger is enabled by default.
 	Disabled *bool `json:"disabled" validate:"required"`
 
-	// Scm source for git type tekton pipeline trigger.
+	// SCM source repository for a Git trigger. Only needed for Git triggers.
 	ScmSource *TriggerScmSource `json:"scm_source,omitempty"`
 
-	// Needed only for git trigger type. Events object defines the events this git trigger listening to.
+	// Only needed for Git triggers. Events object defines the events to which this Git trigger listens.
 	Events *Events `json:"events,omitempty"`
 
-	// UUID.
+	// ID of the repository service instance.
 	ServiceInstanceID *string `json:"service_instance_id,omitempty"`
 }
 
@@ -6734,6 +6320,10 @@ func UnmarshalTriggerScmTrigger(m map[string]json.RawMessage, result interface{}
 	if err != nil {
 		return
 	}
+	err = core.UnmarshalPrimitive(m, "href", &obj.Href)
+	if err != nil {
+		return
+	}
 	err = core.UnmarshalPrimitive(m, "event_listener", &obj.EventListener)
 	if err != nil {
 		return
@@ -6754,7 +6344,7 @@ func UnmarshalTriggerScmTrigger(m map[string]json.RawMessage, result interface{}
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalModel(m, "concurrency", &obj.Concurrency, UnmarshalConcurrency)
+	err = core.UnmarshalPrimitive(m, "max_concurrent_runs", &obj.MaxConcurrentRuns)
 	if err != nil {
 		return
 	}
@@ -6778,7 +6368,7 @@ func UnmarshalTriggerScmTrigger(m map[string]json.RawMessage, result interface{}
 	return
 }
 
-// TriggerTimerTrigger : Timer trigger, which triggers pipelineRun according to the cron value and time zone.
+// TriggerTimerTrigger : Timer trigger, which triggers pipeline run according to the cron value and time zone.
 // This model "extends" Trigger
 type TriggerTimerTrigger struct {
 	// Trigger type.
@@ -6787,10 +6377,13 @@ type TriggerTimerTrigger struct {
 	// Trigger name.
 	Name *string `json:"name" validate:"required"`
 
+	// API URL for interacting with the trigger.
+	Href *string `json:"href,omitempty"`
+
 	// Event listener name.
 	EventListener *string `json:"event_listener" validate:"required"`
 
-	// Id.
+	// ID.
 	ID *string `json:"id,omitempty"`
 
 	// Trigger properties.
@@ -6799,20 +6392,19 @@ type TriggerTimerTrigger struct {
 	// Trigger tags array.
 	Tags []string `json:"tags,omitempty"`
 
-	// Trigger worker used to run the trigger, the trigger worker overrides the default pipeline worker.If not exist, this
-	// trigger uses default pipeline worker.
+	// Worker used to run the trigger. If not specified the trigger will use the default pipeline worker.
 	Worker *Worker `json:"worker,omitempty"`
 
-	// Concurrency object.
-	Concurrency *Concurrency `json:"concurrency,omitempty"`
+	// Defines the maximum number of concurrent runs for this trigger. Omit this property to disable the concurrency limit.
+	MaxConcurrentRuns *int64 `json:"max_concurrent_runs,omitempty"`
 
-	// flag whether the trigger is disabled.
+	// Flag whether the trigger is disabled. If omitted the trigger is enabled by default.
 	Disabled *bool `json:"disabled" validate:"required"`
 
-	// Needed only for timer trigger type. Cron expression for timer trigger. Maximum frequency is every 5 minutes.
+	// Only needed for timer triggers. Cron expression for timer trigger. Maximum frequency is every 5 minutes.
 	Cron *string `json:"cron,omitempty"`
 
-	// Needed only for timer trigger type. Timezones for timer trigger.
+	// Only needed for timer triggers. Timezone for timer trigger.
 	Timezone *string `json:"timezone,omitempty"`
 }
 
@@ -6843,6 +6435,10 @@ func UnmarshalTriggerTimerTrigger(m map[string]json.RawMessage, result interface
 	if err != nil {
 		return
 	}
+	err = core.UnmarshalPrimitive(m, "href", &obj.Href)
+	if err != nil {
+		return
+	}
 	err = core.UnmarshalPrimitive(m, "event_listener", &obj.EventListener)
 	if err != nil {
 		return
@@ -6863,430 +6459,7 @@ func UnmarshalTriggerTimerTrigger(m map[string]json.RawMessage, result interface
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalModel(m, "concurrency", &obj.Concurrency, UnmarshalConcurrency)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "disabled", &obj.Disabled)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "cron", &obj.Cron)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "timezone", &obj.Timezone)
-	if err != nil {
-		return
-	}
-	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
-	return
-}
-
-// TriggersTriggersItemTriggerDuplicateTrigger : request body to duplicate trigger.
-// This model "extends" TriggersTriggersItem
-type TriggersTriggersItemTriggerDuplicateTrigger struct {
-	// General href URL.
-	Href *string `json:"href,omitempty"`
-
-	// source trigger ID to clone from.
-	SourceTriggerID *string `json:"source_trigger_id" validate:"required"`
-
-	// name of the duplicated trigger.
-	Name *string `json:"name" validate:"required"`
-}
-
-func (*TriggersTriggersItemTriggerDuplicateTrigger) isaTriggersTriggersItem() bool {
-	return true
-}
-
-// UnmarshalTriggersTriggersItemTriggerDuplicateTrigger unmarshals an instance of TriggersTriggersItemTriggerDuplicateTrigger from the specified map of raw messages.
-func UnmarshalTriggersTriggersItemTriggerDuplicateTrigger(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(TriggersTriggersItemTriggerDuplicateTrigger)
-	err = core.UnmarshalPrimitive(m, "href", &obj.Href)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "source_trigger_id", &obj.SourceTriggerID)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
-	if err != nil {
-		return
-	}
-	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
-	return
-}
-
-// TriggersTriggersItemTriggerGenericTrigger : Generic trigger, which triggers pipeline when tekton pipeline service receive a valie POST event with secrets.
-// This model "extends" TriggersTriggersItem
-type TriggersTriggersItemTriggerGenericTrigger struct {
-	// General href URL.
-	Href *string `json:"href,omitempty"`
-
-	// Trigger type.
-	Type *string `json:"type" validate:"required"`
-
-	// Trigger name.
-	Name *string `json:"name" validate:"required"`
-
-	// Event listener name.
-	EventListener *string `json:"event_listener" validate:"required"`
-
-	// Id.
-	ID *string `json:"id,omitempty"`
-
-	// Trigger properties.
-	Properties []TriggersTriggersItemTriggerGenericTriggerPropertiesItem `json:"properties,omitempty"`
-
-	// Trigger tags array.
-	Tags []string `json:"tags,omitempty"`
-
-	// Trigger worker used to run the trigger, the trigger worker overrides the default pipeline worker.If not exist, this
-	// trigger uses default pipeline worker.
-	Worker *Worker `json:"worker,omitempty"`
-
-	// Concurrency object.
-	Concurrency *Concurrency `json:"concurrency,omitempty"`
-
-	// flag whether the trigger is disabled.
-	Disabled *bool `json:"disabled" validate:"required"`
-
-	// Needed only for generic trigger type. Secret used to start generic trigger.
-	Secret *GenericSecret `json:"secret,omitempty"`
-}
-
-func (*TriggersTriggersItemTriggerGenericTrigger) isaTriggersTriggersItem() bool {
-	return true
-}
-
-// UnmarshalTriggersTriggersItemTriggerGenericTrigger unmarshals an instance of TriggersTriggersItemTriggerGenericTrigger from the specified map of raw messages.
-func UnmarshalTriggersTriggersItemTriggerGenericTrigger(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(TriggersTriggersItemTriggerGenericTrigger)
-	err = core.UnmarshalPrimitive(m, "href", &obj.Href)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "type", &obj.Type)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "event_listener", &obj.EventListener)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "id", &obj.ID)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalModel(m, "properties", &obj.Properties, UnmarshalTriggersTriggersItemTriggerGenericTriggerPropertiesItem)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "tags", &obj.Tags)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalModel(m, "worker", &obj.Worker, UnmarshalWorker)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalModel(m, "concurrency", &obj.Concurrency, UnmarshalConcurrency)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "disabled", &obj.Disabled)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalModel(m, "secret", &obj.Secret, UnmarshalGenericSecret)
-	if err != nil {
-		return
-	}
-	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
-	return
-}
-
-// TriggersTriggersItemTriggerManualTrigger : Manual trigger.
-// This model "extends" TriggersTriggersItem
-type TriggersTriggersItemTriggerManualTrigger struct {
-	// General href URL.
-	Href *string `json:"href,omitempty"`
-
-	// Trigger type.
-	Type *string `json:"type" validate:"required"`
-
-	// Trigger name.
-	Name *string `json:"name" validate:"required"`
-
-	// Event listener name.
-	EventListener *string `json:"event_listener" validate:"required"`
-
-	// Id.
-	ID *string `json:"id,omitempty"`
-
-	// Trigger properties.
-	Properties []TriggersTriggersItemTriggerManualTriggerPropertiesItem `json:"properties,omitempty"`
-
-	// Trigger tags array.
-	Tags []string `json:"tags,omitempty"`
-
-	// Trigger worker used to run the trigger, the trigger worker overrides the default pipeline worker.If not exist, this
-	// trigger uses default pipeline worker.
-	Worker *Worker `json:"worker,omitempty"`
-
-	// Concurrency object.
-	Concurrency *Concurrency `json:"concurrency,omitempty"`
-
-	// flag whether the trigger is disabled.
-	Disabled *bool `json:"disabled" validate:"required"`
-}
-
-func (*TriggersTriggersItemTriggerManualTrigger) isaTriggersTriggersItem() bool {
-	return true
-}
-
-// UnmarshalTriggersTriggersItemTriggerManualTrigger unmarshals an instance of TriggersTriggersItemTriggerManualTrigger from the specified map of raw messages.
-func UnmarshalTriggersTriggersItemTriggerManualTrigger(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(TriggersTriggersItemTriggerManualTrigger)
-	err = core.UnmarshalPrimitive(m, "href", &obj.Href)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "type", &obj.Type)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "event_listener", &obj.EventListener)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "id", &obj.ID)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalModel(m, "properties", &obj.Properties, UnmarshalTriggersTriggersItemTriggerManualTriggerPropertiesItem)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "tags", &obj.Tags)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalModel(m, "worker", &obj.Worker, UnmarshalWorker)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalModel(m, "concurrency", &obj.Concurrency, UnmarshalConcurrency)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "disabled", &obj.Disabled)
-	if err != nil {
-		return
-	}
-	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
-	return
-}
-
-// TriggersTriggersItemTriggerScmTrigger : Git type trigger, which automatically triggers pipelineRun when tekton pipeline service receive a valid corresponding
-// git event.
-// This model "extends" TriggersTriggersItem
-type TriggersTriggersItemTriggerScmTrigger struct {
-	// General href URL.
-	Href *string `json:"href,omitempty"`
-
-	// Trigger type.
-	Type *string `json:"type" validate:"required"`
-
-	// Trigger name.
-	Name *string `json:"name" validate:"required"`
-
-	// Event listener name.
-	EventListener *string `json:"event_listener" validate:"required"`
-
-	// Id.
-	ID *string `json:"id,omitempty"`
-
-	// Trigger properties.
-	Properties []TriggersTriggersItemTriggerScmTriggerPropertiesItem `json:"properties,omitempty"`
-
-	// Trigger tags array.
-	Tags []string `json:"tags,omitempty"`
-
-	// Trigger worker used to run the trigger, the trigger worker overrides the default pipeline worker.If not exist, this
-	// trigger uses default pipeline worker.
-	Worker *Worker `json:"worker,omitempty"`
-
-	// Concurrency object.
-	Concurrency *Concurrency `json:"concurrency,omitempty"`
-
-	// flag whether the trigger is disabled.
-	Disabled *bool `json:"disabled" validate:"required"`
-
-	// Scm source for git type tekton pipeline trigger.
-	ScmSource *TriggerScmSource `json:"scm_source,omitempty"`
-
-	// Needed only for git trigger type. Events object defines the events this git trigger listening to.
-	Events *Events `json:"events,omitempty"`
-
-	// UUID.
-	ServiceInstanceID *string `json:"service_instance_id,omitempty"`
-}
-
-func (*TriggersTriggersItemTriggerScmTrigger) isaTriggersTriggersItem() bool {
-	return true
-}
-
-// UnmarshalTriggersTriggersItemTriggerScmTrigger unmarshals an instance of TriggersTriggersItemTriggerScmTrigger from the specified map of raw messages.
-func UnmarshalTriggersTriggersItemTriggerScmTrigger(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(TriggersTriggersItemTriggerScmTrigger)
-	err = core.UnmarshalPrimitive(m, "href", &obj.Href)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "type", &obj.Type)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "event_listener", &obj.EventListener)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "id", &obj.ID)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalModel(m, "properties", &obj.Properties, UnmarshalTriggersTriggersItemTriggerScmTriggerPropertiesItem)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "tags", &obj.Tags)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalModel(m, "worker", &obj.Worker, UnmarshalWorker)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalModel(m, "concurrency", &obj.Concurrency, UnmarshalConcurrency)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "disabled", &obj.Disabled)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalModel(m, "scm_source", &obj.ScmSource, UnmarshalTriggerScmSource)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalModel(m, "events", &obj.Events, UnmarshalEvents)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "service_instance_id", &obj.ServiceInstanceID)
-	if err != nil {
-		return
-	}
-	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
-	return
-}
-
-// TriggersTriggersItemTriggerTimerTrigger : Timer trigger, which triggers pipelineRun according to the cron value and time zone.
-// This model "extends" TriggersTriggersItem
-type TriggersTriggersItemTriggerTimerTrigger struct {
-	// General href URL.
-	Href *string `json:"href,omitempty"`
-
-	// Trigger type.
-	Type *string `json:"type" validate:"required"`
-
-	// Trigger name.
-	Name *string `json:"name" validate:"required"`
-
-	// Event listener name.
-	EventListener *string `json:"event_listener" validate:"required"`
-
-	// Id.
-	ID *string `json:"id,omitempty"`
-
-	// Trigger properties.
-	Properties []TriggersTriggersItemTriggerTimerTriggerPropertiesItem `json:"properties,omitempty"`
-
-	// Trigger tags array.
-	Tags []string `json:"tags,omitempty"`
-
-	// Trigger worker used to run the trigger, the trigger worker overrides the default pipeline worker.If not exist, this
-	// trigger uses default pipeline worker.
-	Worker *Worker `json:"worker,omitempty"`
-
-	// Concurrency object.
-	Concurrency *Concurrency `json:"concurrency,omitempty"`
-
-	// flag whether the trigger is disabled.
-	Disabled *bool `json:"disabled" validate:"required"`
-
-	// Needed only for timer trigger type. Cron expression for timer trigger. Maximum frequency is every 5 minutes.
-	Cron *string `json:"cron,omitempty"`
-
-	// Needed only for timer trigger type. Timezones for timer trigger.
-	Timezone *string `json:"timezone,omitempty"`
-}
-
-func (*TriggersTriggersItemTriggerTimerTrigger) isaTriggersTriggersItem() bool {
-	return true
-}
-
-// UnmarshalTriggersTriggersItemTriggerTimerTrigger unmarshals an instance of TriggersTriggersItemTriggerTimerTrigger from the specified map of raw messages.
-func UnmarshalTriggersTriggersItemTriggerTimerTrigger(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(TriggersTriggersItemTriggerTimerTrigger)
-	err = core.UnmarshalPrimitive(m, "href", &obj.Href)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "type", &obj.Type)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "event_listener", &obj.EventListener)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "id", &obj.ID)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalModel(m, "properties", &obj.Properties, UnmarshalTriggersTriggersItemTriggerTimerTriggerPropertiesItem)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "tags", &obj.Tags)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalModel(m, "worker", &obj.Worker, UnmarshalWorker)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalModel(m, "concurrency", &obj.Concurrency, UnmarshalConcurrency)
+	err = core.UnmarshalPrimitive(m, "max_concurrent_runs", &obj.MaxConcurrentRuns)
 	if err != nil {
 		return
 	}
@@ -7340,7 +6513,7 @@ func (pager *TektonPipelineRunsPager) HasNext() bool {
 }
 
 // GetNextWithContext returns the next page of results using the specified Context.
-func (pager *TektonPipelineRunsPager) GetNextWithContext(ctx context.Context) (page []PipelineRunsPipelineRunsItem, err error) {
+func (pager *TektonPipelineRunsPager) GetNextWithContext(ctx context.Context) (page []PipelineRunsCollectionPipelineRunsItem, err error) {
 	if !pager.HasNext() {
 		return nil, fmt.Errorf("no more results available")
 	}
@@ -7371,9 +6544,9 @@ func (pager *TektonPipelineRunsPager) GetNextWithContext(ctx context.Context) (p
 
 // GetAllWithContext returns all results by invoking GetNextWithContext() repeatedly
 // until all pages of results have been retrieved.
-func (pager *TektonPipelineRunsPager) GetAllWithContext(ctx context.Context) (allItems []PipelineRunsPipelineRunsItem, err error) {
+func (pager *TektonPipelineRunsPager) GetAllWithContext(ctx context.Context) (allItems []PipelineRunsCollectionPipelineRunsItem, err error) {
 	for pager.HasNext() {
-		var nextPage []PipelineRunsPipelineRunsItem
+		var nextPage []PipelineRunsCollectionPipelineRunsItem
 		nextPage, err = pager.GetNextWithContext(ctx)
 		if err != nil {
 			return
@@ -7384,11 +6557,11 @@ func (pager *TektonPipelineRunsPager) GetAllWithContext(ctx context.Context) (al
 }
 
 // GetNext invokes GetNextWithContext() using context.Background() as the Context parameter.
-func (pager *TektonPipelineRunsPager) GetNext() (page []PipelineRunsPipelineRunsItem, err error) {
+func (pager *TektonPipelineRunsPager) GetNext() (page []PipelineRunsCollectionPipelineRunsItem, err error) {
 	return pager.GetNextWithContext(context.Background())
 }
 
 // GetAll invokes GetAllWithContext() using context.Background() as the Context parameter.
-func (pager *TektonPipelineRunsPager) GetAll() (allItems []PipelineRunsPipelineRunsItem, err error) {
+func (pager *TektonPipelineRunsPager) GetAll() (allItems []PipelineRunsCollectionPipelineRunsItem, err error) {
 	return pager.GetAllWithContext(context.Background())
 }

--- a/cdtektonpipelinev2/cd_tekton_pipeline_v2.go
+++ b/cdtektonpipelinev2/cd_tekton_pipeline_v2.go
@@ -15,7 +15,7 @@
  */
 
 /*
- * IBM OpenAPI SDK Code Generator Version: 3.53.0-9710cac3-20220713-193508
+ * IBM OpenAPI SDK Code Generator Version: 3.54.2-6c0e29d4-20220824-204545
  */
 
 // Package cdtektonpipelinev2 : Operations and models for the CdTektonPipelineV2 service
@@ -215,6 +215,12 @@ func (cdTektonPipeline *CdTektonPipelineV2) CreateTektonPipelineWithContext(ctx 
 	builder.AddHeader("Content-Type", "application/json")
 
 	body := make(map[string]interface{})
+	if createTektonPipelineOptions.EnableSlackNotifications != nil {
+		body["enable_slack_notifications"] = createTektonPipelineOptions.EnableSlackNotifications
+	}
+	if createTektonPipelineOptions.EnablePartialCloning != nil {
+		body["enable_partial_cloning"] = createTektonPipelineOptions.EnablePartialCloning
+	}
 	if createTektonPipelineOptions.ID != nil {
 		body["id"] = createTektonPipelineOptions.ID
 	}
@@ -2388,6 +2394,15 @@ func (options *CreateTektonPipelineDefinitionOptions) SetHeaders(param map[strin
 
 // CreateTektonPipelineOptions : The CreateTektonPipeline options.
 type CreateTektonPipelineOptions struct {
+	// Flag whether to enable slack notifications for this pipeline. When enabled, pipeline run events will be published on
+	// all slack integration specified channels in the enclosing toolchain.
+	EnableSlackNotifications *bool `json:"enable_slack_notifications,omitempty"`
+
+	// Flag whether to enable partial cloning for this pipeline. When partial clone is enabled, only the files contained
+	// within the paths specified in definition repositories will be read and cloned. This means symbolic links may not
+	// work.
+	EnablePartialCloning *bool `json:"enable_partial_cloning,omitempty"`
+
 	// UUID.
 	ID *string `json:"id,omitempty"`
 
@@ -2401,6 +2416,18 @@ type CreateTektonPipelineOptions struct {
 // NewCreateTektonPipelineOptions : Instantiate CreateTektonPipelineOptions
 func (*CdTektonPipelineV2) NewCreateTektonPipelineOptions() *CreateTektonPipelineOptions {
 	return &CreateTektonPipelineOptions{}
+}
+
+// SetEnableSlackNotifications : Allow user to set EnableSlackNotifications
+func (_options *CreateTektonPipelineOptions) SetEnableSlackNotifications(enableSlackNotifications bool) *CreateTektonPipelineOptions {
+	_options.EnableSlackNotifications = core.BoolPtr(enableSlackNotifications)
+	return _options
+}
+
+// SetEnablePartialCloning : Allow user to set EnablePartialCloning
+func (_options *CreateTektonPipelineOptions) SetEnablePartialCloning(enablePartialCloning bool) *CreateTektonPipelineOptions {
+	_options.EnablePartialCloning = core.BoolPtr(enablePartialCloning)
+	return _options
 }
 
 // SetID : Allow user to set ID
@@ -4788,9 +4815,6 @@ type TektonPipelinePatch struct {
 	// work.
 	EnablePartialCloning *bool `json:"enable_partial_cloning,omitempty"`
 
-	// Flag whether this pipeline is enabled.
-	Enabled *bool `json:"enabled,omitempty"`
-
 	// Worker object containing worker ID only. If omitted the IBM Managed shared workers are used by default.
 	Worker *WorkerWithID `json:"worker,omitempty"`
 }
@@ -4803,10 +4827,6 @@ func UnmarshalTektonPipelinePatch(m map[string]json.RawMessage, result interface
 		return
 	}
 	err = core.UnmarshalPrimitive(m, "enable_partial_cloning", &obj.EnablePartialCloning)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "enabled", &obj.Enabled)
 	if err != nil {
 		return
 	}

--- a/cdtektonpipelinev2/cd_tekton_pipeline_v2.go
+++ b/cdtektonpipelinev2/cd_tekton_pipeline_v2.go
@@ -346,15 +346,13 @@ func (cdTektonPipeline *CdTektonPipelineV2) UpdateTektonPipelineWithContext(ctx 
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
-	builder.AddHeader("Content-Type", "application/json")
+	builder.AddHeader("Content-Type", "application/merge-patch+json")
 
-	body := make(map[string]interface{})
-	if updateTektonPipelineOptions.Worker != nil {
-		body["worker"] = updateTektonPipelineOptions.Worker
-	}
-	_, err = builder.SetBodyContentJSON(body)
-	if err != nil {
-		return
+	if updateTektonPipelineOptions.TektonPipelinePatch != nil {
+		_, err = builder.SetBodyContentJSON(updateTektonPipelineOptions.TektonPipelinePatch)
+		if err != nil {
+			return
+		}
 	}
 
 	request, err := builder.Build()
@@ -831,8 +829,9 @@ func (cdTektonPipeline *CdTektonPipelineV2) RerunTektonPipelineRunWithContext(ct
 	return
 }
 
-// GetTektonPipelineRunLogs : Get a list of pipeline run log IDs
-// This request fetches the list of log IDs for a pipeline run identified by `{id}`.
+// GetTektonPipelineRunLogs : Get a list of pipeline run log objects
+// This request fetches a list of log data for a pipeline run identified by `{id}`. The `href` in each log entry can be
+// used to fetch that individual log.
 func (cdTektonPipeline *CdTektonPipelineV2) GetTektonPipelineRunLogs(getTektonPipelineRunLogsOptions *GetTektonPipelineRunLogsOptions) (result *LogsCollection, response *core.DetailedResponse, err error) {
 	return cdTektonPipeline.GetTektonPipelineRunLogsWithContext(context.Background(), getTektonPipelineRunLogsOptions)
 }
@@ -1060,9 +1059,6 @@ func (cdTektonPipeline *CdTektonPipelineV2) CreateTektonPipelineDefinitionWithCo
 	if createTektonPipelineDefinitionOptions.ScmSource != nil {
 		body["scm_source"] = createTektonPipelineDefinitionOptions.ScmSource
 	}
-	if createTektonPipelineDefinitionOptions.ServiceInstanceID != nil {
-		body["service_instance_id"] = createTektonPipelineDefinitionOptions.ServiceInstanceID
-	}
 	if createTektonPipelineDefinitionOptions.ID != nil {
 		body["id"] = createTektonPipelineDefinitionOptions.ID
 	}
@@ -1198,9 +1194,6 @@ func (cdTektonPipeline *CdTektonPipelineV2) ReplaceTektonPipelineDefinitionWithC
 	body := make(map[string]interface{})
 	if replaceTektonPipelineDefinitionOptions.ScmSource != nil {
 		body["scm_source"] = replaceTektonPipelineDefinitionOptions.ScmSource
-	}
-	if replaceTektonPipelineDefinitionOptions.ServiceInstanceID != nil {
-		body["service_instance_id"] = replaceTektonPipelineDefinitionOptions.ServiceInstanceID
 	}
 	if replaceTektonPipelineDefinitionOptions.ID != nil {
 		body["id"] = replaceTektonPipelineDefinitionOptions.ID
@@ -1883,48 +1876,13 @@ func (cdTektonPipeline *CdTektonPipelineV2) UpdateTektonPipelineTriggerWithConte
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
-	builder.AddHeader("Content-Type", "application/json")
+	builder.AddHeader("Content-Type", "application/merge-patch+json")
 
-	body := make(map[string]interface{})
-	if updateTektonPipelineTriggerOptions.Type != nil {
-		body["type"] = updateTektonPipelineTriggerOptions.Type
-	}
-	if updateTektonPipelineTriggerOptions.Name != nil {
-		body["name"] = updateTektonPipelineTriggerOptions.Name
-	}
-	if updateTektonPipelineTriggerOptions.EventListener != nil {
-		body["event_listener"] = updateTektonPipelineTriggerOptions.EventListener
-	}
-	if updateTektonPipelineTriggerOptions.Tags != nil {
-		body["tags"] = updateTektonPipelineTriggerOptions.Tags
-	}
-	if updateTektonPipelineTriggerOptions.Worker != nil {
-		body["worker"] = updateTektonPipelineTriggerOptions.Worker
-	}
-	if updateTektonPipelineTriggerOptions.MaxConcurrentRuns != nil {
-		body["max_concurrent_runs"] = updateTektonPipelineTriggerOptions.MaxConcurrentRuns
-	}
-	if updateTektonPipelineTriggerOptions.Disabled != nil {
-		body["disabled"] = updateTektonPipelineTriggerOptions.Disabled
-	}
-	if updateTektonPipelineTriggerOptions.Secret != nil {
-		body["secret"] = updateTektonPipelineTriggerOptions.Secret
-	}
-	if updateTektonPipelineTriggerOptions.Cron != nil {
-		body["cron"] = updateTektonPipelineTriggerOptions.Cron
-	}
-	if updateTektonPipelineTriggerOptions.Timezone != nil {
-		body["timezone"] = updateTektonPipelineTriggerOptions.Timezone
-	}
-	if updateTektonPipelineTriggerOptions.ScmSource != nil {
-		body["scm_source"] = updateTektonPipelineTriggerOptions.ScmSource
-	}
-	if updateTektonPipelineTriggerOptions.Events != nil {
-		body["events"] = updateTektonPipelineTriggerOptions.Events
-	}
-	_, err = builder.SetBodyContentJSON(body)
-	if err != nil {
-		return
+	if updateTektonPipelineTriggerOptions.TriggerPatch != nil {
+		_, err = builder.SetBodyContentJSON(updateTektonPipelineTriggerOptions.TriggerPatch)
+		if err != nil {
+			return
+		}
 	}
 
 	request, err := builder.Build()
@@ -2402,9 +2360,6 @@ type CreateTektonPipelineDefinitionOptions struct {
 	// SCM source for Tekton pipeline definition.
 	ScmSource *DefinitionScmSource `json:"scm_source,omitempty"`
 
-	// ID of the SCM repository service instance.
-	ServiceInstanceID *string `json:"service_instance_id,omitempty"`
-
 	// UUID.
 	ID *string `json:"id,omitempty"`
 
@@ -2428,12 +2383,6 @@ func (_options *CreateTektonPipelineDefinitionOptions) SetPipelineID(pipelineID 
 // SetScmSource : Allow user to set ScmSource
 func (_options *CreateTektonPipelineDefinitionOptions) SetScmSource(scmSource *DefinitionScmSource) *CreateTektonPipelineDefinitionOptions {
 	_options.ScmSource = scmSource
-	return _options
-}
-
-// SetServiceInstanceID : Allow user to set ServiceInstanceID
-func (_options *CreateTektonPipelineDefinitionOptions) SetServiceInstanceID(serviceInstanceID string) *CreateTektonPipelineDefinitionOptions {
-	_options.ServiceInstanceID = core.StringPtr(serviceInstanceID)
 	return _options
 }
 
@@ -2495,16 +2444,16 @@ type CreateTektonPipelinePropertiesOptions struct {
 	// Property value.
 	Value *string `json:"value,omitempty"`
 
-	// Options for SINGLE_SELECT property type. Only needed when using SINGLE_SELECT property type.
+	// Options for single_select property type. Only needed when using single_select property type.
 	Enum []string `json:"enum,omitempty"`
 
-	// Default option for SINGLE_SELECT property type. Only needed when using SINGLE_SELECT property type.
+	// Default option for single_select property type. Only needed when using single_select property type.
 	Default *string `json:"default,omitempty"`
 
 	// Property type.
 	Type *string `json:"type,omitempty"`
 
-	// A dot notation path for INTEGRATION type properties to select a value from the tool integration.
+	// A dot notation path for integration type properties to select a value from the tool integration.
 	Path *string `json:"path,omitempty"`
 
 	// Allows users to set headers on API requests
@@ -2514,11 +2463,11 @@ type CreateTektonPipelinePropertiesOptions struct {
 // Constants associated with the CreateTektonPipelinePropertiesOptions.Type property.
 // Property type.
 const (
-	CreateTektonPipelinePropertiesOptionsTypeAppconfigConst = "APPCONFIG"
-	CreateTektonPipelinePropertiesOptionsTypeIntegrationConst = "INTEGRATION"
-	CreateTektonPipelinePropertiesOptionsTypeSecureConst = "SECURE"
-	CreateTektonPipelinePropertiesOptionsTypeSingleSelectConst = "SINGLE_SELECT"
-	CreateTektonPipelinePropertiesOptionsTypeTextConst = "TEXT"
+	CreateTektonPipelinePropertiesOptionsTypeAppconfigConst = "appconfig"
+	CreateTektonPipelinePropertiesOptionsTypeIntegrationConst = "integration"
+	CreateTektonPipelinePropertiesOptionsTypeSecureConst = "secure"
+	CreateTektonPipelinePropertiesOptionsTypeSingleSelectConst = "single_select"
+	CreateTektonPipelinePropertiesOptionsTypeTextConst = "text"
 )
 
 // NewCreateTektonPipelinePropertiesOptions : Instantiate CreateTektonPipelinePropertiesOptions
@@ -2584,11 +2533,11 @@ type CreateTektonPipelineRunOptions struct {
 	// Trigger name.
 	TriggerName *string `json:"trigger_name,omitempty"`
 
-	// An object containing string values only that provides additional TEXT properties, or overrides existing
+	// An object containing string values only that provides additional text properties, or overrides existing
 	// pipeline/trigger properties.
 	TriggerProperties map[string]interface{} `json:"trigger_properties,omitempty"`
 
-	// An object containing string values only that provides additional SECURE properties, or overrides existing SECURE
+	// An object containing string values only that provides additional secure properties, or overrides existing secure
 	// pipeline/trigger properties.
 	SecureTriggerProperties map[string]interface{} `json:"secure_trigger_properties,omitempty"`
 
@@ -2700,19 +2649,19 @@ type CreateTektonPipelineTriggerPropertiesOptions struct {
 	// Property name.
 	Name *string `json:"name,omitempty"`
 
-	// Property value. Can be empty and should be omitted for SINGLE_SELECT property type.
+	// Property value. Can be empty and should be omitted for single_select property type.
 	Value *string `json:"value,omitempty"`
 
-	// Options for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
+	// Options for single_select property type. Only needed for single_select property type.
 	Enum []string `json:"enum,omitempty"`
 
-	// Default option for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
+	// Default option for single_select property type. Only needed for single_select property type.
 	Default *string `json:"default,omitempty"`
 
 	// Property type.
 	Type *string `json:"type,omitempty"`
 
-	// A dot notation path for INTEGRATION type properties to select a value from the tool integration. If left blank the
+	// A dot notation path for integration type properties to select a value from the tool integration. If left blank the
 	// full tool integration JSON will be selected.
 	Path *string `json:"path,omitempty"`
 
@@ -2723,11 +2672,11 @@ type CreateTektonPipelineTriggerPropertiesOptions struct {
 // Constants associated with the CreateTektonPipelineTriggerPropertiesOptions.Type property.
 // Property type.
 const (
-	CreateTektonPipelineTriggerPropertiesOptionsTypeAppconfigConst = "APPCONFIG"
-	CreateTektonPipelineTriggerPropertiesOptionsTypeIntegrationConst = "INTEGRATION"
-	CreateTektonPipelineTriggerPropertiesOptionsTypeSecureConst = "SECURE"
-	CreateTektonPipelineTriggerPropertiesOptionsTypeSingleSelectConst = "SINGLE_SELECT"
-	CreateTektonPipelineTriggerPropertiesOptionsTypeTextConst = "TEXT"
+	CreateTektonPipelineTriggerPropertiesOptionsTypeAppconfigConst = "appconfig"
+	CreateTektonPipelineTriggerPropertiesOptionsTypeIntegrationConst = "integration"
+	CreateTektonPipelineTriggerPropertiesOptionsTypeSecureConst = "secure"
+	CreateTektonPipelineTriggerPropertiesOptionsTypeSingleSelectConst = "single_select"
+	CreateTektonPipelineTriggerPropertiesOptionsTypeTextConst = "text"
 )
 
 // NewCreateTektonPipelineTriggerPropertiesOptions : Instantiate CreateTektonPipelineTriggerPropertiesOptions
@@ -2797,9 +2746,6 @@ type Definition struct {
 	// SCM source for Tekton pipeline definition.
 	ScmSource *DefinitionScmSource `json:"scm_source" validate:"required"`
 
-	// ID of the SCM repository service instance.
-	ServiceInstanceID *string `json:"service_instance_id" validate:"required"`
-
 	// UUID.
 	ID *string `json:"id,omitempty"`
 }
@@ -2808,10 +2754,6 @@ type Definition struct {
 func UnmarshalDefinition(m map[string]json.RawMessage, result interface{}) (err error) {
 	obj := new(Definition)
 	err = core.UnmarshalModel(m, "scm_source", &obj.ScmSource, UnmarshalDefinitionScmSource)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "service_instance_id", &obj.ServiceInstanceID)
 	if err != nil {
 		return
 	}
@@ -2836,6 +2778,9 @@ type DefinitionScmSource struct {
 
 	// The path to the definition's yaml files.
 	Path *string `json:"path" validate:"required"`
+
+	// ID of the SCM repository service instance.
+	ServiceInstanceID *string `json:"service_instance_id,omitempty"`
 }
 
 // NewDefinitionScmSource : Instantiate DefinitionScmSource (Generic Model Constructor)
@@ -2867,6 +2812,10 @@ func UnmarshalDefinitionScmSource(m map[string]json.RawMessage, result interface
 	if err != nil {
 		return
 	}
+	err = core.UnmarshalPrimitive(m, "service_instance_id", &obj.ServiceInstanceID)
+	if err != nil {
+		return
+	}
 	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
 	return
 }
@@ -2894,9 +2843,6 @@ type DefinitionsCollectionDefinitionsItem struct {
 	// SCM source for Tekton pipeline definition.
 	ScmSource *DefinitionScmSource `json:"scm_source" validate:"required"`
 
-	// ID of the SCM repository service instance.
-	ServiceInstanceID *string `json:"service_instance_id" validate:"required"`
-
 	// UUID.
 	ID *string `json:"id,omitempty"`
 
@@ -2908,10 +2854,6 @@ type DefinitionsCollectionDefinitionsItem struct {
 func UnmarshalDefinitionsCollectionDefinitionsItem(m map[string]json.RawMessage, result interface{}) (err error) {
 	obj := new(DefinitionsCollectionDefinitionsItem)
 	err = core.UnmarshalModel(m, "scm_source", &obj.ScmSource, UnmarshalDefinitionScmSource)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "service_instance_id", &obj.ServiceInstanceID)
 	if err != nil {
 		return
 	}
@@ -3191,29 +3133,29 @@ type GenericSecret struct {
 	// Secret type.
 	Type *string `json:"type,omitempty"`
 
-	// Secret value, not needed if secret type is "internalValidation".
+	// Secret value, not needed if secret type is "internal_validation".
 	Value *string `json:"value,omitempty"`
 
-	// Secret location, not needed if secret type is "internalValidation".
+	// Secret location, not needed if secret type is "internal_validation".
 	Source *string `json:"source,omitempty"`
 
-	// Secret name, not needed if type is "internalValidation".
+	// Secret name, not needed if type is "internal_validation".
 	KeyName *string `json:"key_name,omitempty"`
 
-	// Algorithm used for "digestMatches" secret type. Only needed for "digestMatches" secret type.
+	// Algorithm used for "digest_matches" secret type. Only needed for "digest_matches" secret type.
 	Algorithm *string `json:"algorithm,omitempty"`
 }
 
 // Constants associated with the GenericSecret.Type property.
 // Secret type.
 const (
-	GenericSecretTypeDigestmatchesConst = "digestMatches"
-	GenericSecretTypeInternalvalidationConst = "internalValidation"
-	GenericSecretTypeTokenmatchesConst = "tokenMatches"
+	GenericSecretTypeDigestMatchesConst = "digest_matches"
+	GenericSecretTypeInternalValidationConst = "internal_validation"
+	GenericSecretTypeTokenMatchesConst = "token_matches"
 )
 
 // Constants associated with the GenericSecret.Source property.
-// Secret location, not needed if secret type is "internalValidation".
+// Secret location, not needed if secret type is "internal_validation".
 const (
 	GenericSecretSourceHeaderConst = "header"
 	GenericSecretSourcePayloadConst = "payload"
@@ -3221,7 +3163,7 @@ const (
 )
 
 // Constants associated with the GenericSecret.Algorithm property.
-// Algorithm used for "digestMatches" secret type. Only needed for "digestMatches" secret type.
+// Algorithm used for "digest_matches" secret type. Only needed for "digest_matches" secret type.
 const (
 	GenericSecretAlgorithmMd4Const = "md4"
 	GenericSecretAlgorithmMd5Const = "md5"
@@ -3639,11 +3581,11 @@ type ListTektonPipelinePropertiesOptions struct {
 // Constants associated with the ListTektonPipelinePropertiesOptions.Type property.
 // Query in URL.
 const (
-	ListTektonPipelinePropertiesOptionsTypeAppconfigConst = "APPCONFIG"
-	ListTektonPipelinePropertiesOptionsTypeIntegrationConst = "INTEGRATION"
-	ListTektonPipelinePropertiesOptionsTypeSecureConst = "SECURE"
-	ListTektonPipelinePropertiesOptionsTypeSingleSelectConst = "SINGLE_SELECT"
-	ListTektonPipelinePropertiesOptionsTypeTextConst = "TEXT"
+	ListTektonPipelinePropertiesOptionsTypeAppconfigConst = "appconfig"
+	ListTektonPipelinePropertiesOptionsTypeIntegrationConst = "integration"
+	ListTektonPipelinePropertiesOptionsTypeSecureConst = "secure"
+	ListTektonPipelinePropertiesOptionsTypeSingleSelectConst = "single_select"
+	ListTektonPipelinePropertiesOptionsTypeTextConst = "text"
 )
 
 // NewListTektonPipelinePropertiesOptions : Instantiate ListTektonPipelinePropertiesOptions
@@ -3772,7 +3714,7 @@ type ListTektonPipelineTriggerPropertiesOptions struct {
 	// Filter properties by "name".
 	Name *string `json:"name" validate:"required"`
 
-	// Filter properties by "type". Valid types are "SECURE", "TEXT", "INTEGRATION", "SINGLE_SELECT", "APPCONFIG".
+	// Filter properties by "type". Valid types are "secure", "text", "integration", "single_select", "appconfig".
 	Type *string `json:"type" validate:"required"`
 
 	// Sort properties by name. They can be sorted in ascending order using "name" or in descending order using "-name".
@@ -3924,48 +3866,23 @@ func (options *ListTektonPipelineTriggersOptions) SetHeaders(param map[string]st
 
 // Log : Log object for Tekton pipeline run step.
 type Log struct {
+	// The raw log content of step.
+	Data *string `json:"data,omitempty"`
+
+	// API for getting log content.
+	Href *string `json:"href,omitempty"`
+
 	// Step log ID.
 	ID *string `json:"id" validate:"required"`
 
-	// The raw log content of step.
-	Data *string `json:"data" validate:"required"`
+	// <podName>/<containerName> of this log.
+	Name *string `json:"name,omitempty"`
 }
 
 // UnmarshalLog unmarshals an instance of Log from the specified map of raw messages.
 func UnmarshalLog(m map[string]json.RawMessage, result interface{}) (err error) {
 	obj := new(Log)
-	err = core.UnmarshalPrimitive(m, "id", &obj.ID)
-	if err != nil {
-		return
-	}
 	err = core.UnmarshalPrimitive(m, "data", &obj.Data)
-	if err != nil {
-		return
-	}
-	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
-	return
-}
-
-// LogID : Pipeline run log ID object.
-type LogID struct {
-	// <podName>/<containerName> of this log.
-	Name *string `json:"name,omitempty"`
-
-	// Generated log ID.
-	ID *string `json:"id,omitempty"`
-
-	// API for getting log content.
-	Href *string `json:"href,omitempty"`
-}
-
-// UnmarshalLogID unmarshals an instance of LogID from the specified map of raw messages.
-func UnmarshalLogID(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(LogID)
-	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "id", &obj.ID)
 	if err != nil {
 		return
 	}
@@ -3973,19 +3890,27 @@ func UnmarshalLogID(m map[string]json.RawMessage, result interface{}) (err error
 	if err != nil {
 		return
 	}
+	err = core.UnmarshalPrimitive(m, "id", &obj.ID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
+	if err != nil {
+		return
+	}
 	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
 	return
 }
 
-// LogsCollection : List of pipeline run log IDs.
+// LogsCollection : List of pipeline run log objects.
 type LogsCollection struct {
-	Logs []LogID `json:"logs,omitempty"`
+	Logs []Log `json:"logs,omitempty"`
 }
 
 // UnmarshalLogsCollection unmarshals an instance of LogsCollection from the specified map of raw messages.
 func UnmarshalLogsCollection(m map[string]json.RawMessage, result interface{}) (err error) {
 	obj := new(LogsCollection)
-	err = core.UnmarshalModel(m, "logs", &obj.Logs, UnmarshalLogID)
+	err = core.UnmarshalModel(m, "logs", &obj.Logs, UnmarshalLog)
 	if err != nil {
 		return
 	}
@@ -4035,8 +3960,8 @@ type PipelineRun struct {
 	// Standard RFC 3339 Date Time String.
 	UpdatedAt *strfmt.DateTime `json:"updated_at,omitempty"`
 
-	// URL for this pipeline run.
-	HTMLURL *string `json:"html_url" validate:"required"`
+	// URL for the details page of this pipeline run.
+	RunURL *string `json:"run_url" validate:"required"`
 }
 
 // Constants associated with the PipelineRun.Status property.
@@ -4108,7 +4033,7 @@ func UnmarshalPipelineRun(m map[string]json.RawMessage, result interface{}) (err
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalPrimitive(m, "html_url", &obj.HTMLURL)
+	err = core.UnmarshalPrimitive(m, "run_url", &obj.RunURL)
 	if err != nil {
 		return
 	}
@@ -4292,8 +4217,8 @@ type PipelineRunsCollectionPipelineRunsItem struct {
 	// Standard RFC 3339 Date Time String.
 	UpdatedAt *strfmt.DateTime `json:"updated_at,omitempty"`
 
-	// URL for this pipeline run.
-	HTMLURL *string `json:"html_url" validate:"required"`
+	// URL for the details page of this pipeline run.
+	RunURL *string `json:"run_url" validate:"required"`
 
 	// API URL for interacting with the pipeline run.
 	Href *string `json:"href,omitempty"`
@@ -4368,7 +4293,7 @@ func UnmarshalPipelineRunsCollectionPipelineRunsItem(m map[string]json.RawMessag
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalPrimitive(m, "html_url", &obj.HTMLURL)
+	err = core.UnmarshalPrimitive(m, "run_url", &obj.RunURL)
 	if err != nil {
 		return
 	}
@@ -4405,27 +4330,27 @@ type Property struct {
 	// Property value.
 	Value *string `json:"value,omitempty"`
 
-	// Options for SINGLE_SELECT property type. Only needed when using SINGLE_SELECT property type.
+	// Options for single_select property type. Only needed when using single_select property type.
 	Enum []string `json:"enum,omitempty"`
 
-	// Default option for SINGLE_SELECT property type. Only needed when using SINGLE_SELECT property type.
+	// Default option for single_select property type. Only needed when using single_select property type.
 	Default *string `json:"default,omitempty"`
 
 	// Property type.
 	Type *string `json:"type" validate:"required"`
 
-	// A dot notation path for INTEGRATION type properties to select a value from the tool integration.
+	// A dot notation path for integration type properties to select a value from the tool integration.
 	Path *string `json:"path,omitempty"`
 }
 
 // Constants associated with the Property.Type property.
 // Property type.
 const (
-	PropertyTypeAppconfigConst = "APPCONFIG"
-	PropertyTypeIntegrationConst = "INTEGRATION"
-	PropertyTypeSecureConst = "SECURE"
-	PropertyTypeSingleSelectConst = "SINGLE_SELECT"
-	PropertyTypeTextConst = "TEXT"
+	PropertyTypeAppconfigConst = "appconfig"
+	PropertyTypeIntegrationConst = "integration"
+	PropertyTypeSecureConst = "secure"
+	PropertyTypeSingleSelectConst = "single_select"
+	PropertyTypeTextConst = "text"
 )
 
 // UnmarshalProperty unmarshals an instance of Property from the specified map of raw messages.
@@ -4470,9 +4395,6 @@ type ReplaceTektonPipelineDefinitionOptions struct {
 	// SCM source for Tekton pipeline definition.
 	ScmSource *DefinitionScmSource `json:"scm_source,omitempty"`
 
-	// ID of the SCM repository service instance.
-	ServiceInstanceID *string `json:"service_instance_id,omitempty"`
-
 	// UUID.
 	ID *string `json:"id,omitempty"`
 
@@ -4506,12 +4428,6 @@ func (_options *ReplaceTektonPipelineDefinitionOptions) SetScmSource(scmSource *
 	return _options
 }
 
-// SetServiceInstanceID : Allow user to set ServiceInstanceID
-func (_options *ReplaceTektonPipelineDefinitionOptions) SetServiceInstanceID(serviceInstanceID string) *ReplaceTektonPipelineDefinitionOptions {
-	_options.ServiceInstanceID = core.StringPtr(serviceInstanceID)
-	return _options
-}
-
 // SetID : Allow user to set ID
 func (_options *ReplaceTektonPipelineDefinitionOptions) SetID(id string) *ReplaceTektonPipelineDefinitionOptions {
 	_options.ID = core.StringPtr(id)
@@ -4538,16 +4454,16 @@ type ReplaceTektonPipelinePropertyOptions struct {
 	// Property value.
 	Value *string `json:"value,omitempty"`
 
-	// Options for SINGLE_SELECT property type. Only needed when using SINGLE_SELECT property type.
+	// Options for single_select property type. Only needed when using single_select property type.
 	Enum []string `json:"enum,omitempty"`
 
-	// Default option for SINGLE_SELECT property type. Only needed when using SINGLE_SELECT property type.
+	// Default option for single_select property type. Only needed when using single_select property type.
 	Default *string `json:"default,omitempty"`
 
 	// Property type.
 	Type *string `json:"type,omitempty"`
 
-	// A dot notation path for INTEGRATION type properties to select a value from the tool integration.
+	// A dot notation path for integration type properties to select a value from the tool integration.
 	Path *string `json:"path,omitempty"`
 
 	// Allows users to set headers on API requests
@@ -4557,11 +4473,11 @@ type ReplaceTektonPipelinePropertyOptions struct {
 // Constants associated with the ReplaceTektonPipelinePropertyOptions.Type property.
 // Property type.
 const (
-	ReplaceTektonPipelinePropertyOptionsTypeAppconfigConst = "APPCONFIG"
-	ReplaceTektonPipelinePropertyOptionsTypeIntegrationConst = "INTEGRATION"
-	ReplaceTektonPipelinePropertyOptionsTypeSecureConst = "SECURE"
-	ReplaceTektonPipelinePropertyOptionsTypeSingleSelectConst = "SINGLE_SELECT"
-	ReplaceTektonPipelinePropertyOptionsTypeTextConst = "TEXT"
+	ReplaceTektonPipelinePropertyOptionsTypeAppconfigConst = "appconfig"
+	ReplaceTektonPipelinePropertyOptionsTypeIntegrationConst = "integration"
+	ReplaceTektonPipelinePropertyOptionsTypeSecureConst = "secure"
+	ReplaceTektonPipelinePropertyOptionsTypeSingleSelectConst = "single_select"
+	ReplaceTektonPipelinePropertyOptionsTypeTextConst = "text"
 )
 
 // NewReplaceTektonPipelinePropertyOptions : Instantiate ReplaceTektonPipelinePropertyOptions
@@ -4640,19 +4556,19 @@ type ReplaceTektonPipelineTriggerPropertyOptions struct {
 	// Property name.
 	Name *string `json:"name,omitempty"`
 
-	// Property value. Can be empty and should be omitted for SINGLE_SELECT property type.
+	// Property value. Can be empty and should be omitted for single_select property type.
 	Value *string `json:"value,omitempty"`
 
-	// Options for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
+	// Options for single_select property type. Only needed for single_select property type.
 	Enum []string `json:"enum,omitempty"`
 
-	// Default option for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
+	// Default option for single_select property type. Only needed for single_select property type.
 	Default *string `json:"default,omitempty"`
 
 	// Property type.
 	Type *string `json:"type,omitempty"`
 
-	// A dot notation path for INTEGRATION type properties to select a value from the tool integration. If left blank the
+	// A dot notation path for integration type properties to select a value from the tool integration. If left blank the
 	// full tool integration JSON will be selected.
 	Path *string `json:"path,omitempty"`
 
@@ -4663,11 +4579,11 @@ type ReplaceTektonPipelineTriggerPropertyOptions struct {
 // Constants associated with the ReplaceTektonPipelineTriggerPropertyOptions.Type property.
 // Property type.
 const (
-	ReplaceTektonPipelineTriggerPropertyOptionsTypeAppconfigConst = "APPCONFIG"
-	ReplaceTektonPipelineTriggerPropertyOptionsTypeIntegrationConst = "INTEGRATION"
-	ReplaceTektonPipelineTriggerPropertyOptionsTypeSecureConst = "SECURE"
-	ReplaceTektonPipelineTriggerPropertyOptionsTypeSingleSelectConst = "SINGLE_SELECT"
-	ReplaceTektonPipelineTriggerPropertyOptionsTypeTextConst = "TEXT"
+	ReplaceTektonPipelineTriggerPropertyOptionsTypeAppconfigConst = "appconfig"
+	ReplaceTektonPipelineTriggerPropertyOptionsTypeIntegrationConst = "integration"
+	ReplaceTektonPipelineTriggerPropertyOptionsTypeSecureConst = "secure"
+	ReplaceTektonPipelineTriggerPropertyOptionsTypeSingleSelectConst = "single_select"
+	ReplaceTektonPipelineTriggerPropertyOptionsTypeTextConst = "text"
 )
 
 // NewReplaceTektonPipelineTriggerPropertyOptions : Instantiate ReplaceTektonPipelineTriggerPropertyOptions
@@ -4815,8 +4731,8 @@ type TektonPipeline struct {
 	// Default pipeline worker used to run the pipeline.
 	Worker *Worker `json:"worker" validate:"required"`
 
-	// Dashboard URL of this pipeline.
-	HTMLURL *string `json:"html_url" validate:"required"`
+	// URL for this pipeline showing the list of pipeline runs.
+	RunsURL *string `json:"runs_url" validate:"required"`
 
 	// The latest pipeline run build number. If this property is absent, the pipeline hasn't had any pipeline runs.
 	BuildNumber *int64 `json:"build_number,omitempty"`
@@ -4883,7 +4799,7 @@ func UnmarshalTektonPipeline(m map[string]json.RawMessage, result interface{}) (
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalPrimitive(m, "html_url", &obj.HTMLURL)
+	err = core.UnmarshalPrimitive(m, "runs_url", &obj.RunsURL)
 	if err != nil {
 		return
 	}
@@ -4896,6 +4812,34 @@ func UnmarshalTektonPipeline(m map[string]json.RawMessage, result interface{}) (
 		return
 	}
 	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// TektonPipelinePatch : Request body used to change worker for this pipeline. To get the worker ID call the toolchain endpoint
+// /api/v1/toolchains/{toolchain_id}.
+type TektonPipelinePatch struct {
+	// Worker object containing worker ID only. If omitted the IBM Managed shared workers are used by default.
+	Worker *WorkerWithID `json:"worker,omitempty"`
+}
+
+// UnmarshalTektonPipelinePatch unmarshals an instance of TektonPipelinePatch from the specified map of raw messages.
+func UnmarshalTektonPipelinePatch(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(TektonPipelinePatch)
+	err = core.UnmarshalModel(m, "worker", &obj.Worker, UnmarshalWorkerWithID)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// AsPatch returns a generic map representation of the TektonPipelinePatch
+func (tektonPipelinePatch *TektonPipelinePatch) AsPatch() (_patch map[string]interface{}, err error) {
+	var jsonData []byte
+	jsonData, err = json.Marshal(tektonPipelinePatch)
+	if err == nil {
+		err = json.Unmarshal(jsonData, &_patch)
+	}
 	return
 }
 
@@ -4976,7 +4920,8 @@ type Trigger struct {
 	// API URL for interacting with the trigger.
 	Href *string `json:"href,omitempty"`
 
-	// Event listener name.
+	// Event listener name. The name of the event listener to which the trigger is associated. The event listeners are
+	// defined in the definition repositories of the Tekton pipeline.
 	EventListener *string `json:"event_listener,omitempty"`
 
 	// ID.
@@ -5002,9 +4947,6 @@ type Trigger struct {
 
 	// Only needed for Git triggers. Events object defines the events to which this Git trigger listens.
 	Events *Events `json:"events,omitempty"`
-
-	// ID of the repository service instance.
-	ServiceInstanceID *string `json:"service_instance_id,omitempty"`
 
 	// Only needed for timer triggers. Cron expression for timer trigger. Maximum frequency is every 5 minutes.
 	Cron *string `json:"cron,omitempty"`
@@ -5078,10 +5020,6 @@ func UnmarshalTrigger(m map[string]json.RawMessage, result interface{}) (err err
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalPrimitive(m, "service_instance_id", &obj.ServiceInstanceID)
-	if err != nil {
-		return
-	}
 	err = core.UnmarshalPrimitive(m, "cron", &obj.Cron)
 	if err != nil {
 		return
@@ -5103,19 +5041,19 @@ type TriggerGenericTriggerPropertiesItem struct {
 	// Property name.
 	Name *string `json:"name" validate:"required"`
 
-	// Property value. Can be empty and should be omitted for SINGLE_SELECT property type.
+	// Property value. Can be empty and should be omitted for single_select property type.
 	Value *string `json:"value,omitempty"`
 
-	// Options for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
+	// Options for single_select property type. Only needed for single_select property type.
 	Enum []string `json:"enum,omitempty"`
 
-	// Default option for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
+	// Default option for single_select property type. Only needed for single_select property type.
 	Default *string `json:"default,omitempty"`
 
 	// Property type.
 	Type *string `json:"type" validate:"required"`
 
-	// A dot notation path for INTEGRATION type properties to select a value from the tool integration. If left blank the
+	// A dot notation path for integration type properties to select a value from the tool integration. If left blank the
 	// full tool integration JSON will be selected.
 	Path *string `json:"path,omitempty"`
 
@@ -5126,11 +5064,11 @@ type TriggerGenericTriggerPropertiesItem struct {
 // Constants associated with the TriggerGenericTriggerPropertiesItem.Type property.
 // Property type.
 const (
-	TriggerGenericTriggerPropertiesItemTypeAppconfigConst = "APPCONFIG"
-	TriggerGenericTriggerPropertiesItemTypeIntegrationConst = "INTEGRATION"
-	TriggerGenericTriggerPropertiesItemTypeSecureConst = "SECURE"
-	TriggerGenericTriggerPropertiesItemTypeSingleSelectConst = "SINGLE_SELECT"
-	TriggerGenericTriggerPropertiesItemTypeTextConst = "TEXT"
+	TriggerGenericTriggerPropertiesItemTypeAppconfigConst = "appconfig"
+	TriggerGenericTriggerPropertiesItemTypeIntegrationConst = "integration"
+	TriggerGenericTriggerPropertiesItemTypeSecureConst = "secure"
+	TriggerGenericTriggerPropertiesItemTypeSingleSelectConst = "single_select"
+	TriggerGenericTriggerPropertiesItemTypeTextConst = "text"
 )
 
 // NewTriggerGenericTriggerPropertiesItem : Instantiate TriggerGenericTriggerPropertiesItem (Generic Model Constructor)
@@ -5183,19 +5121,19 @@ type TriggerManualTriggerPropertiesItem struct {
 	// Property name.
 	Name *string `json:"name" validate:"required"`
 
-	// Property value. Can be empty and should be omitted for SINGLE_SELECT property type.
+	// Property value. Can be empty and should be omitted for single_select property type.
 	Value *string `json:"value,omitempty"`
 
-	// Options for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
+	// Options for single_select property type. Only needed for single_select property type.
 	Enum []string `json:"enum,omitempty"`
 
-	// Default option for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
+	// Default option for single_select property type. Only needed for single_select property type.
 	Default *string `json:"default,omitempty"`
 
 	// Property type.
 	Type *string `json:"type" validate:"required"`
 
-	// A dot notation path for INTEGRATION type properties to select a value from the tool integration. If left blank the
+	// A dot notation path for integration type properties to select a value from the tool integration. If left blank the
 	// full tool integration JSON will be selected.
 	Path *string `json:"path,omitempty"`
 
@@ -5206,11 +5144,11 @@ type TriggerManualTriggerPropertiesItem struct {
 // Constants associated with the TriggerManualTriggerPropertiesItem.Type property.
 // Property type.
 const (
-	TriggerManualTriggerPropertiesItemTypeAppconfigConst = "APPCONFIG"
-	TriggerManualTriggerPropertiesItemTypeIntegrationConst = "INTEGRATION"
-	TriggerManualTriggerPropertiesItemTypeSecureConst = "SECURE"
-	TriggerManualTriggerPropertiesItemTypeSingleSelectConst = "SINGLE_SELECT"
-	TriggerManualTriggerPropertiesItemTypeTextConst = "TEXT"
+	TriggerManualTriggerPropertiesItemTypeAppconfigConst = "appconfig"
+	TriggerManualTriggerPropertiesItemTypeIntegrationConst = "integration"
+	TriggerManualTriggerPropertiesItemTypeSecureConst = "secure"
+	TriggerManualTriggerPropertiesItemTypeSingleSelectConst = "single_select"
+	TriggerManualTriggerPropertiesItemTypeTextConst = "text"
 )
 
 // NewTriggerManualTriggerPropertiesItem : Instantiate TriggerManualTriggerPropertiesItem (Generic Model Constructor)
@@ -5258,6 +5196,120 @@ func UnmarshalTriggerManualTriggerPropertiesItem(m map[string]json.RawMessage, r
 	return
 }
 
+// TriggerPatch : Tekton pipeline trigger object used for updating the trigger.
+type TriggerPatch struct {
+	// Trigger type.
+	Type *string `json:"type,omitempty"`
+
+	// Trigger name.
+	Name *string `json:"name,omitempty"`
+
+	// Event listener name. The name of the event listener to which the trigger is associated. The event listeners are
+	// defined in the definition repositories of the Tekton pipeline.
+	EventListener *string `json:"event_listener,omitempty"`
+
+	// Trigger tags array. Optional tags for the trigger.
+	Tags []string `json:"tags,omitempty"`
+
+	// Worker used to run the trigger. If not specified the trigger will use the default pipeline worker.
+	Worker *Worker `json:"worker,omitempty"`
+
+	// Defines the maximum number of concurrent runs for this trigger. Omit this property to disable the concurrency limit.
+	MaxConcurrentRuns *int64 `json:"max_concurrent_runs,omitempty"`
+
+	// Defines if this trigger is disabled.
+	Disabled *bool `json:"disabled,omitempty"`
+
+	// Only needed for generic webhook trigger type. Secret used to start generic webhook trigger.
+	Secret *GenericSecret `json:"secret,omitempty"`
+
+	// Only needed for timer triggers. Cron expression for timer trigger.
+	Cron *string `json:"cron,omitempty"`
+
+	// Only needed for timer triggers. Timezone for timer trigger.
+	Timezone *string `json:"timezone,omitempty"`
+
+	// SCM source repository for a Git trigger. Only needed for Git triggers.
+	ScmSource *TriggerScmSource `json:"scm_source,omitempty"`
+
+	// Only needed for Git triggers. Events object defines the events to which this Git trigger listens.
+	Events *Events `json:"events,omitempty"`
+}
+
+// Constants associated with the TriggerPatch.Type property.
+// Trigger type.
+const (
+	TriggerPatchTypeGenericConst = "generic"
+	TriggerPatchTypeManualConst = "manual"
+	TriggerPatchTypeScmConst = "scm"
+	TriggerPatchTypeTimerConst = "timer"
+)
+
+// UnmarshalTriggerPatch unmarshals an instance of TriggerPatch from the specified map of raw messages.
+func UnmarshalTriggerPatch(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(TriggerPatch)
+	err = core.UnmarshalPrimitive(m, "type", &obj.Type)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "event_listener", &obj.EventListener)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "tags", &obj.Tags)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "worker", &obj.Worker, UnmarshalWorker)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "max_concurrent_runs", &obj.MaxConcurrentRuns)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "disabled", &obj.Disabled)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "secret", &obj.Secret, UnmarshalGenericSecret)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "cron", &obj.Cron)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "timezone", &obj.Timezone)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "scm_source", &obj.ScmSource, UnmarshalTriggerScmSource)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "events", &obj.Events, UnmarshalEvents)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// AsPatch returns a generic map representation of the TriggerPatch
+func (triggerPatch *TriggerPatch) AsPatch() (_patch map[string]interface{}, err error) {
+	var jsonData []byte
+	jsonData, err = json.Marshal(triggerPatch)
+	if err == nil {
+		err = json.Unmarshal(jsonData, &_patch)
+	}
+	return
+}
+
 // TriggerPropertiesCollection : Trigger properties object.
 type TriggerPropertiesCollection struct {
 	// Trigger properties list.
@@ -5280,19 +5332,19 @@ type TriggerPropertiesCollectionPropertiesItem struct {
 	// Property name.
 	Name *string `json:"name" validate:"required"`
 
-	// Property value. Can be empty and should be omitted for SINGLE_SELECT property type.
+	// Property value. Can be empty and should be omitted for single_select property type.
 	Value *string `json:"value,omitempty"`
 
-	// Options for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
+	// Options for single_select property type. Only needed for single_select property type.
 	Enum []string `json:"enum,omitempty"`
 
-	// Default option for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
+	// Default option for single_select property type. Only needed for single_select property type.
 	Default *string `json:"default,omitempty"`
 
 	// Property type.
 	Type *string `json:"type" validate:"required"`
 
-	// A dot notation path for INTEGRATION type properties to select a value from the tool integration. If left blank the
+	// A dot notation path for integration type properties to select a value from the tool integration. If left blank the
 	// full tool integration JSON will be selected.
 	Path *string `json:"path,omitempty"`
 
@@ -5303,11 +5355,11 @@ type TriggerPropertiesCollectionPropertiesItem struct {
 // Constants associated with the TriggerPropertiesCollectionPropertiesItem.Type property.
 // Property type.
 const (
-	TriggerPropertiesCollectionPropertiesItemTypeAppconfigConst = "APPCONFIG"
-	TriggerPropertiesCollectionPropertiesItemTypeIntegrationConst = "INTEGRATION"
-	TriggerPropertiesCollectionPropertiesItemTypeSecureConst = "SECURE"
-	TriggerPropertiesCollectionPropertiesItemTypeSingleSelectConst = "SINGLE_SELECT"
-	TriggerPropertiesCollectionPropertiesItemTypeTextConst = "TEXT"
+	TriggerPropertiesCollectionPropertiesItemTypeAppconfigConst = "appconfig"
+	TriggerPropertiesCollectionPropertiesItemTypeIntegrationConst = "integration"
+	TriggerPropertiesCollectionPropertiesItemTypeSecureConst = "secure"
+	TriggerPropertiesCollectionPropertiesItemTypeSingleSelectConst = "single_select"
+	TriggerPropertiesCollectionPropertiesItemTypeTextConst = "text"
 )
 
 // UnmarshalTriggerPropertiesCollectionPropertiesItem unmarshals an instance of TriggerPropertiesCollectionPropertiesItem from the specified map of raw messages.
@@ -5350,19 +5402,19 @@ type TriggerPropertiesItem struct {
 	// Property name.
 	Name *string `json:"name" validate:"required"`
 
-	// Property value. Can be empty and should be omitted for SINGLE_SELECT property type.
+	// Property value. Can be empty and should be omitted for single_select property type.
 	Value *string `json:"value,omitempty"`
 
-	// Options for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
+	// Options for single_select property type. Only needed for single_select property type.
 	Enum []string `json:"enum,omitempty"`
 
-	// Default option for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
+	// Default option for single_select property type. Only needed for single_select property type.
 	Default *string `json:"default,omitempty"`
 
 	// Property type.
 	Type *string `json:"type" validate:"required"`
 
-	// A dot notation path for INTEGRATION type properties to select a value from the tool integration. If left blank the
+	// A dot notation path for integration type properties to select a value from the tool integration. If left blank the
 	// full tool integration JSON will be selected.
 	Path *string `json:"path,omitempty"`
 
@@ -5373,11 +5425,11 @@ type TriggerPropertiesItem struct {
 // Constants associated with the TriggerPropertiesItem.Type property.
 // Property type.
 const (
-	TriggerPropertiesItemTypeAppconfigConst = "APPCONFIG"
-	TriggerPropertiesItemTypeIntegrationConst = "INTEGRATION"
-	TriggerPropertiesItemTypeSecureConst = "SECURE"
-	TriggerPropertiesItemTypeSingleSelectConst = "SINGLE_SELECT"
-	TriggerPropertiesItemTypeTextConst = "TEXT"
+	TriggerPropertiesItemTypeAppconfigConst = "appconfig"
+	TriggerPropertiesItemTypeIntegrationConst = "integration"
+	TriggerPropertiesItemTypeSecureConst = "secure"
+	TriggerPropertiesItemTypeSingleSelectConst = "single_select"
+	TriggerPropertiesItemTypeTextConst = "text"
 )
 
 // NewTriggerPropertiesItem : Instantiate TriggerPropertiesItem (Generic Model Constructor)
@@ -5430,19 +5482,19 @@ type TriggerProperty struct {
 	// Property name.
 	Name *string `json:"name" validate:"required"`
 
-	// Property value. Can be empty and should be omitted for SINGLE_SELECT property type.
+	// Property value. Can be empty and should be omitted for single_select property type.
 	Value *string `json:"value,omitempty"`
 
-	// Options for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
+	// Options for single_select property type. Only needed for single_select property type.
 	Enum []string `json:"enum,omitempty"`
 
-	// Default option for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
+	// Default option for single_select property type. Only needed for single_select property type.
 	Default *string `json:"default,omitempty"`
 
 	// Property type.
 	Type *string `json:"type" validate:"required"`
 
-	// A dot notation path for INTEGRATION type properties to select a value from the tool integration. If left blank the
+	// A dot notation path for integration type properties to select a value from the tool integration. If left blank the
 	// full tool integration JSON will be selected.
 	Path *string `json:"path,omitempty"`
 }
@@ -5450,11 +5502,11 @@ type TriggerProperty struct {
 // Constants associated with the TriggerProperty.Type property.
 // Property type.
 const (
-	TriggerPropertyTypeAppconfigConst = "APPCONFIG"
-	TriggerPropertyTypeIntegrationConst = "INTEGRATION"
-	TriggerPropertyTypeSecureConst = "SECURE"
-	TriggerPropertyTypeSingleSelectConst = "SINGLE_SELECT"
-	TriggerPropertyTypeTextConst = "TEXT"
+	TriggerPropertyTypeAppconfigConst = "appconfig"
+	TriggerPropertyTypeIntegrationConst = "integration"
+	TriggerPropertyTypeSecureConst = "secure"
+	TriggerPropertyTypeSingleSelectConst = "single_select"
+	TriggerPropertyTypeTextConst = "text"
 )
 
 // UnmarshalTriggerProperty unmarshals an instance of TriggerProperty from the specified map of raw messages.
@@ -5505,6 +5557,9 @@ type TriggerScmSource struct {
 
 	// ID of the webhook from the repo. Computed upon creation of the trigger.
 	HookID *string `json:"hook_id,omitempty"`
+
+	// ID of the repository service instance.
+	ServiceInstanceID *string `json:"service_instance_id,omitempty"`
 }
 
 // NewTriggerScmSource : Instantiate TriggerScmSource (Generic Model Constructor)
@@ -5539,6 +5594,10 @@ func UnmarshalTriggerScmSource(m map[string]json.RawMessage, result interface{})
 	if err != nil {
 		return
 	}
+	err = core.UnmarshalPrimitive(m, "service_instance_id", &obj.ServiceInstanceID)
+	if err != nil {
+		return
+	}
 	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
 	return
 }
@@ -5548,19 +5607,19 @@ type TriggerScmTriggerPropertiesItem struct {
 	// Property name.
 	Name *string `json:"name" validate:"required"`
 
-	// Property value. Can be empty and should be omitted for SINGLE_SELECT property type.
+	// Property value. Can be empty and should be omitted for single_select property type.
 	Value *string `json:"value,omitempty"`
 
-	// Options for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
+	// Options for single_select property type. Only needed for single_select property type.
 	Enum []string `json:"enum,omitempty"`
 
-	// Default option for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
+	// Default option for single_select property type. Only needed for single_select property type.
 	Default *string `json:"default,omitempty"`
 
 	// Property type.
 	Type *string `json:"type" validate:"required"`
 
-	// A dot notation path for INTEGRATION type properties to select a value from the tool integration. If left blank the
+	// A dot notation path for integration type properties to select a value from the tool integration. If left blank the
 	// full tool integration JSON will be selected.
 	Path *string `json:"path,omitempty"`
 
@@ -5571,11 +5630,11 @@ type TriggerScmTriggerPropertiesItem struct {
 // Constants associated with the TriggerScmTriggerPropertiesItem.Type property.
 // Property type.
 const (
-	TriggerScmTriggerPropertiesItemTypeAppconfigConst = "APPCONFIG"
-	TriggerScmTriggerPropertiesItemTypeIntegrationConst = "INTEGRATION"
-	TriggerScmTriggerPropertiesItemTypeSecureConst = "SECURE"
-	TriggerScmTriggerPropertiesItemTypeSingleSelectConst = "SINGLE_SELECT"
-	TriggerScmTriggerPropertiesItemTypeTextConst = "TEXT"
+	TriggerScmTriggerPropertiesItemTypeAppconfigConst = "appconfig"
+	TriggerScmTriggerPropertiesItemTypeIntegrationConst = "integration"
+	TriggerScmTriggerPropertiesItemTypeSecureConst = "secure"
+	TriggerScmTriggerPropertiesItemTypeSingleSelectConst = "single_select"
+	TriggerScmTriggerPropertiesItemTypeTextConst = "text"
 )
 
 // NewTriggerScmTriggerPropertiesItem : Instantiate TriggerScmTriggerPropertiesItem (Generic Model Constructor)
@@ -5628,19 +5687,19 @@ type TriggerTimerTriggerPropertiesItem struct {
 	// Property name.
 	Name *string `json:"name" validate:"required"`
 
-	// Property value. Can be empty and should be omitted for SINGLE_SELECT property type.
+	// Property value. Can be empty and should be omitted for single_select property type.
 	Value *string `json:"value,omitempty"`
 
-	// Options for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
+	// Options for single_select property type. Only needed for single_select property type.
 	Enum []string `json:"enum,omitempty"`
 
-	// Default option for SINGLE_SELECT property type. Only needed for SINGLE_SELECT property type.
+	// Default option for single_select property type. Only needed for single_select property type.
 	Default *string `json:"default,omitempty"`
 
 	// Property type.
 	Type *string `json:"type" validate:"required"`
 
-	// A dot notation path for INTEGRATION type properties to select a value from the tool integration. If left blank the
+	// A dot notation path for integration type properties to select a value from the tool integration. If left blank the
 	// full tool integration JSON will be selected.
 	Path *string `json:"path,omitempty"`
 
@@ -5651,11 +5710,11 @@ type TriggerTimerTriggerPropertiesItem struct {
 // Constants associated with the TriggerTimerTriggerPropertiesItem.Type property.
 // Property type.
 const (
-	TriggerTimerTriggerPropertiesItemTypeAppconfigConst = "APPCONFIG"
-	TriggerTimerTriggerPropertiesItemTypeIntegrationConst = "INTEGRATION"
-	TriggerTimerTriggerPropertiesItemTypeSecureConst = "SECURE"
-	TriggerTimerTriggerPropertiesItemTypeSingleSelectConst = "SINGLE_SELECT"
-	TriggerTimerTriggerPropertiesItemTypeTextConst = "TEXT"
+	TriggerTimerTriggerPropertiesItemTypeAppconfigConst = "appconfig"
+	TriggerTimerTriggerPropertiesItemTypeIntegrationConst = "integration"
+	TriggerTimerTriggerPropertiesItemTypeSecureConst = "secure"
+	TriggerTimerTriggerPropertiesItemTypeSingleSelectConst = "single_select"
+	TriggerTimerTriggerPropertiesItemTypeTextConst = "text"
 )
 
 // NewTriggerTimerTriggerPropertiesItem : Instantiate TriggerTimerTriggerPropertiesItem (Generic Model Constructor)
@@ -5725,8 +5784,8 @@ type UpdateTektonPipelineOptions struct {
 	// ID of current instance.
 	ID *string `json:"id" validate:"required,ne="`
 
-	// Worker object containing worker ID only. If omitted the IBM Managed shared workers are used by default.
-	Worker *WorkerWithID `json:"worker,omitempty"`
+	// JSON Merge-Patch content for update_tekton_pipeline.
+	TektonPipelinePatch map[string]interface{} `json:"TektonPipeline_patch,omitempty"`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -5745,9 +5804,9 @@ func (_options *UpdateTektonPipelineOptions) SetID(id string) *UpdateTektonPipel
 	return _options
 }
 
-// SetWorker : Allow user to set Worker
-func (_options *UpdateTektonPipelineOptions) SetWorker(worker *WorkerWithID) *UpdateTektonPipelineOptions {
-	_options.Worker = worker
+// SetTektonPipelinePatch : Allow user to set TektonPipelinePatch
+func (_options *UpdateTektonPipelineOptions) SetTektonPipelinePatch(tektonPipelinePatch map[string]interface{}) *UpdateTektonPipelineOptions {
+	_options.TektonPipelinePatch = tektonPipelinePatch
 	return _options
 }
 
@@ -5765,54 +5824,12 @@ type UpdateTektonPipelineTriggerOptions struct {
 	// The trigger ID.
 	TriggerID *string `json:"trigger_id" validate:"required,ne="`
 
-	// Trigger type.
-	Type *string `json:"type,omitempty"`
-
-	// Trigger name.
-	Name *string `json:"name,omitempty"`
-
-	// Event listener name.
-	EventListener *string `json:"event_listener,omitempty"`
-
-	// Trigger tags array. Optional tags for the trigger.
-	Tags []string `json:"tags,omitempty"`
-
-	// Worker used to run the trigger. If not specified the trigger will use the default pipeline worker.
-	Worker *Worker `json:"worker,omitempty"`
-
-	// Defines the maximum number of concurrent runs for this trigger. Omit this property to disable the concurrency limit.
-	MaxConcurrentRuns *int64 `json:"max_concurrent_runs,omitempty"`
-
-	// Defines if this trigger is disabled.
-	Disabled *bool `json:"disabled,omitempty"`
-
-	// Only needed for generic webhook trigger type. Secret used to start generic webhook trigger.
-	Secret *GenericSecret `json:"secret,omitempty"`
-
-	// Only needed for timer triggers. Cron expression for timer trigger.
-	Cron *string `json:"cron,omitempty"`
-
-	// Only needed for timer triggers. Timezone for timer trigger.
-	Timezone *string `json:"timezone,omitempty"`
-
-	// SCM source repository for a Git trigger. Only needed for Git triggers.
-	ScmSource *TriggerScmSource `json:"scm_source,omitempty"`
-
-	// Only needed for Git triggers. Events object defines the events to which this Git trigger listens.
-	Events *Events `json:"events,omitempty"`
+	// JSON Merge-Patch content for update_tekton_pipeline_trigger.
+	TriggerPatch map[string]interface{} `json:"Trigger_patch,omitempty"`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
 }
-
-// Constants associated with the UpdateTektonPipelineTriggerOptions.Type property.
-// Trigger type.
-const (
-	UpdateTektonPipelineTriggerOptionsTypeGenericConst = "generic"
-	UpdateTektonPipelineTriggerOptionsTypeManualConst = "manual"
-	UpdateTektonPipelineTriggerOptionsTypeScmConst = "scm"
-	UpdateTektonPipelineTriggerOptionsTypeTimerConst = "timer"
-)
 
 // NewUpdateTektonPipelineTriggerOptions : Instantiate UpdateTektonPipelineTriggerOptions
 func (*CdTektonPipelineV2) NewUpdateTektonPipelineTriggerOptions(pipelineID string, triggerID string) *UpdateTektonPipelineTriggerOptions {
@@ -5834,75 +5851,9 @@ func (_options *UpdateTektonPipelineTriggerOptions) SetTriggerID(triggerID strin
 	return _options
 }
 
-// SetType : Allow user to set Type
-func (_options *UpdateTektonPipelineTriggerOptions) SetType(typeVar string) *UpdateTektonPipelineTriggerOptions {
-	_options.Type = core.StringPtr(typeVar)
-	return _options
-}
-
-// SetName : Allow user to set Name
-func (_options *UpdateTektonPipelineTriggerOptions) SetName(name string) *UpdateTektonPipelineTriggerOptions {
-	_options.Name = core.StringPtr(name)
-	return _options
-}
-
-// SetEventListener : Allow user to set EventListener
-func (_options *UpdateTektonPipelineTriggerOptions) SetEventListener(eventListener string) *UpdateTektonPipelineTriggerOptions {
-	_options.EventListener = core.StringPtr(eventListener)
-	return _options
-}
-
-// SetTags : Allow user to set Tags
-func (_options *UpdateTektonPipelineTriggerOptions) SetTags(tags []string) *UpdateTektonPipelineTriggerOptions {
-	_options.Tags = tags
-	return _options
-}
-
-// SetWorker : Allow user to set Worker
-func (_options *UpdateTektonPipelineTriggerOptions) SetWorker(worker *Worker) *UpdateTektonPipelineTriggerOptions {
-	_options.Worker = worker
-	return _options
-}
-
-// SetMaxConcurrentRuns : Allow user to set MaxConcurrentRuns
-func (_options *UpdateTektonPipelineTriggerOptions) SetMaxConcurrentRuns(maxConcurrentRuns int64) *UpdateTektonPipelineTriggerOptions {
-	_options.MaxConcurrentRuns = core.Int64Ptr(maxConcurrentRuns)
-	return _options
-}
-
-// SetDisabled : Allow user to set Disabled
-func (_options *UpdateTektonPipelineTriggerOptions) SetDisabled(disabled bool) *UpdateTektonPipelineTriggerOptions {
-	_options.Disabled = core.BoolPtr(disabled)
-	return _options
-}
-
-// SetSecret : Allow user to set Secret
-func (_options *UpdateTektonPipelineTriggerOptions) SetSecret(secret *GenericSecret) *UpdateTektonPipelineTriggerOptions {
-	_options.Secret = secret
-	return _options
-}
-
-// SetCron : Allow user to set Cron
-func (_options *UpdateTektonPipelineTriggerOptions) SetCron(cron string) *UpdateTektonPipelineTriggerOptions {
-	_options.Cron = core.StringPtr(cron)
-	return _options
-}
-
-// SetTimezone : Allow user to set Timezone
-func (_options *UpdateTektonPipelineTriggerOptions) SetTimezone(timezone string) *UpdateTektonPipelineTriggerOptions {
-	_options.Timezone = core.StringPtr(timezone)
-	return _options
-}
-
-// SetScmSource : Allow user to set ScmSource
-func (_options *UpdateTektonPipelineTriggerOptions) SetScmSource(scmSource *TriggerScmSource) *UpdateTektonPipelineTriggerOptions {
-	_options.ScmSource = scmSource
-	return _options
-}
-
-// SetEvents : Allow user to set Events
-func (_options *UpdateTektonPipelineTriggerOptions) SetEvents(events *Events) *UpdateTektonPipelineTriggerOptions {
-	_options.Events = events
+// SetTriggerPatch : Allow user to set TriggerPatch
+func (_options *UpdateTektonPipelineTriggerOptions) SetTriggerPatch(triggerPatch map[string]interface{}) *UpdateTektonPipelineTriggerOptions {
+	_options.TriggerPatch = triggerPatch
 	return _options
 }
 
@@ -6060,7 +6011,8 @@ type TriggerGenericTrigger struct {
 	// API URL for interacting with the trigger.
 	Href *string `json:"href,omitempty"`
 
-	// Event listener name.
+	// Event listener name. The name of the event listener to which the trigger is associated. The event listeners are
+	// defined in the definition repositories of the Tekton pipeline.
 	EventListener *string `json:"event_listener" validate:"required"`
 
 	// ID.
@@ -6164,7 +6116,8 @@ type TriggerManualTrigger struct {
 	// API URL for interacting with the trigger.
 	Href *string `json:"href,omitempty"`
 
-	// Event listener name.
+	// Event listener name. The name of the event listener to which the trigger is associated. The event listeners are
+	// defined in the definition repositories of the Tekton pipeline.
 	EventListener *string `json:"event_listener" validate:"required"`
 
 	// ID.
@@ -6262,7 +6215,8 @@ type TriggerScmTrigger struct {
 	// API URL for interacting with the trigger.
 	Href *string `json:"href,omitempty"`
 
-	// Event listener name.
+	// Event listener name. The name of the event listener to which the trigger is associated. The event listeners are
+	// defined in the definition repositories of the Tekton pipeline.
 	EventListener *string `json:"event_listener" validate:"required"`
 
 	// ID.
@@ -6288,9 +6242,6 @@ type TriggerScmTrigger struct {
 
 	// Only needed for Git triggers. Events object defines the events to which this Git trigger listens.
 	Events *Events `json:"events,omitempty"`
-
-	// ID of the repository service instance.
-	ServiceInstanceID *string `json:"service_instance_id,omitempty"`
 }
 
 // NewTriggerScmTrigger : Instantiate TriggerScmTrigger (Generic Model Constructor)
@@ -6360,10 +6311,6 @@ func UnmarshalTriggerScmTrigger(m map[string]json.RawMessage, result interface{}
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalPrimitive(m, "service_instance_id", &obj.ServiceInstanceID)
-	if err != nil {
-		return
-	}
 	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
 	return
 }
@@ -6380,7 +6327,8 @@ type TriggerTimerTrigger struct {
 	// API URL for interacting with the trigger.
 	Href *string `json:"href,omitempty"`
 
-	// Event listener name.
+	// Event listener name. The name of the event listener to which the trigger is associated. The event listeners are
+	// defined in the definition repositories of the Tekton pipeline.
 	EventListener *string `json:"event_listener" validate:"required"`
 
 	// ID.

--- a/cdtektonpipelinev2/cd_tekton_pipeline_v2.go
+++ b/cdtektonpipelinev2/cd_tekton_pipeline_v2.go
@@ -1749,11 +1749,46 @@ func (cdTektonPipeline *CdTektonPipelineV2) CreateTektonPipelineTriggerWithConte
 	builder.AddHeader("Accept", "application/json")
 	builder.AddHeader("Content-Type", "application/json")
 
-	if createTektonPipelineTriggerOptions.Trigger != nil {
-		_, err = builder.SetBodyContentJSON(createTektonPipelineTriggerOptions.Trigger)
-		if err != nil {
-			return
-		}
+	body := make(map[string]interface{})
+	if createTektonPipelineTriggerOptions.Type != nil {
+		body["type"] = createTektonPipelineTriggerOptions.Type
+	}
+	if createTektonPipelineTriggerOptions.Name != nil {
+		body["name"] = createTektonPipelineTriggerOptions.Name
+	}
+	if createTektonPipelineTriggerOptions.EventListener != nil {
+		body["event_listener"] = createTektonPipelineTriggerOptions.EventListener
+	}
+	if createTektonPipelineTriggerOptions.Tags != nil {
+		body["tags"] = createTektonPipelineTriggerOptions.Tags
+	}
+	if createTektonPipelineTriggerOptions.Worker != nil {
+		body["worker"] = createTektonPipelineTriggerOptions.Worker
+	}
+	if createTektonPipelineTriggerOptions.MaxConcurrentRuns != nil {
+		body["max_concurrent_runs"] = createTektonPipelineTriggerOptions.MaxConcurrentRuns
+	}
+	if createTektonPipelineTriggerOptions.Disabled != nil {
+		body["disabled"] = createTektonPipelineTriggerOptions.Disabled
+	}
+	if createTektonPipelineTriggerOptions.Secret != nil {
+		body["secret"] = createTektonPipelineTriggerOptions.Secret
+	}
+	if createTektonPipelineTriggerOptions.Cron != nil {
+		body["cron"] = createTektonPipelineTriggerOptions.Cron
+	}
+	if createTektonPipelineTriggerOptions.Timezone != nil {
+		body["timezone"] = createTektonPipelineTriggerOptions.Timezone
+	}
+	if createTektonPipelineTriggerOptions.ScmSource != nil {
+		body["scm_source"] = createTektonPipelineTriggerOptions.ScmSource
+	}
+	if createTektonPipelineTriggerOptions.Events != nil {
+		body["events"] = createTektonPipelineTriggerOptions.Events
+	}
+	_, err = builder.SetBodyContentJSON(body)
+	if err != nil {
+		return
 	}
 
 	request, err := builder.Build()
@@ -2685,12 +2720,55 @@ type CreateTektonPipelineTriggerOptions struct {
 	// The Tekton pipeline ID.
 	PipelineID *string `json:"pipeline_id" validate:"required,ne="`
 
-	// Tekton pipeline trigger.
-	Trigger TriggerIntf `json:"Trigger,omitempty"`
+	// Trigger type.
+	Type *string `json:"type,omitempty"`
+
+	// Trigger name.
+	Name *string `json:"name,omitempty"`
+
+	// Event listener name. The name of the event listener to which the trigger is associated. The event listeners are
+	// defined in the definition repositories of the Tekton pipeline.
+	EventListener *string `json:"event_listener,omitempty"`
+
+	// Trigger tags array.
+	Tags []string `json:"tags,omitempty"`
+
+	// Worker used to run the trigger. If not specified the trigger will use the default pipeline worker.
+	Worker *Worker `json:"worker,omitempty"`
+
+	// Defines the maximum number of concurrent runs for this trigger. Omit this property to disable the concurrency limit.
+	MaxConcurrentRuns *int64 `json:"max_concurrent_runs,omitempty"`
+
+	// Flag whether the trigger is disabled. If omitted the trigger is enabled by default.
+	Disabled *bool `json:"disabled,omitempty"`
+
+	// Only needed for generic webhook trigger type. Secret used to start generic webhook trigger.
+	Secret *GenericSecret `json:"secret,omitempty"`
+
+	// Only needed for timer triggers. Cron expression for timer trigger.
+	Cron *string `json:"cron,omitempty"`
+
+	// Only needed for timer triggers. Timezone for timer trigger.
+	Timezone *string `json:"timezone,omitempty"`
+
+	// SCM source repository for a Git trigger. Only needed for Git triggers.
+	ScmSource *TriggerScmSource `json:"scm_source,omitempty"`
+
+	// Only needed for Git triggers. Events object defines the events to which this Git trigger listens.
+	Events *Events `json:"events,omitempty"`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
 }
+
+// Constants associated with the CreateTektonPipelineTriggerOptions.Type property.
+// Trigger type.
+const (
+	CreateTektonPipelineTriggerOptionsTypeGenericConst = "generic"
+	CreateTektonPipelineTriggerOptionsTypeManualConst = "manual"
+	CreateTektonPipelineTriggerOptionsTypeScmConst = "scm"
+	CreateTektonPipelineTriggerOptionsTypeTimerConst = "timer"
+)
 
 // NewCreateTektonPipelineTriggerOptions : Instantiate CreateTektonPipelineTriggerOptions
 func (*CdTektonPipelineV2) NewCreateTektonPipelineTriggerOptions(pipelineID string) *CreateTektonPipelineTriggerOptions {
@@ -2705,9 +2783,75 @@ func (_options *CreateTektonPipelineTriggerOptions) SetPipelineID(pipelineID str
 	return _options
 }
 
-// SetTrigger : Allow user to set Trigger
-func (_options *CreateTektonPipelineTriggerOptions) SetTrigger(trigger TriggerIntf) *CreateTektonPipelineTriggerOptions {
-	_options.Trigger = trigger
+// SetType : Allow user to set Type
+func (_options *CreateTektonPipelineTriggerOptions) SetType(typeVar string) *CreateTektonPipelineTriggerOptions {
+	_options.Type = core.StringPtr(typeVar)
+	return _options
+}
+
+// SetName : Allow user to set Name
+func (_options *CreateTektonPipelineTriggerOptions) SetName(name string) *CreateTektonPipelineTriggerOptions {
+	_options.Name = core.StringPtr(name)
+	return _options
+}
+
+// SetEventListener : Allow user to set EventListener
+func (_options *CreateTektonPipelineTriggerOptions) SetEventListener(eventListener string) *CreateTektonPipelineTriggerOptions {
+	_options.EventListener = core.StringPtr(eventListener)
+	return _options
+}
+
+// SetTags : Allow user to set Tags
+func (_options *CreateTektonPipelineTriggerOptions) SetTags(tags []string) *CreateTektonPipelineTriggerOptions {
+	_options.Tags = tags
+	return _options
+}
+
+// SetWorker : Allow user to set Worker
+func (_options *CreateTektonPipelineTriggerOptions) SetWorker(worker *Worker) *CreateTektonPipelineTriggerOptions {
+	_options.Worker = worker
+	return _options
+}
+
+// SetMaxConcurrentRuns : Allow user to set MaxConcurrentRuns
+func (_options *CreateTektonPipelineTriggerOptions) SetMaxConcurrentRuns(maxConcurrentRuns int64) *CreateTektonPipelineTriggerOptions {
+	_options.MaxConcurrentRuns = core.Int64Ptr(maxConcurrentRuns)
+	return _options
+}
+
+// SetDisabled : Allow user to set Disabled
+func (_options *CreateTektonPipelineTriggerOptions) SetDisabled(disabled bool) *CreateTektonPipelineTriggerOptions {
+	_options.Disabled = core.BoolPtr(disabled)
+	return _options
+}
+
+// SetSecret : Allow user to set Secret
+func (_options *CreateTektonPipelineTriggerOptions) SetSecret(secret *GenericSecret) *CreateTektonPipelineTriggerOptions {
+	_options.Secret = secret
+	return _options
+}
+
+// SetCron : Allow user to set Cron
+func (_options *CreateTektonPipelineTriggerOptions) SetCron(cron string) *CreateTektonPipelineTriggerOptions {
+	_options.Cron = core.StringPtr(cron)
+	return _options
+}
+
+// SetTimezone : Allow user to set Timezone
+func (_options *CreateTektonPipelineTriggerOptions) SetTimezone(timezone string) *CreateTektonPipelineTriggerOptions {
+	_options.Timezone = core.StringPtr(timezone)
+	return _options
+}
+
+// SetScmSource : Allow user to set ScmSource
+func (_options *CreateTektonPipelineTriggerOptions) SetScmSource(scmSource *TriggerScmSource) *CreateTektonPipelineTriggerOptions {
+	_options.ScmSource = scmSource
+	return _options
+}
+
+// SetEvents : Allow user to set Events
+func (_options *CreateTektonPipelineTriggerOptions) SetEvents(events *Events) *CreateTektonPipelineTriggerOptions {
+	_options.Events = events
 	return _options
 }
 
@@ -5218,16 +5362,6 @@ const (
 	TriggerGenericTriggerPropertiesItemTypeTextConst = "text"
 )
 
-// NewTriggerGenericTriggerPropertiesItem : Instantiate TriggerGenericTriggerPropertiesItem (Generic Model Constructor)
-func (*CdTektonPipelineV2) NewTriggerGenericTriggerPropertiesItem(name string, typeVar string) (_model *TriggerGenericTriggerPropertiesItem, err error) {
-	_model = &TriggerGenericTriggerPropertiesItem{
-		Name: core.StringPtr(name),
-		Type: core.StringPtr(typeVar),
-	}
-	err = core.ValidateStruct(_model, "required parameters")
-	return
-}
-
 // UnmarshalTriggerGenericTriggerPropertiesItem unmarshals an instance of TriggerGenericTriggerPropertiesItem from the specified map of raw messages.
 func UnmarshalTriggerGenericTriggerPropertiesItem(m map[string]json.RawMessage, result interface{}) (err error) {
 	obj := new(TriggerGenericTriggerPropertiesItem)
@@ -5290,16 +5424,6 @@ const (
 	TriggerManualTriggerPropertiesItemTypeSingleSelectConst = "single_select"
 	TriggerManualTriggerPropertiesItemTypeTextConst = "text"
 )
-
-// NewTriggerManualTriggerPropertiesItem : Instantiate TriggerManualTriggerPropertiesItem (Generic Model Constructor)
-func (*CdTektonPipelineV2) NewTriggerManualTriggerPropertiesItem(name string, typeVar string) (_model *TriggerManualTriggerPropertiesItem, err error) {
-	_model = &TriggerManualTriggerPropertiesItem{
-		Name: core.StringPtr(name),
-		Type: core.StringPtr(typeVar),
-	}
-	err = core.ValidateStruct(_model, "required parameters")
-	return
-}
 
 // UnmarshalTriggerManualTriggerPropertiesItem unmarshals an instance of TriggerManualTriggerPropertiesItem from the specified map of raw messages.
 func UnmarshalTriggerManualTriggerPropertiesItem(m map[string]json.RawMessage, result interface{}) (err error) {
@@ -5558,16 +5682,6 @@ const (
 	TriggerPropertiesItemTypeTextConst = "text"
 )
 
-// NewTriggerPropertiesItem : Instantiate TriggerPropertiesItem (Generic Model Constructor)
-func (*CdTektonPipelineV2) NewTriggerPropertiesItem(name string, typeVar string) (_model *TriggerPropertiesItem, err error) {
-	_model = &TriggerPropertiesItem{
-		Name: core.StringPtr(name),
-		Type: core.StringPtr(typeVar),
-	}
-	err = core.ValidateStruct(_model, "required parameters")
-	return
-}
-
 // UnmarshalTriggerPropertiesItem unmarshals an instance of TriggerPropertiesItem from the specified map of raw messages.
 func UnmarshalTriggerPropertiesItem(m map[string]json.RawMessage, result interface{}) (err error) {
 	obj := new(TriggerPropertiesItem)
@@ -5666,8 +5780,8 @@ type TriggerScmSource struct {
 	// Git branch or tag pattern to listen to. Please refer to https://github.com/micromatch/micromatch for pattern syntax.
 	Pattern *string `json:"pattern,omitempty"`
 
-	// Set this boolean to true if the server is not addressable on the public internet. IBM Cloud will not be able to
-	// validate the connection details you provide. False by default.
+	// True if the repository server is not addressable on the public internet. IBM Cloud will not be able to validate the
+	// connection details you provide.
 	BlindConnection *bool `json:"blind_connection,omitempty"`
 
 	// ID of the webhook from the repo. Computed upon creation of the trigger.
@@ -5749,16 +5863,6 @@ const (
 	TriggerScmTriggerPropertiesItemTypeTextConst = "text"
 )
 
-// NewTriggerScmTriggerPropertiesItem : Instantiate TriggerScmTriggerPropertiesItem (Generic Model Constructor)
-func (*CdTektonPipelineV2) NewTriggerScmTriggerPropertiesItem(name string, typeVar string) (_model *TriggerScmTriggerPropertiesItem, err error) {
-	_model = &TriggerScmTriggerPropertiesItem{
-		Name: core.StringPtr(name),
-		Type: core.StringPtr(typeVar),
-	}
-	err = core.ValidateStruct(_model, "required parameters")
-	return
-}
-
 // UnmarshalTriggerScmTriggerPropertiesItem unmarshals an instance of TriggerScmTriggerPropertiesItem from the specified map of raw messages.
 func UnmarshalTriggerScmTriggerPropertiesItem(m map[string]json.RawMessage, result interface{}) (err error) {
 	obj := new(TriggerScmTriggerPropertiesItem)
@@ -5821,16 +5925,6 @@ const (
 	TriggerTimerTriggerPropertiesItemTypeSingleSelectConst = "single_select"
 	TriggerTimerTriggerPropertiesItemTypeTextConst = "text"
 )
-
-// NewTriggerTimerTriggerPropertiesItem : Instantiate TriggerTimerTriggerPropertiesItem (Generic Model Constructor)
-func (*CdTektonPipelineV2) NewTriggerTimerTriggerPropertiesItem(name string, typeVar string) (_model *TriggerTimerTriggerPropertiesItem, err error) {
-	_model = &TriggerTimerTriggerPropertiesItem{
-		Name: core.StringPtr(name),
-		Type: core.StringPtr(typeVar),
-	}
-	err = core.ValidateStruct(_model, "required parameters")
-	return
-}
 
 // UnmarshalTriggerTimerTriggerPropertiesItem unmarshals an instance of TriggerTimerTriggerPropertiesItem from the specified map of raw messages.
 func UnmarshalTriggerTimerTriggerPropertiesItem(m map[string]json.RawMessage, result interface{}) (err error) {
@@ -6099,18 +6193,6 @@ type TriggerGenericTrigger struct {
 	Secret *GenericSecret `json:"secret,omitempty"`
 }
 
-// NewTriggerGenericTrigger : Instantiate TriggerGenericTrigger (Generic Model Constructor)
-func (*CdTektonPipelineV2) NewTriggerGenericTrigger(typeVar string, name string, eventListener string, disabled bool) (_model *TriggerGenericTrigger, err error) {
-	_model = &TriggerGenericTrigger{
-		Type: core.StringPtr(typeVar),
-		Name: core.StringPtr(name),
-		EventListener: core.StringPtr(eventListener),
-		Disabled: core.BoolPtr(disabled),
-	}
-	err = core.ValidateStruct(_model, "required parameters")
-	return
-}
-
 func (*TriggerGenericTrigger) isaTrigger() bool {
 	return true
 }
@@ -6199,18 +6281,6 @@ type TriggerManualTrigger struct {
 
 	// Flag whether the trigger is disabled. If omitted the trigger is enabled by default.
 	Disabled *bool `json:"disabled" validate:"required"`
-}
-
-// NewTriggerManualTrigger : Instantiate TriggerManualTrigger (Generic Model Constructor)
-func (*CdTektonPipelineV2) NewTriggerManualTrigger(typeVar string, name string, eventListener string, disabled bool) (_model *TriggerManualTrigger, err error) {
-	_model = &TriggerManualTrigger{
-		Type: core.StringPtr(typeVar),
-		Name: core.StringPtr(name),
-		EventListener: core.StringPtr(eventListener),
-		Disabled: core.BoolPtr(disabled),
-	}
-	err = core.ValidateStruct(_model, "required parameters")
-	return
 }
 
 func (*TriggerManualTrigger) isaTrigger() bool {
@@ -6304,18 +6374,6 @@ type TriggerScmTrigger struct {
 
 	// Only needed for Git triggers. Events object defines the events to which this Git trigger listens.
 	Events *Events `json:"events,omitempty"`
-}
-
-// NewTriggerScmTrigger : Instantiate TriggerScmTrigger (Generic Model Constructor)
-func (*CdTektonPipelineV2) NewTriggerScmTrigger(typeVar string, name string, eventListener string, disabled bool) (_model *TriggerScmTrigger, err error) {
-	_model = &TriggerScmTrigger{
-		Type: core.StringPtr(typeVar),
-		Name: core.StringPtr(name),
-		EventListener: core.StringPtr(eventListener),
-		Disabled: core.BoolPtr(disabled),
-	}
-	err = core.ValidateStruct(_model, "required parameters")
-	return
 }
 
 func (*TriggerScmTrigger) isaTrigger() bool {
@@ -6416,18 +6474,6 @@ type TriggerTimerTrigger struct {
 
 	// Only needed for timer triggers. Timezone for timer trigger.
 	Timezone *string `json:"timezone,omitempty"`
-}
-
-// NewTriggerTimerTrigger : Instantiate TriggerTimerTrigger (Generic Model Constructor)
-func (*CdTektonPipelineV2) NewTriggerTimerTrigger(typeVar string, name string, eventListener string, disabled bool) (_model *TriggerTimerTrigger, err error) {
-	_model = &TriggerTimerTrigger{
-		Type: core.StringPtr(typeVar),
-		Name: core.StringPtr(name),
-		EventListener: core.StringPtr(eventListener),
-		Disabled: core.BoolPtr(disabled),
-	}
-	err = core.ValidateStruct(_model, "required parameters")
-	return
 }
 
 func (*TriggerTimerTrigger) isaTrigger() bool {

--- a/cdtektonpipelinev2/cd_tekton_pipeline_v2.go
+++ b/cdtektonpipelinev2/cd_tekton_pipeline_v2.go
@@ -47,7 +47,7 @@ type CdTektonPipelineV2 struct {
 }
 
 // DefaultServiceURL is the default URL to make service requests to.
-const DefaultServiceURL = "https://api.us-south.devops.cloud.ibm.com/v2"
+const DefaultServiceURL = "https://api.us-south.devops.cloud.ibm.com/pipeline/v2"
 
 // DefaultServiceName is the default key used to find external configuration information.
 const DefaultServiceName = "cd_tekton_pipeline"
@@ -117,15 +117,15 @@ func NewCdTektonPipelineV2(options *CdTektonPipelineV2Options) (service *CdTekto
 // GetServiceURLForRegion returns the service URL to be used for the specified region
 func GetServiceURLForRegion(region string) (string, error) {
 	var endpoints = map[string]string{
-		"us-south": "https://api.us-south.devops.cloud.ibm.com/v2", // The host URL for Tekton Pipeline Service in the us-south region.
-		"us-east": "https://api.us-east.devops.cloud.ibm.com/v2", // The host URL for Tekton Pipeline Service in the us-east region.
-		"eu-de": "https://api.eu-de.devops.cloud.ibm.com/v2", // The host URL for Tekton Pipeline Service in the eu-de region.
-		"eu-gb": "https://api.eu-gb.devops.cloud.ibm.com/v2", // The host URL for Tekton Pipeline Service in the eu-gb region.
-		"jp-osa": "https://api.jp-osa.devops.cloud.ibm.com/v2", // The host URL for Tekton Pipeline Service in the jp-osa region.
-		"jp-tok": "https://api.jp-tok.devops.cloud.ibm.com/v2", // The host URL for Tekton Pipeline Service in the jp-tok region.
-		"au-syd": "https://api.au-syd.devops.cloud.ibm.com/v2", // The host URL for Tekton Pipeline Service in the au-syd region.
-		"ca-tor": "https://api.ca-tor.devops.cloud.ibm.com/v2", // The host URL for Tekton Pipeline Service in the ca-tor region.
-		"br-sao": "https://api.br-sao.devops.cloud.ibm.com/v2", // The host URL for Tekton Pipeline Service in the br-sao region.
+		"us-south": "https://api.us-south.devops.cloud.ibm.com/pipeline/v2", // The host URL for Tekton Pipeline Service in the us-south region.
+		"us-east": "https://api.us-east.devops.cloud.ibm.com/pipeline/v2", // The host URL for Tekton Pipeline Service in the us-east region.
+		"eu-de": "https://api.eu-de.devops.cloud.ibm.com/pipeline/v2", // The host URL for Tekton Pipeline Service in the eu-de region.
+		"eu-gb": "https://api.eu-gb.devops.cloud.ibm.com/pipeline/v2", // The host URL for Tekton Pipeline Service in the eu-gb region.
+		"jp-osa": "https://api.jp-osa.devops.cloud.ibm.com/pipeline/v2", // The host URL for Tekton Pipeline Service in the jp-osa region.
+		"jp-tok": "https://api.jp-tok.devops.cloud.ibm.com/pipeline/v2", // The host URL for Tekton Pipeline Service in the jp-tok region.
+		"au-syd": "https://api.au-syd.devops.cloud.ibm.com/pipeline/v2", // The host URL for Tekton Pipeline Service in the au-syd region.
+		"ca-tor": "https://api.ca-tor.devops.cloud.ibm.com/pipeline/v2", // The host URL for Tekton Pipeline Service in the ca-tor region.
+		"br-sao": "https://api.br-sao.devops.cloud.ibm.com/pipeline/v2", // The host URL for Tekton Pipeline Service in the br-sao region.
 	}
 
 	if url, ok := endpoints[region]; ok {
@@ -1393,9 +1393,6 @@ func (cdTektonPipeline *CdTektonPipelineV2) CreateTektonPipelinePropertiesWithCo
 	if createTektonPipelinePropertiesOptions.Enum != nil {
 		body["enum"] = createTektonPipelinePropertiesOptions.Enum
 	}
-	if createTektonPipelinePropertiesOptions.Default != nil {
-		body["default"] = createTektonPipelinePropertiesOptions.Default
-	}
 	if createTektonPipelinePropertiesOptions.Type != nil {
 		body["type"] = createTektonPipelinePropertiesOptions.Type
 	}
@@ -1540,9 +1537,6 @@ func (cdTektonPipeline *CdTektonPipelineV2) ReplaceTektonPipelinePropertyWithCon
 	}
 	if replaceTektonPipelinePropertyOptions.Enum != nil {
 		body["enum"] = replaceTektonPipelinePropertyOptions.Enum
-	}
-	if replaceTektonPipelinePropertyOptions.Default != nil {
-		body["default"] = replaceTektonPipelinePropertyOptions.Default
 	}
 	if replaceTektonPipelinePropertyOptions.Type != nil {
 		body["type"] = replaceTektonPipelinePropertyOptions.Type
@@ -2071,9 +2065,6 @@ func (cdTektonPipeline *CdTektonPipelineV2) CreateTektonPipelineTriggerPropertie
 	if createTektonPipelineTriggerPropertiesOptions.Enum != nil {
 		body["enum"] = createTektonPipelineTriggerPropertiesOptions.Enum
 	}
-	if createTektonPipelineTriggerPropertiesOptions.Default != nil {
-		body["default"] = createTektonPipelineTriggerPropertiesOptions.Default
-	}
 	if createTektonPipelineTriggerPropertiesOptions.Type != nil {
 		body["type"] = createTektonPipelineTriggerPropertiesOptions.Type
 	}
@@ -2219,9 +2210,6 @@ func (cdTektonPipeline *CdTektonPipelineV2) ReplaceTektonPipelineTriggerProperty
 	}
 	if replaceTektonPipelineTriggerPropertyOptions.Enum != nil {
 		body["enum"] = replaceTektonPipelineTriggerPropertyOptions.Enum
-	}
-	if replaceTektonPipelineTriggerPropertyOptions.Default != nil {
-		body["default"] = replaceTektonPipelineTriggerPropertyOptions.Default
 	}
 	if replaceTektonPipelineTriggerPropertyOptions.Type != nil {
 		body["type"] = replaceTektonPipelineTriggerPropertyOptions.Type
@@ -2444,16 +2432,13 @@ type CreateTektonPipelinePropertiesOptions struct {
 	// Property value.
 	Value *string `json:"value,omitempty"`
 
-	// Options for single_select property type. Only needed when using single_select property type.
+	// Options for `single_select` property type. Only needed when using `single_select` property type.
 	Enum []string `json:"enum,omitempty"`
-
-	// Default option for single_select property type. Only needed when using single_select property type.
-	Default *string `json:"default,omitempty"`
 
 	// Property type.
 	Type *string `json:"type,omitempty"`
 
-	// A dot notation path for integration type properties to select a value from the tool integration.
+	// A dot notation path for `integration` type properties to select a value from the tool integration.
 	Path *string `json:"path,omitempty"`
 
 	// Allows users to set headers on API requests
@@ -2501,12 +2486,6 @@ func (_options *CreateTektonPipelinePropertiesOptions) SetEnum(enum []string) *C
 	return _options
 }
 
-// SetDefault : Allow user to set Default
-func (_options *CreateTektonPipelinePropertiesOptions) SetDefault(defaultVar string) *CreateTektonPipelinePropertiesOptions {
-	_options.Default = core.StringPtr(defaultVar)
-	return _options
-}
-
 // SetType : Allow user to set Type
 func (_options *CreateTektonPipelinePropertiesOptions) SetType(typeVar string) *CreateTektonPipelinePropertiesOptions {
 	_options.Type = core.StringPtr(typeVar)
@@ -2533,19 +2512,19 @@ type CreateTektonPipelineRunOptions struct {
 	// Trigger name.
 	TriggerName *string `json:"trigger_name,omitempty"`
 
-	// An object containing string values only that provides additional text properties, or overrides existing
+	// An object containing string values only that provides additional `text` properties, or overrides existing
 	// pipeline/trigger properties.
 	TriggerProperties map[string]interface{} `json:"trigger_properties,omitempty"`
 
-	// An object containing string values only that provides additional secure properties, or overrides existing secure
+	// An object containing string values only that provides additional `secure` properties, or overrides existing `secure`
 	// pipeline/trigger properties.
 	SecureTriggerProperties map[string]interface{} `json:"secure_trigger_properties,omitempty"`
 
-	// An object containing string values only that provides the trigger header. Use $(header.header_key_name) to access it
-	// in triggerBinding.
+	// An object containing string values only that provides the trigger header. Use `$(header.header_key_name)` to access
+	// it in triggerBinding.
 	TriggerHeader map[string]interface{} `json:"trigger_header,omitempty"`
 
-	// An object that provides the trigger body. Use $(body.body_key_name) to access it in triggerBinding.
+	// An object that provides the trigger body. Use `$(body.body_key_name)` to access it in triggerBinding.
 	TriggerBody map[string]interface{} `json:"trigger_body,omitempty"`
 
 	// Allows users to set headers on API requests
@@ -2649,19 +2628,16 @@ type CreateTektonPipelineTriggerPropertiesOptions struct {
 	// Property name.
 	Name *string `json:"name,omitempty"`
 
-	// Property value. Can be empty and should be omitted for single_select property type.
+	// Property value.
 	Value *string `json:"value,omitempty"`
 
-	// Options for single_select property type. Only needed for single_select property type.
+	// Options for `single_select` property type. Only needed for `single_select` property type.
 	Enum []string `json:"enum,omitempty"`
-
-	// Default option for single_select property type. Only needed for single_select property type.
-	Default *string `json:"default,omitempty"`
 
 	// Property type.
 	Type *string `json:"type,omitempty"`
 
-	// A dot notation path for integration type properties to select a value from the tool integration. If left blank the
+	// A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the
 	// full tool integration JSON will be selected.
 	Path *string `json:"path,omitempty"`
 
@@ -2714,12 +2690,6 @@ func (_options *CreateTektonPipelineTriggerPropertiesOptions) SetValue(value str
 // SetEnum : Allow user to set Enum
 func (_options *CreateTektonPipelineTriggerPropertiesOptions) SetEnum(enum []string) *CreateTektonPipelineTriggerPropertiesOptions {
 	_options.Enum = enum
-	return _options
-}
-
-// SetDefault : Allow user to set Default
-func (_options *CreateTektonPipelineTriggerPropertiesOptions) SetDefault(defaultVar string) *CreateTektonPipelineTriggerPropertiesOptions {
-	_options.Default = core.StringPtr(defaultVar)
 	return _options
 }
 
@@ -3133,16 +3103,16 @@ type GenericSecret struct {
 	// Secret type.
 	Type *string `json:"type,omitempty"`
 
-	// Secret value, not needed if secret type is "internal_validation".
+	// Secret value, not needed if secret type is `internal_validation`.
 	Value *string `json:"value,omitempty"`
 
-	// Secret location, not needed if secret type is "internal_validation".
+	// Secret location, not needed if secret type is `internal_validation`.
 	Source *string `json:"source,omitempty"`
 
-	// Secret name, not needed if type is "internal_validation".
+	// Secret name, not needed if type is `internal_validation`.
 	KeyName *string `json:"key_name,omitempty"`
 
-	// Algorithm used for "digest_matches" secret type. Only needed for "digest_matches" secret type.
+	// Algorithm used for `digest_matches` secret type. Only needed for `digest_matches` secret type.
 	Algorithm *string `json:"algorithm,omitempty"`
 }
 
@@ -3155,7 +3125,7 @@ const (
 )
 
 // Constants associated with the GenericSecret.Source property.
-// Secret location, not needed if secret type is "internal_validation".
+// Secret location, not needed if secret type is `internal_validation`.
 const (
 	GenericSecretSourceHeaderConst = "header"
 	GenericSecretSourcePayloadConst = "payload"
@@ -3163,7 +3133,7 @@ const (
 )
 
 // Constants associated with the GenericSecret.Algorithm property.
-// Algorithm used for "digest_matches" secret type. Only needed for "digest_matches" secret type.
+// Algorithm used for `digest_matches` secret type. Only needed for `digest_matches` secret type.
 const (
 	GenericSecretAlgorithmMd4Const = "md4"
 	GenericSecretAlgorithmMd5Const = "md5"
@@ -3571,7 +3541,7 @@ type ListTektonPipelinePropertiesOptions struct {
 	// Filters the collection to resources with the specified property type.
 	Type []string `json:"type,omitempty"`
 
-	// Sorts the returned properties by name, in ascending order using "name" or in descending order using "-name".
+	// Sorts the returned properties by name, in ascending order using `name` or in descending order using `-name`.
 	Sort *string `json:"sort,omitempty"`
 
 	// Allows users to set headers on API requests
@@ -3711,13 +3681,13 @@ type ListTektonPipelineTriggerPropertiesOptions struct {
 	// The trigger ID.
 	TriggerID *string `json:"trigger_id" validate:"required,ne="`
 
-	// Filter properties by "name".
+	// Filter properties by `name`.
 	Name *string `json:"name" validate:"required"`
 
-	// Filter properties by "type". Valid types are "secure", "text", "integration", "single_select", "appconfig".
+	// Filter properties by `type`. Valid types are `secure`, `text`, `integration`, `single_select`, `appconfig`.
 	Type *string `json:"type" validate:"required"`
 
-	// Sort properties by name. They can be sorted in ascending order using "name" or in descending order using "-name".
+	// Sort properties by name. They can be sorted in ascending order using `name` or in descending order using `-name`.
 	Sort *string `json:"sort" validate:"required"`
 
 	// Allows users to set headers on API requests
@@ -4330,16 +4300,13 @@ type Property struct {
 	// Property value.
 	Value *string `json:"value,omitempty"`
 
-	// Options for single_select property type. Only needed when using single_select property type.
+	// Options for `single_select` property type. Only needed when using `single_select` property type.
 	Enum []string `json:"enum,omitempty"`
-
-	// Default option for single_select property type. Only needed when using single_select property type.
-	Default *string `json:"default,omitempty"`
 
 	// Property type.
 	Type *string `json:"type" validate:"required"`
 
-	// A dot notation path for integration type properties to select a value from the tool integration.
+	// A dot notation path for `integration` type properties to select a value from the tool integration.
 	Path *string `json:"path,omitempty"`
 }
 
@@ -4365,10 +4332,6 @@ func UnmarshalProperty(m map[string]json.RawMessage, result interface{}) (err er
 		return
 	}
 	err = core.UnmarshalPrimitive(m, "enum", &obj.Enum)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "default", &obj.Default)
 	if err != nil {
 		return
 	}
@@ -4454,16 +4417,13 @@ type ReplaceTektonPipelinePropertyOptions struct {
 	// Property value.
 	Value *string `json:"value,omitempty"`
 
-	// Options for single_select property type. Only needed when using single_select property type.
+	// Options for `single_select` property type. Only needed when using `single_select` property type.
 	Enum []string `json:"enum,omitempty"`
-
-	// Default option for single_select property type. Only needed when using single_select property type.
-	Default *string `json:"default,omitempty"`
 
 	// Property type.
 	Type *string `json:"type,omitempty"`
 
-	// A dot notation path for integration type properties to select a value from the tool integration.
+	// A dot notation path for `integration` type properties to select a value from the tool integration.
 	Path *string `json:"path,omitempty"`
 
 	// Allows users to set headers on API requests
@@ -4518,12 +4478,6 @@ func (_options *ReplaceTektonPipelinePropertyOptions) SetEnum(enum []string) *Re
 	return _options
 }
 
-// SetDefault : Allow user to set Default
-func (_options *ReplaceTektonPipelinePropertyOptions) SetDefault(defaultVar string) *ReplaceTektonPipelinePropertyOptions {
-	_options.Default = core.StringPtr(defaultVar)
-	return _options
-}
-
 // SetType : Allow user to set Type
 func (_options *ReplaceTektonPipelinePropertyOptions) SetType(typeVar string) *ReplaceTektonPipelinePropertyOptions {
 	_options.Type = core.StringPtr(typeVar)
@@ -4556,19 +4510,16 @@ type ReplaceTektonPipelineTriggerPropertyOptions struct {
 	// Property name.
 	Name *string `json:"name,omitempty"`
 
-	// Property value. Can be empty and should be omitted for single_select property type.
+	// Property value.
 	Value *string `json:"value,omitempty"`
 
-	// Options for single_select property type. Only needed for single_select property type.
+	// Options for `single_select` property type. Only needed for `single_select` property type.
 	Enum []string `json:"enum,omitempty"`
-
-	// Default option for single_select property type. Only needed for single_select property type.
-	Default *string `json:"default,omitempty"`
 
 	// Property type.
 	Type *string `json:"type,omitempty"`
 
-	// A dot notation path for integration type properties to select a value from the tool integration. If left blank the
+	// A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the
 	// full tool integration JSON will be selected.
 	Path *string `json:"path,omitempty"`
 
@@ -4628,12 +4579,6 @@ func (_options *ReplaceTektonPipelineTriggerPropertyOptions) SetValue(value stri
 // SetEnum : Allow user to set Enum
 func (_options *ReplaceTektonPipelineTriggerPropertyOptions) SetEnum(enum []string) *ReplaceTektonPipelineTriggerPropertyOptions {
 	_options.Enum = enum
-	return _options
-}
-
-// SetDefault : Allow user to set Default
-func (_options *ReplaceTektonPipelineTriggerPropertyOptions) SetDefault(defaultVar string) *ReplaceTektonPipelineTriggerPropertyOptions {
-	_options.Default = core.StringPtr(defaultVar)
 	return _options
 }
 
@@ -4737,6 +4682,15 @@ type TektonPipeline struct {
 	// The latest pipeline run build number. If this property is absent, the pipeline hasn't had any pipeline runs.
 	BuildNumber *int64 `json:"build_number,omitempty"`
 
+	// Flag whether to enable slack notifications for this pipeline. When enabled, pipeline run events will be published on
+	// all slack integration specified channels in the enclosing toolchain.
+	EnableSlackNotifications *bool `json:"enable_slack_notifications,omitempty"`
+
+	// Flag whether to enable partial cloning for this pipeline. When partial clone is enabled, only the files contained
+	// within the paths specified in definition repositories will be read and cloned. This means symbolic links may not
+	// work.
+	EnablePartialCloning *bool `json:"enable_partial_cloning,omitempty"`
+
 	// Flag whether this pipeline is enabled.
 	Enabled *bool `json:"enabled" validate:"required"`
 }
@@ -4807,6 +4761,14 @@ func UnmarshalTektonPipeline(m map[string]json.RawMessage, result interface{}) (
 	if err != nil {
 		return
 	}
+	err = core.UnmarshalPrimitive(m, "enable_slack_notifications", &obj.EnableSlackNotifications)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "enable_partial_cloning", &obj.EnablePartialCloning)
+	if err != nil {
+		return
+	}
 	err = core.UnmarshalPrimitive(m, "enabled", &obj.Enabled)
 	if err != nil {
 		return
@@ -4815,9 +4777,20 @@ func UnmarshalTektonPipeline(m map[string]json.RawMessage, result interface{}) (
 	return
 }
 
-// TektonPipelinePatch : Request body used to change worker for this pipeline. To get the worker ID call the toolchain endpoint
-// /api/v1/toolchains/{toolchain_id}.
+// TektonPipelinePatch : Request body used to update this pipeline.
 type TektonPipelinePatch struct {
+	// Flag whether to enable slack notifications for this pipeline. When enabled, pipeline run events will be published on
+	// all slack integration specified channels in the enclosing toolchain.
+	EnableSlackNotifications *bool `json:"enable_slack_notifications,omitempty"`
+
+	// Flag whether to enable partial cloning for this pipeline. When partial clone is enabled, only the files contained
+	// within the paths specified in definition repositories will be read and cloned. This means symbolic links may not
+	// work.
+	EnablePartialCloning *bool `json:"enable_partial_cloning,omitempty"`
+
+	// Flag whether this pipeline is enabled.
+	Enabled *bool `json:"enabled,omitempty"`
+
 	// Worker object containing worker ID only. If omitted the IBM Managed shared workers are used by default.
 	Worker *WorkerWithID `json:"worker,omitempty"`
 }
@@ -4825,6 +4798,18 @@ type TektonPipelinePatch struct {
 // UnmarshalTektonPipelinePatch unmarshals an instance of TektonPipelinePatch from the specified map of raw messages.
 func UnmarshalTektonPipelinePatch(m map[string]json.RawMessage, result interface{}) (err error) {
 	obj := new(TektonPipelinePatch)
+	err = core.UnmarshalPrimitive(m, "enable_slack_notifications", &obj.EnableSlackNotifications)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "enable_partial_cloning", &obj.EnablePartialCloning)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "enabled", &obj.Enabled)
+	if err != nil {
+		return
+	}
 	err = core.UnmarshalModel(m, "worker", &obj.Worker, UnmarshalWorkerWithID)
 	if err != nil {
 		return
@@ -5041,19 +5026,16 @@ type TriggerGenericTriggerPropertiesItem struct {
 	// Property name.
 	Name *string `json:"name" validate:"required"`
 
-	// Property value. Can be empty and should be omitted for single_select property type.
+	// Property value. Can be empty and should be omitted for `single_select` property type.
 	Value *string `json:"value,omitempty"`
 
-	// Options for single_select property type. Only needed for single_select property type.
+	// Options for `single_select` property type. Only needed for `single_select` property type.
 	Enum []string `json:"enum,omitempty"`
-
-	// Default option for single_select property type. Only needed for single_select property type.
-	Default *string `json:"default,omitempty"`
 
 	// Property type.
 	Type *string `json:"type" validate:"required"`
 
-	// A dot notation path for integration type properties to select a value from the tool integration. If left blank the
+	// A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the
 	// full tool integration JSON will be selected.
 	Path *string `json:"path,omitempty"`
 
@@ -5096,10 +5078,6 @@ func UnmarshalTriggerGenericTriggerPropertiesItem(m map[string]json.RawMessage, 
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalPrimitive(m, "default", &obj.Default)
-	if err != nil {
-		return
-	}
 	err = core.UnmarshalPrimitive(m, "type", &obj.Type)
 	if err != nil {
 		return
@@ -5121,19 +5099,16 @@ type TriggerManualTriggerPropertiesItem struct {
 	// Property name.
 	Name *string `json:"name" validate:"required"`
 
-	// Property value. Can be empty and should be omitted for single_select property type.
+	// Property value. Can be empty and should be omitted for `single_select` property type.
 	Value *string `json:"value,omitempty"`
 
-	// Options for single_select property type. Only needed for single_select property type.
+	// Options for `single_select` property type. Only needed for `single_select` property type.
 	Enum []string `json:"enum,omitempty"`
-
-	// Default option for single_select property type. Only needed for single_select property type.
-	Default *string `json:"default,omitempty"`
 
 	// Property type.
 	Type *string `json:"type" validate:"required"`
 
-	// A dot notation path for integration type properties to select a value from the tool integration. If left blank the
+	// A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the
 	// full tool integration JSON will be selected.
 	Path *string `json:"path,omitempty"`
 
@@ -5173,10 +5148,6 @@ func UnmarshalTriggerManualTriggerPropertiesItem(m map[string]json.RawMessage, r
 		return
 	}
 	err = core.UnmarshalPrimitive(m, "enum", &obj.Enum)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "default", &obj.Default)
 	if err != nil {
 		return
 	}
@@ -5332,19 +5303,16 @@ type TriggerPropertiesCollectionPropertiesItem struct {
 	// Property name.
 	Name *string `json:"name" validate:"required"`
 
-	// Property value. Can be empty and should be omitted for single_select property type.
+	// Property value. Can be empty and should be omitted for `single_select` property type.
 	Value *string `json:"value,omitempty"`
 
-	// Options for single_select property type. Only needed for single_select property type.
+	// Options for `single_select` property type. Only needed for `single_select` property type.
 	Enum []string `json:"enum,omitempty"`
-
-	// Default option for single_select property type. Only needed for single_select property type.
-	Default *string `json:"default,omitempty"`
 
 	// Property type.
 	Type *string `json:"type" validate:"required"`
 
-	// A dot notation path for integration type properties to select a value from the tool integration. If left blank the
+	// A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the
 	// full tool integration JSON will be selected.
 	Path *string `json:"path,omitempty"`
 
@@ -5377,10 +5345,6 @@ func UnmarshalTriggerPropertiesCollectionPropertiesItem(m map[string]json.RawMes
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalPrimitive(m, "default", &obj.Default)
-	if err != nil {
-		return
-	}
 	err = core.UnmarshalPrimitive(m, "type", &obj.Type)
 	if err != nil {
 		return
@@ -5402,19 +5366,16 @@ type TriggerPropertiesItem struct {
 	// Property name.
 	Name *string `json:"name" validate:"required"`
 
-	// Property value. Can be empty and should be omitted for single_select property type.
+	// Property value. Can be empty and should be omitted for `single_select` property type.
 	Value *string `json:"value,omitempty"`
 
-	// Options for single_select property type. Only needed for single_select property type.
+	// Options for `single_select` property type. Only needed for `single_select` property type.
 	Enum []string `json:"enum,omitempty"`
-
-	// Default option for single_select property type. Only needed for single_select property type.
-	Default *string `json:"default,omitempty"`
 
 	// Property type.
 	Type *string `json:"type" validate:"required"`
 
-	// A dot notation path for integration type properties to select a value from the tool integration. If left blank the
+	// A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the
 	// full tool integration JSON will be selected.
 	Path *string `json:"path,omitempty"`
 
@@ -5457,10 +5418,6 @@ func UnmarshalTriggerPropertiesItem(m map[string]json.RawMessage, result interfa
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalPrimitive(m, "default", &obj.Default)
-	if err != nil {
-		return
-	}
 	err = core.UnmarshalPrimitive(m, "type", &obj.Type)
 	if err != nil {
 		return
@@ -5482,19 +5439,16 @@ type TriggerProperty struct {
 	// Property name.
 	Name *string `json:"name" validate:"required"`
 
-	// Property value. Can be empty and should be omitted for single_select property type.
+	// Property value. Can be empty and should be omitted for `single_select` property type.
 	Value *string `json:"value,omitempty"`
 
-	// Options for single_select property type. Only needed for single_select property type.
+	// Options for `single_select` property type. Only needed for `single_select` property type.
 	Enum []string `json:"enum,omitempty"`
-
-	// Default option for single_select property type. Only needed for single_select property type.
-	Default *string `json:"default,omitempty"`
 
 	// Property type.
 	Type *string `json:"type" validate:"required"`
 
-	// A dot notation path for integration type properties to select a value from the tool integration. If left blank the
+	// A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the
 	// full tool integration JSON will be selected.
 	Path *string `json:"path,omitempty"`
 }
@@ -5521,10 +5475,6 @@ func UnmarshalTriggerProperty(m map[string]json.RawMessage, result interface{}) 
 		return
 	}
 	err = core.UnmarshalPrimitive(m, "enum", &obj.Enum)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "default", &obj.Default)
 	if err != nil {
 		return
 	}
@@ -5607,19 +5557,16 @@ type TriggerScmTriggerPropertiesItem struct {
 	// Property name.
 	Name *string `json:"name" validate:"required"`
 
-	// Property value. Can be empty and should be omitted for single_select property type.
+	// Property value. Can be empty and should be omitted for `single_select` property type.
 	Value *string `json:"value,omitempty"`
 
-	// Options for single_select property type. Only needed for single_select property type.
+	// Options for `single_select` property type. Only needed for `single_select` property type.
 	Enum []string `json:"enum,omitempty"`
-
-	// Default option for single_select property type. Only needed for single_select property type.
-	Default *string `json:"default,omitempty"`
 
 	// Property type.
 	Type *string `json:"type" validate:"required"`
 
-	// A dot notation path for integration type properties to select a value from the tool integration. If left blank the
+	// A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the
 	// full tool integration JSON will be selected.
 	Path *string `json:"path,omitempty"`
 
@@ -5662,10 +5609,6 @@ func UnmarshalTriggerScmTriggerPropertiesItem(m map[string]json.RawMessage, resu
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalPrimitive(m, "default", &obj.Default)
-	if err != nil {
-		return
-	}
 	err = core.UnmarshalPrimitive(m, "type", &obj.Type)
 	if err != nil {
 		return
@@ -5687,19 +5630,16 @@ type TriggerTimerTriggerPropertiesItem struct {
 	// Property name.
 	Name *string `json:"name" validate:"required"`
 
-	// Property value. Can be empty and should be omitted for single_select property type.
+	// Property value. Can be empty and should be omitted for `single_select` property type.
 	Value *string `json:"value,omitempty"`
 
-	// Options for single_select property type. Only needed for single_select property type.
+	// Options for `single_select` property type. Only needed for `single_select` property type.
 	Enum []string `json:"enum,omitempty"`
-
-	// Default option for single_select property type. Only needed for single_select property type.
-	Default *string `json:"default,omitempty"`
 
 	// Property type.
 	Type *string `json:"type" validate:"required"`
 
-	// A dot notation path for integration type properties to select a value from the tool integration. If left blank the
+	// A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the
 	// full tool integration JSON will be selected.
 	Path *string `json:"path,omitempty"`
 
@@ -5739,10 +5679,6 @@ func UnmarshalTriggerTimerTriggerPropertiesItem(m map[string]json.RawMessage, re
 		return
 	}
 	err = core.UnmarshalPrimitive(m, "enum", &obj.Enum)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "default", &obj.Default)
 	if err != nil {
 		return
 	}

--- a/cdtektonpipelinev2/cd_tekton_pipeline_v2_examples_test.go
+++ b/cdtektonpipelinev2/cd_tekton_pipeline_v2_examples_test.go
@@ -186,6 +186,7 @@ var _ = Describe(`CdTektonPipelineV2 Examples Tests`, func() {
 			listTektonPipelineRunsOptions := &cdtektonpipelinev2.ListTektonPipelineRunsOptions{
 				PipelineID: core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90"),
 				Limit: core.Int64Ptr(int64(10)),
+				Offset: core.Int64Ptr(int64(38)),
 				Status: core.StringPtr("succeeded"),
 				TriggerName: core.StringPtr("manual-trigger"),
 			}

--- a/cdtektonpipelinev2/cd_tekton_pipeline_v2_examples_test.go
+++ b/cdtektonpipelinev2/cd_tekton_pipeline_v2_examples_test.go
@@ -156,10 +156,16 @@ var _ = Describe(`CdTektonPipelineV2 Examples Tests`, func() {
 				ID: core.StringPtr("public"),
 			}
 
+			tektonPipelinePatchModel := &cdtektonpipelinev2.TektonPipelinePatch{
+				Worker: workerWithIDModel,
+			}
+			tektonPipelinePatchModelAsPatch, asPatchErr := tektonPipelinePatchModel.AsPatch()
+			Expect(asPatchErr).To(BeNil())
+
 			updateTektonPipelineOptions := cdTektonPipelineService.NewUpdateTektonPipelineOptions(
 				"94619026-912b-4d92-8f51-6c74f0692d90",
 			)
-			updateTektonPipelineOptions.SetWorker(workerWithIDModel)
+			updateTektonPipelineOptions.SetTektonPipelinePatch(tektonPipelinePatchModelAsPatch)
 
 			tektonPipeline, response, err := cdTektonPipelineService.UpdateTektonPipeline(updateTektonPipelineOptions)
 			if err != nil {
@@ -415,6 +421,7 @@ var _ = Describe(`CdTektonPipelineV2 Examples Tests`, func() {
 				URL: core.StringPtr("https://github.com/IBM/tekton-tutorial.git"),
 				Branch: core.StringPtr("master"),
 				Path: core.StringPtr(".tekton"),
+				ServiceInstanceID: core.StringPtr("071d8049-d984-4feb-a2ed-2a1e938918ba"),
 			}
 
 			replaceTektonPipelineDefinitionOptions := cdTektonPipelineService.NewReplaceTektonPipelineDefinitionOptions(
@@ -422,7 +429,6 @@ var _ = Describe(`CdTektonPipelineV2 Examples Tests`, func() {
 				"94299034-d45f-4e9a-8ed5-6bd5c7bb7ada",
 			)
 			replaceTektonPipelineDefinitionOptions.SetScmSource(definitionScmSourceModel)
-			replaceTektonPipelineDefinitionOptions.SetServiceInstanceID("071d8049-d984-4feb-a2ed-2a1e938918ba")
 			replaceTektonPipelineDefinitionOptions.SetID("22f92ab1-e0ac-4c65-84e7-8a4cb32dba0f")
 
 			definition, response, err := cdTektonPipelineService.ReplaceTektonPipelineDefinition(replaceTektonPipelineDefinitionOptions)
@@ -446,7 +452,7 @@ var _ = Describe(`CdTektonPipelineV2 Examples Tests`, func() {
 				"94619026-912b-4d92-8f51-6c74f0692d90",
 			)
 			listTektonPipelinePropertiesOptions.SetName("prod")
-			listTektonPipelinePropertiesOptions.SetType([]string{"SECURE", "TEXT"})
+			listTektonPipelinePropertiesOptions.SetType([]string{"secure", "text"})
 			listTektonPipelinePropertiesOptions.SetSort("name")
 
 			propertiesCollection, response, err := cdTektonPipelineService.ListTektonPipelineProperties(listTektonPipelinePropertiesOptions)
@@ -471,7 +477,7 @@ var _ = Describe(`CdTektonPipelineV2 Examples Tests`, func() {
 			)
 			createTektonPipelinePropertiesOptions.SetName("key1")
 			createTektonPipelinePropertiesOptions.SetValue("https://github.com/IBM/tekton-tutorial.git")
-			createTektonPipelinePropertiesOptions.SetType("TEXT")
+			createTektonPipelinePropertiesOptions.SetType("text")
 
 			property, response, err := cdTektonPipelineService.CreateTektonPipelineProperties(createTektonPipelinePropertiesOptions)
 			if err != nil {
@@ -518,7 +524,7 @@ var _ = Describe(`CdTektonPipelineV2 Examples Tests`, func() {
 			)
 			replaceTektonPipelinePropertyOptions.SetName("key1")
 			replaceTektonPipelinePropertyOptions.SetValue("https://github.com/IBM/tekton-tutorial.git")
-			replaceTektonPipelinePropertyOptions.SetType("TEXT")
+			replaceTektonPipelinePropertyOptions.SetType("text")
 
 			property, response, err := cdTektonPipelineService.ReplaceTektonPipelineProperty(replaceTektonPipelinePropertyOptions)
 			if err != nil {
@@ -610,12 +616,18 @@ var _ = Describe(`CdTektonPipelineV2 Examples Tests`, func() {
 			fmt.Println("\nUpdateTektonPipelineTrigger() result:")
 			// begin-update_tekton_pipeline_trigger
 
+			triggerPatchModel := &cdtektonpipelinev2.TriggerPatch{
+				Name: core.StringPtr("start-deploy"),
+				Disabled: core.BoolPtr(true),
+			}
+			triggerPatchModelAsPatch, asPatchErr := triggerPatchModel.AsPatch()
+			Expect(asPatchErr).To(BeNil())
+
 			updateTektonPipelineTriggerOptions := cdTektonPipelineService.NewUpdateTektonPipelineTriggerOptions(
 				"94619026-912b-4d92-8f51-6c74f0692d90",
 				"1bb892a1-2e04-4768-a369-b1159eace147",
 			)
-			updateTektonPipelineTriggerOptions.SetName("start-deploy")
-			updateTektonPipelineTriggerOptions.SetDisabled(true)
+			updateTektonPipelineTriggerOptions.SetTriggerPatch(triggerPatchModelAsPatch)
 
 			trigger, response, err := cdTektonPipelineService.UpdateTektonPipelineTrigger(updateTektonPipelineTriggerOptions)
 			if err != nil {
@@ -638,7 +650,7 @@ var _ = Describe(`CdTektonPipelineV2 Examples Tests`, func() {
 				"94619026-912b-4d92-8f51-6c74f0692d90",
 				"1bb892a1-2e04-4768-a369-b1159eace147",
 				"prod",
-				"SECURE,TEXT",
+				"secure,text",
 				"name",
 			)
 
@@ -665,7 +677,7 @@ var _ = Describe(`CdTektonPipelineV2 Examples Tests`, func() {
 			)
 			createTektonPipelineTriggerPropertiesOptions.SetName("key1")
 			createTektonPipelineTriggerPropertiesOptions.SetValue("https://github.com/IBM/tekton-tutorial.git")
-			createTektonPipelineTriggerPropertiesOptions.SetType("TEXT")
+			createTektonPipelineTriggerPropertiesOptions.SetType("text")
 
 			triggerProperty, response, err := cdTektonPipelineService.CreateTektonPipelineTriggerProperties(createTektonPipelineTriggerPropertiesOptions)
 			if err != nil {
@@ -714,7 +726,7 @@ var _ = Describe(`CdTektonPipelineV2 Examples Tests`, func() {
 			)
 			replaceTektonPipelineTriggerPropertyOptions.SetName("key1")
 			replaceTektonPipelineTriggerPropertyOptions.SetValue("https://github.com/IBM/tekton-tutorial.git")
-			replaceTektonPipelineTriggerPropertyOptions.SetType("TEXT")
+			replaceTektonPipelineTriggerPropertyOptions.SetType("text")
 
 			triggerProperty, response, err := cdTektonPipelineService.ReplaceTektonPipelineTriggerProperty(replaceTektonPipelineTriggerPropertyOptions)
 			if err != nil {

--- a/cdtektonpipelinev2/cd_tekton_pipeline_v2_examples_test.go
+++ b/cdtektonpipelinev2/cd_tekton_pipeline_v2_examples_test.go
@@ -569,30 +569,18 @@ var _ = Describe(`CdTektonPipelineV2 Examples Tests`, func() {
 			// begin-create_tekton_pipeline_trigger
 
 			workerModel := &cdtektonpipelinev2.Worker{
-				ID: core.StringPtr("5df804a4-9d7b-44e1-874f-3810866fb80b"),
-			}
-
-			genericSecretModel := &cdtektonpipelinev2.GenericSecret{
-				Type: core.StringPtr("token_matches"),
-				Value: core.StringPtr("secret"),
-				Source: core.StringPtr("query"),
-				KeyName: core.StringPtr("auth"),
-			}
-
-			triggerModel := &cdtektonpipelinev2.TriggerGenericTrigger{
-				Type: core.StringPtr("generic"),
-				Name: core.StringPtr("Generic Webhook Trigger"),
-				EventListener: core.StringPtr("pr-listener"),
-				Tags: []string{"prod", "dev"},
-				Worker: workerModel,
-				Disabled: core.BoolPtr(false),
-				Secret: genericSecretModel,
+				ID: core.StringPtr("public"),
 			}
 
 			createTektonPipelineTriggerOptions := cdTektonPipelineService.NewCreateTektonPipelineTriggerOptions(
 				"94619026-912b-4d92-8f51-6c74f0692d90",
 			)
-			createTektonPipelineTriggerOptions.SetTrigger(triggerModel)
+			createTektonPipelineTriggerOptions.SetType("manual")
+			createTektonPipelineTriggerOptions.SetName("Manual Trigger")
+			createTektonPipelineTriggerOptions.SetEventListener("pr-listener")
+			createTektonPipelineTriggerOptions.SetWorker(workerModel)
+			createTektonPipelineTriggerOptions.SetMaxConcurrentRuns(int64(3))
+			createTektonPipelineTriggerOptions.SetDisabled(false)
 
 			trigger, response, err := cdTektonPipelineService.CreateTektonPipelineTrigger(createTektonPipelineTriggerOptions)
 			if err != nil {

--- a/cdtektonpipelinev2/cd_tekton_pipeline_v2_examples_test.go
+++ b/cdtektonpipelinev2/cd_tekton_pipeline_v2_examples_test.go
@@ -568,9 +568,25 @@ var _ = Describe(`CdTektonPipelineV2 Examples Tests`, func() {
 			fmt.Println("\nCreateTektonPipelineTrigger() result:")
 			// begin-create_tekton_pipeline_trigger
 
-			triggerModel := &cdtektonpipelinev2.TriggerDuplicateTrigger{
-				SourceTriggerID: core.StringPtr("b3a8228f-1c82-409b-b249-7639166a0300"),
-				Name: core.StringPtr("Trigger Name"),
+			workerModel := &cdtektonpipelinev2.Worker{
+				ID: core.StringPtr("5df804a4-9d7b-44e1-874f-3810866fb80b"),
+			}
+
+			genericSecretModel := &cdtektonpipelinev2.GenericSecret{
+				Type: core.StringPtr("token_matches"),
+				Value: core.StringPtr("secret"),
+				Source: core.StringPtr("query"),
+				KeyName: core.StringPtr("auth"),
+			}
+
+			triggerModel := &cdtektonpipelinev2.TriggerGenericTrigger{
+				Type: core.StringPtr("generic"),
+				Name: core.StringPtr("Generic Webhook Trigger"),
+				EventListener: core.StringPtr("pr-listener"),
+				Tags: []string{"prod", "dev"},
+				Worker: workerModel,
+				Disabled: core.BoolPtr(false),
+				Secret: genericSecretModel,
 			}
 
 			createTektonPipelineTriggerOptions := cdTektonPipelineService.NewCreateTektonPipelineTriggerOptions(
@@ -641,6 +657,29 @@ var _ = Describe(`CdTektonPipelineV2 Examples Tests`, func() {
 
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
+			Expect(trigger).ToNot(BeNil())
+		})
+		It(`DuplicateTektonPipelineTrigger request example`, func() {
+			fmt.Println("\nDuplicateTektonPipelineTrigger() result:")
+			// begin-duplicate_tekton_pipeline_trigger
+
+			duplicateTektonPipelineTriggerOptions := cdTektonPipelineService.NewDuplicateTektonPipelineTriggerOptions(
+				"94619026-912b-4d92-8f51-6c74f0692d90",
+				"1bb892a1-2e04-4768-a369-b1159eace147",
+			)
+			duplicateTektonPipelineTriggerOptions.SetName("triggerName")
+
+			trigger, response, err := cdTektonPipelineService.DuplicateTektonPipelineTrigger(duplicateTektonPipelineTriggerOptions)
+			if err != nil {
+				panic(err)
+			}
+			b, _ := json.MarshalIndent(trigger, "", "  ")
+			fmt.Println(string(b))
+
+			// end-duplicate_tekton_pipeline_trigger
+
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(201))
 			Expect(trigger).ToNot(BeNil())
 		})
 		It(`ListTektonPipelineTriggerProperties request example`, func() {

--- a/cdtektonpipelinev2/cd_tekton_pipeline_v2_examples_test.go
+++ b/cdtektonpipelinev2/cd_tekton_pipeline_v2_examples_test.go
@@ -189,7 +189,7 @@ var _ = Describe(`CdTektonPipelineV2 Examples Tests`, func() {
 				panic(err)
 			}
 
-			var allResults []cdtektonpipelinev2.PipelineRunsPipelineRunsItem
+			var allResults []cdtektonpipelinev2.PipelineRunsCollectionPipelineRunsItem
 			for pager.HasNext() {
 				nextPage, err := pager.GetNext()
 				if err != nil {
@@ -300,18 +300,18 @@ var _ = Describe(`CdTektonPipelineV2 Examples Tests`, func() {
 				"94619026-912b-4d92-8f51-6c74f0692d90",
 			)
 
-			pipelineRunLogs, response, err := cdTektonPipelineService.GetTektonPipelineRunLogs(getTektonPipelineRunLogsOptions)
+			logsCollection, response, err := cdTektonPipelineService.GetTektonPipelineRunLogs(getTektonPipelineRunLogsOptions)
 			if err != nil {
 				panic(err)
 			}
-			b, _ := json.MarshalIndent(pipelineRunLogs, "", "  ")
+			b, _ := json.MarshalIndent(logsCollection, "", "  ")
 			fmt.Println(string(b))
 
 			// end-get_tekton_pipeline_run_logs
 
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
-			Expect(pipelineRunLogs).ToNot(BeNil())
+			Expect(logsCollection).ToNot(BeNil())
 		})
 		It(`GetTektonPipelineRunLogContent request example`, func() {
 			fmt.Println("\nGetTektonPipelineRunLogContent() result:")
@@ -323,18 +323,18 @@ var _ = Describe(`CdTektonPipelineV2 Examples Tests`, func() {
 				"94619026-912b-4d92-8f51-6c74f0692d90",
 			)
 
-			stepLog, response, err := cdTektonPipelineService.GetTektonPipelineRunLogContent(getTektonPipelineRunLogContentOptions)
+			log, response, err := cdTektonPipelineService.GetTektonPipelineRunLogContent(getTektonPipelineRunLogContentOptions)
 			if err != nil {
 				panic(err)
 			}
-			b, _ := json.MarshalIndent(stepLog, "", "  ")
+			b, _ := json.MarshalIndent(log, "", "  ")
 			fmt.Println(string(b))
 
 			// end-get_tekton_pipeline_run_log_content
 
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
-			Expect(stepLog).ToNot(BeNil())
+			Expect(log).ToNot(BeNil())
 		})
 		It(`ListTektonPipelineDefinitions request example`, func() {
 			fmt.Println("\nListTektonPipelineDefinitions() result:")
@@ -344,18 +344,18 @@ var _ = Describe(`CdTektonPipelineV2 Examples Tests`, func() {
 				"94619026-912b-4d92-8f51-6c74f0692d90",
 			)
 
-			definitions, response, err := cdTektonPipelineService.ListTektonPipelineDefinitions(listTektonPipelineDefinitionsOptions)
+			definitionsCollection, response, err := cdTektonPipelineService.ListTektonPipelineDefinitions(listTektonPipelineDefinitionsOptions)
 			if err != nil {
 				panic(err)
 			}
-			b, _ := json.MarshalIndent(definitions, "", "  ")
+			b, _ := json.MarshalIndent(definitionsCollection, "", "  ")
 			fmt.Println(string(b))
 
 			// end-list_tekton_pipeline_definitions
 
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
-			Expect(definitions).ToNot(BeNil())
+			Expect(definitionsCollection).ToNot(BeNil())
 		})
 		It(`CreateTektonPipelineDefinition request example`, func() {
 			fmt.Println("\nCreateTektonPipelineDefinition() result:")
@@ -449,18 +449,18 @@ var _ = Describe(`CdTektonPipelineV2 Examples Tests`, func() {
 			listTektonPipelinePropertiesOptions.SetType([]string{"SECURE", "TEXT"})
 			listTektonPipelinePropertiesOptions.SetSort("name")
 
-			envProperties, response, err := cdTektonPipelineService.ListTektonPipelineProperties(listTektonPipelinePropertiesOptions)
+			propertiesCollection, response, err := cdTektonPipelineService.ListTektonPipelineProperties(listTektonPipelinePropertiesOptions)
 			if err != nil {
 				panic(err)
 			}
-			b, _ := json.MarshalIndent(envProperties, "", "  ")
+			b, _ := json.MarshalIndent(propertiesCollection, "", "  ")
 			fmt.Println(string(b))
 
 			// end-list_tekton_pipeline_properties
 
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
-			Expect(envProperties).ToNot(BeNil())
+			Expect(propertiesCollection).ToNot(BeNil())
 		})
 		It(`CreateTektonPipelineProperties request example`, func() {
 			fmt.Println("\nCreateTektonPipelineProperties() result:")
@@ -544,18 +544,18 @@ var _ = Describe(`CdTektonPipelineV2 Examples Tests`, func() {
 			listTektonPipelineTriggersOptions.SetDisabled("true")
 			listTektonPipelineTriggersOptions.SetTags("tag1,tag2")
 
-			triggers, response, err := cdTektonPipelineService.ListTektonPipelineTriggers(listTektonPipelineTriggersOptions)
+			triggersCollection, response, err := cdTektonPipelineService.ListTektonPipelineTriggers(listTektonPipelineTriggersOptions)
 			if err != nil {
 				panic(err)
 			}
-			b, _ := json.MarshalIndent(triggers, "", "  ")
+			b, _ := json.MarshalIndent(triggersCollection, "", "  ")
 			fmt.Println(string(b))
 
 			// end-list_tekton_pipeline_triggers
 
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
-			Expect(triggers).ToNot(BeNil())
+			Expect(triggersCollection).ToNot(BeNil())
 		})
 		It(`CreateTektonPipelineTrigger request example`, func() {
 			fmt.Println("\nCreateTektonPipelineTrigger() result:")
@@ -563,7 +563,7 @@ var _ = Describe(`CdTektonPipelineV2 Examples Tests`, func() {
 
 			triggerModel := &cdtektonpipelinev2.TriggerDuplicateTrigger{
 				SourceTriggerID: core.StringPtr("b3a8228f-1c82-409b-b249-7639166a0300"),
-				Name: core.StringPtr("Generic Trigger- duplicated"),
+				Name: core.StringPtr("Trigger Name"),
 			}
 
 			createTektonPipelineTriggerOptions := cdTektonPipelineService.NewCreateTektonPipelineTriggerOptions(
@@ -642,18 +642,18 @@ var _ = Describe(`CdTektonPipelineV2 Examples Tests`, func() {
 				"name",
 			)
 
-			triggerProperties, response, err := cdTektonPipelineService.ListTektonPipelineTriggerProperties(listTektonPipelineTriggerPropertiesOptions)
+			triggerPropertiesCollection, response, err := cdTektonPipelineService.ListTektonPipelineTriggerProperties(listTektonPipelineTriggerPropertiesOptions)
 			if err != nil {
 				panic(err)
 			}
-			b, _ := json.MarshalIndent(triggerProperties, "", "  ")
+			b, _ := json.MarshalIndent(triggerPropertiesCollection, "", "  ")
 			fmt.Println(string(b))
 
 			// end-list_tekton_pipeline_trigger_properties
 
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
-			Expect(triggerProperties).ToNot(BeNil())
+			Expect(triggerPropertiesCollection).ToNot(BeNil())
 		})
 		It(`CreateTektonPipelineTriggerProperties request example`, func() {
 			fmt.Println("\nCreateTektonPipelineTriggerProperties() result:")

--- a/cdtektonpipelinev2/cd_tekton_pipeline_v2_integration_test.go
+++ b/cdtektonpipelinev2/cd_tekton_pipeline_v2_integration_test.go
@@ -531,46 +531,49 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 			shouldSkipTest()
 		})
 		It(`CreateTektonPipelineTrigger(createTektonPipelineTriggerOptions *CreateTektonPipelineTriggerOptions)`, func() {
-			triggerGenericTriggerPropertiesItemModel := &cdtektonpipelinev2.TriggerGenericTriggerPropertiesItem{
-				Name: core.StringPtr("testString"),
-				Value: core.StringPtr("testString"),
-				Enum: []string{"testString"},
-				Type: core.StringPtr("secure"),
-				Path: core.StringPtr("testString"),
-				Href: core.StringPtr("testString"),
-			}
-
 			workerModel := &cdtektonpipelinev2.Worker{
 				Name: core.StringPtr("testString"),
 				Type: core.StringPtr("private"),
-				ID: core.StringPtr("5df804a4-9d7b-44e1-874f-3810866fb80b"),
+				ID: core.StringPtr("public"),
 			}
 
 			genericSecretModel := &cdtektonpipelinev2.GenericSecret{
 				Type: core.StringPtr("token_matches"),
-				Value: core.StringPtr("secret"),
-				Source: core.StringPtr("query"),
-				KeyName: core.StringPtr("auth"),
+				Value: core.StringPtr("testString"),
+				Source: core.StringPtr("header"),
+				KeyName: core.StringPtr("testString"),
 				Algorithm: core.StringPtr("md4"),
 			}
 
-			triggerModel := &cdtektonpipelinev2.TriggerGenericTrigger{
-				Type: core.StringPtr("generic"),
-				Name: core.StringPtr("Generic Webhook Trigger"),
-				Href: core.StringPtr("testString"),
-				EventListener: core.StringPtr("pr-listener"),
-				ID: core.StringPtr("testString"),
-				Properties: []cdtektonpipelinev2.TriggerGenericTriggerPropertiesItem{*triggerGenericTriggerPropertiesItemModel},
-				Tags: []string{"prod", "dev"},
-				Worker: workerModel,
-				MaxConcurrentRuns: core.Int64Ptr(int64(4)),
-				Disabled: core.BoolPtr(false),
-				Secret: genericSecretModel,
+			triggerScmSourceModel := &cdtektonpipelinev2.TriggerScmSource{
+				URL: core.StringPtr("testString"),
+				Branch: core.StringPtr("testString"),
+				Pattern: core.StringPtr("testString"),
+				BlindConnection: core.BoolPtr(true),
+				HookID: core.StringPtr("testString"),
+				ServiceInstanceID: core.StringPtr("testString"),
+			}
+
+			eventsModel := &cdtektonpipelinev2.Events{
+				Push: core.BoolPtr(true),
+				PullRequestClosed: core.BoolPtr(true),
+				PullRequest: core.BoolPtr(true),
 			}
 
 			createTektonPipelineTriggerOptions := &cdtektonpipelinev2.CreateTektonPipelineTriggerOptions{
 				PipelineID: core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90"),
-				Trigger: triggerModel,
+				Type: core.StringPtr("manual"),
+				Name: core.StringPtr("Manual Trigger"),
+				EventListener: core.StringPtr("pr-listener"),
+				Tags: []string{"testString"},
+				Worker: workerModel,
+				MaxConcurrentRuns: core.Int64Ptr(int64(3)),
+				Disabled: core.BoolPtr(false),
+				Secret: genericSecretModel,
+				Cron: core.StringPtr("testString"),
+				Timezone: core.StringPtr("testString"),
+				ScmSource: triggerScmSourceModel,
+				Events: eventsModel,
 			}
 
 			trigger, response, err := cdTektonPipelineService.CreateTektonPipelineTrigger(createTektonPipelineTriggerOptions)

--- a/cdtektonpipelinev2/cd_tekton_pipeline_v2_integration_test.go
+++ b/cdtektonpipelinev2/cd_tekton_pipeline_v2_integration_test.go
@@ -166,13 +166,14 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 		It(`ListTektonPipelineRuns(listTektonPipelineRunsOptions *ListTektonPipelineRunsOptions) with pagination`, func(){
 			listTektonPipelineRunsOptions := &cdtektonpipelinev2.ListTektonPipelineRunsOptions{
 				PipelineID: core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90"),
+				Start: core.StringPtr("testString"),
 				Limit: core.Int64Ptr(int64(10)),
 				Offset: core.Int64Ptr(int64(38)),
 				Status: core.StringPtr("succeeded"),
 				TriggerName: core.StringPtr("manual-trigger"),
 			}
 
-			listTektonPipelineRunsOptions.Offset = nil
+			listTektonPipelineRunsOptions.Start = nil
 			listTektonPipelineRunsOptions.Limit = core.Int64Ptr(1)
 
 			var allResults []cdtektonpipelinev2.PipelineRunsCollectionPipelineRunsItem
@@ -183,10 +184,10 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 				Expect(pipelineRunsCollection).ToNot(BeNil())
 				allResults = append(allResults, pipelineRunsCollection.PipelineRuns...)
 
-				listTektonPipelineRunsOptions.Offset, err = pipelineRunsCollection.GetNextOffset()
+				listTektonPipelineRunsOptions.Start, err = pipelineRunsCollection.GetNextStart()
 				Expect(err).To(BeNil())
 
-				if listTektonPipelineRunsOptions.Offset == nil {
+				if listTektonPipelineRunsOptions.Start == nil {
 					break
 				}
 			}
@@ -196,6 +197,7 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 			listTektonPipelineRunsOptions := &cdtektonpipelinev2.ListTektonPipelineRunsOptions{
 				PipelineID: core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90"),
 				Limit: core.Int64Ptr(int64(10)),
+				Offset: core.Int64Ptr(int64(38)),
 				Status: core.StringPtr("succeeded"),
 				TriggerName: core.StringPtr("manual-trigger"),
 			}

--- a/cdtektonpipelinev2/cd_tekton_pipeline_v2_integration_test.go
+++ b/cdtektonpipelinev2/cd_tekton_pipeline_v2_integration_test.go
@@ -137,9 +137,15 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 				ID: core.StringPtr("public"),
 			}
 
+			tektonPipelinePatchModel := &cdtektonpipelinev2.TektonPipelinePatch{
+				Worker: workerWithIDModel,
+			}
+			tektonPipelinePatchModelAsPatch, asPatchErr := tektonPipelinePatchModel.AsPatch()
+			Expect(asPatchErr).To(BeNil())
+
 			updateTektonPipelineOptions := &cdtektonpipelinev2.UpdateTektonPipelineOptions{
 				ID: core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90"),
-				Worker: workerWithIDModel,
+				TektonPipelinePatch: tektonPipelinePatchModelAsPatch,
 			}
 
 			tektonPipeline, response, err := cdTektonPipelineService.UpdateTektonPipeline(updateTektonPipelineOptions)
@@ -291,7 +297,7 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`GetTektonPipelineRunLogs - Get a list of pipeline run log IDs`, func() {
+	Describe(`GetTektonPipelineRunLogs - Get a list of pipeline run log objects`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
@@ -352,12 +358,12 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 				Branch: core.StringPtr("master"),
 				Tag: core.StringPtr("testString"),
 				Path: core.StringPtr(".tekton"),
+				ServiceInstanceID: core.StringPtr("testString"),
 			}
 
 			createTektonPipelineDefinitionOptions := &cdtektonpipelinev2.CreateTektonPipelineDefinitionOptions{
 				PipelineID: core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90"),
 				ScmSource: definitionScmSourceModel,
-				ServiceInstanceID: core.StringPtr("testString"),
 				ID: core.StringPtr("testString"),
 			}
 
@@ -395,13 +401,13 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 				Branch: core.StringPtr("master"),
 				Tag: core.StringPtr("testString"),
 				Path: core.StringPtr(".tekton"),
+				ServiceInstanceID: core.StringPtr("071d8049-d984-4feb-a2ed-2a1e938918ba"),
 			}
 
 			replaceTektonPipelineDefinitionOptions := &cdtektonpipelinev2.ReplaceTektonPipelineDefinitionOptions{
 				PipelineID: core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90"),
 				DefinitionID: core.StringPtr("94299034-d45f-4e9a-8ed5-6bd5c7bb7ada"),
 				ScmSource: definitionScmSourceModel,
-				ServiceInstanceID: core.StringPtr("071d8049-d984-4feb-a2ed-2a1e938918ba"),
 				ID: core.StringPtr("22f92ab1-e0ac-4c65-84e7-8a4cb32dba0f"),
 			}
 
@@ -420,7 +426,7 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 			listTektonPipelinePropertiesOptions := &cdtektonpipelinev2.ListTektonPipelinePropertiesOptions{
 				PipelineID: core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90"),
 				Name: core.StringPtr("prod"),
-				Type: []string{"SECURE", "TEXT"},
+				Type: []string{"secure", "text"},
 				Sort: core.StringPtr("name"),
 			}
 
@@ -442,7 +448,7 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 				Value: core.StringPtr("https://github.com/IBM/tekton-tutorial.git"),
 				Enum: []string{"testString"},
 				Default: core.StringPtr("testString"),
-				Type: core.StringPtr("TEXT"),
+				Type: core.StringPtr("text"),
 				Path: core.StringPtr("testString"),
 			}
 
@@ -482,7 +488,7 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 				Value: core.StringPtr("https://github.com/IBM/tekton-tutorial.git"),
 				Enum: []string{"testString"},
 				Default: core.StringPtr("testString"),
-				Type: core.StringPtr("TEXT"),
+				Type: core.StringPtr("text"),
 				Path: core.StringPtr("testString"),
 			}
 
@@ -567,7 +573,7 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 			}
 
 			genericSecretModel := &cdtektonpipelinev2.GenericSecret{
-				Type: core.StringPtr("tokenMatches"),
+				Type: core.StringPtr("token_matches"),
 				Value: core.StringPtr("testString"),
 				Source: core.StringPtr("header"),
 				KeyName: core.StringPtr("testString"),
@@ -580,6 +586,7 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 				Pattern: core.StringPtr("testString"),
 				BlindConnection: core.BoolPtr(true),
 				HookID: core.StringPtr("testString"),
+				ServiceInstanceID: core.StringPtr("testString"),
 			}
 
 			eventsModel := &cdtektonpipelinev2.Events{
@@ -588,21 +595,27 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 				PullRequest: core.BoolPtr(true),
 			}
 
-			updateTektonPipelineTriggerOptions := &cdtektonpipelinev2.UpdateTektonPipelineTriggerOptions{
-				PipelineID: core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90"),
-				TriggerID: core.StringPtr("1bb892a1-2e04-4768-a369-b1159eace147"),
+			triggerPatchModel := &cdtektonpipelinev2.TriggerPatch{
 				Type: core.StringPtr("manual"),
 				Name: core.StringPtr("start-deploy"),
 				EventListener: core.StringPtr("testString"),
 				Tags: []string{"testString"},
 				Worker: workerModel,
-				MaxConcurrentRuns: core.Int64Ptr(int64(38)),
+				MaxConcurrentRuns: core.Int64Ptr(int64(4)),
 				Disabled: core.BoolPtr(true),
 				Secret: genericSecretModel,
 				Cron: core.StringPtr("testString"),
-				Timezone: core.StringPtr("Africa/Abidjan"),
+				Timezone: core.StringPtr("America/Los_Angeles, CET, Europe/London, GMT, US/Eastern, or UTC"),
 				ScmSource: triggerScmSourceModel,
 				Events: eventsModel,
+			}
+			triggerPatchModelAsPatch, asPatchErr := triggerPatchModel.AsPatch()
+			Expect(asPatchErr).To(BeNil())
+
+			updateTektonPipelineTriggerOptions := &cdtektonpipelinev2.UpdateTektonPipelineTriggerOptions{
+				PipelineID: core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90"),
+				TriggerID: core.StringPtr("1bb892a1-2e04-4768-a369-b1159eace147"),
+				TriggerPatch: triggerPatchModelAsPatch,
 			}
 
 			trigger, response, err := cdTektonPipelineService.UpdateTektonPipelineTrigger(updateTektonPipelineTriggerOptions)
@@ -621,7 +634,7 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 				PipelineID: core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90"),
 				TriggerID: core.StringPtr("1bb892a1-2e04-4768-a369-b1159eace147"),
 				Name: core.StringPtr("prod"),
-				Type: core.StringPtr("SECURE,TEXT"),
+				Type: core.StringPtr("secure,text"),
 				Sort: core.StringPtr("name"),
 			}
 
@@ -644,7 +657,7 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 				Value: core.StringPtr("https://github.com/IBM/tekton-tutorial.git"),
 				Enum: []string{"testString"},
 				Default: core.StringPtr("testString"),
-				Type: core.StringPtr("TEXT"),
+				Type: core.StringPtr("text"),
 				Path: core.StringPtr("testString"),
 			}
 
@@ -686,7 +699,7 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 				Value: core.StringPtr("https://github.com/IBM/tekton-tutorial.git"),
 				Enum: []string{"testString"},
 				Default: core.StringPtr("testString"),
-				Type: core.StringPtr("TEXT"),
+				Type: core.StringPtr("text"),
 				Path: core.StringPtr("testString"),
 			}
 

--- a/cdtektonpipelinev2/cd_tekton_pipeline_v2_integration_test.go
+++ b/cdtektonpipelinev2/cd_tekton_pipeline_v2_integration_test.go
@@ -91,7 +91,7 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`CreateTektonPipeline - Create tekton pipeline`, func() {
+	Describe(`CreateTektonPipeline - Create Tekton pipeline`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
@@ -112,7 +112,7 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`GetTektonPipeline - Get tekton pipeline data`, func() {
+	Describe(`GetTektonPipeline - Get Tekton pipeline data`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
@@ -128,7 +128,7 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`UpdateTektonPipeline - Update tekton pipeline data`, func() {
+	Describe(`UpdateTektonPipeline - Update Tekton pipeline data`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
@@ -165,15 +165,15 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 			listTektonPipelineRunsOptions.Offset = nil
 			listTektonPipelineRunsOptions.Limit = core.Int64Ptr(1)
 
-			var allResults []cdtektonpipelinev2.PipelineRunsPipelineRunsItem
+			var allResults []cdtektonpipelinev2.PipelineRunsCollectionPipelineRunsItem
 			for {
-				pipelineRuns, response, err := cdTektonPipelineService.ListTektonPipelineRuns(listTektonPipelineRunsOptions)
+				pipelineRunsCollection, response, err := cdTektonPipelineService.ListTektonPipelineRuns(listTektonPipelineRunsOptions)
 				Expect(err).To(BeNil())
 				Expect(response.StatusCode).To(Equal(200))
-				Expect(pipelineRuns).ToNot(BeNil())
-				allResults = append(allResults, pipelineRuns.PipelineRuns...)
+				Expect(pipelineRunsCollection).ToNot(BeNil())
+				allResults = append(allResults, pipelineRunsCollection.PipelineRuns...)
 
-				listTektonPipelineRunsOptions.Offset, err = pipelineRuns.GetNextOffset()
+				listTektonPipelineRunsOptions.Offset, err = pipelineRunsCollection.GetNextOffset()
 				Expect(err).To(BeNil())
 
 				if listTektonPipelineRunsOptions.Offset == nil {
@@ -195,7 +195,7 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 			Expect(err).To(BeNil())
 			Expect(pager).ToNot(BeNil())
 
-			var allResults []cdtektonpipelinev2.PipelineRunsPipelineRunsItem
+			var allResults []cdtektonpipelinev2.PipelineRunsCollectionPipelineRunsItem
 			for pager.HasNext() {
 				nextPage, err := pager.GetNext()
 				Expect(err).To(BeNil())
@@ -217,7 +217,7 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`CreateTektonPipelineRun - Start a trigger to create a pipelineRun`, func() {
+	Describe(`CreateTektonPipelineRun - Trigger a pipeline run`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
@@ -301,14 +301,14 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 				ID: core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90"),
 			}
 
-			pipelineRunLogs, response, err := cdTektonPipelineService.GetTektonPipelineRunLogs(getTektonPipelineRunLogsOptions)
+			logsCollection, response, err := cdTektonPipelineService.GetTektonPipelineRunLogs(getTektonPipelineRunLogsOptions)
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
-			Expect(pipelineRunLogs).ToNot(BeNil())
+			Expect(logsCollection).ToNot(BeNil())
 		})
 	})
 
-	Describe(`GetTektonPipelineRunLogContent - Get the log content of a pipeline run step by using the step log ID`, func() {
+	Describe(`GetTektonPipelineRunLogContent - Get the log content of a pipeline run step`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
@@ -319,10 +319,10 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 				ID: core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90"),
 			}
 
-			stepLog, response, err := cdTektonPipelineService.GetTektonPipelineRunLogContent(getTektonPipelineRunLogContentOptions)
+			log, response, err := cdTektonPipelineService.GetTektonPipelineRunLogContent(getTektonPipelineRunLogContentOptions)
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
-			Expect(stepLog).ToNot(BeNil())
+			Expect(log).ToNot(BeNil())
 		})
 	})
 
@@ -335,10 +335,10 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 				PipelineID: core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90"),
 			}
 
-			definitions, response, err := cdTektonPipelineService.ListTektonPipelineDefinitions(listTektonPipelineDefinitionsOptions)
+			definitionsCollection, response, err := cdTektonPipelineService.ListTektonPipelineDefinitions(listTektonPipelineDefinitionsOptions)
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
-			Expect(definitions).ToNot(BeNil())
+			Expect(definitionsCollection).ToNot(BeNil())
 		})
 	})
 
@@ -357,6 +357,8 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 			createTektonPipelineDefinitionOptions := &cdtektonpipelinev2.CreateTektonPipelineDefinitionOptions{
 				PipelineID: core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90"),
 				ScmSource: definitionScmSourceModel,
+				ServiceInstanceID: core.StringPtr("testString"),
+				ID: core.StringPtr("testString"),
 			}
 
 			definition, response, err := cdTektonPipelineService.CreateTektonPipelineDefinition(createTektonPipelineDefinitionOptions)
@@ -410,7 +412,7 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`ListTektonPipelineProperties - List pipeline environment properties`, func() {
+	Describe(`ListTektonPipelineProperties - List the pipeline's environment properties`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
@@ -422,14 +424,14 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 				Sort: core.StringPtr("name"),
 			}
 
-			envProperties, response, err := cdTektonPipelineService.ListTektonPipelineProperties(listTektonPipelinePropertiesOptions)
+			propertiesCollection, response, err := cdTektonPipelineService.ListTektonPipelineProperties(listTektonPipelinePropertiesOptions)
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
-			Expect(envProperties).ToNot(BeNil())
+			Expect(propertiesCollection).ToNot(BeNil())
 		})
 	})
 
-	Describe(`CreateTektonPipelineProperties - Create pipeline environment property`, func() {
+	Describe(`CreateTektonPipelineProperties - Create a pipeline environment property`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
@@ -451,7 +453,7 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`GetTektonPipelineProperty - Get a single pipeline environment property`, func() {
+	Describe(`GetTektonPipelineProperty - Get a pipeline environment property`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
@@ -468,7 +470,7 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`ReplaceTektonPipelineProperty - Replace a single pipeline environment property value`, func() {
+	Describe(`ReplaceTektonPipelineProperty - Replace the value of an environment property`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
@@ -507,10 +509,10 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 				Tags: core.StringPtr("tag1,tag2"),
 			}
 
-			triggers, response, err := cdTektonPipelineService.ListTektonPipelineTriggers(listTektonPipelineTriggersOptions)
+			triggersCollection, response, err := cdTektonPipelineService.ListTektonPipelineTriggers(listTektonPipelineTriggersOptions)
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
-			Expect(triggers).ToNot(BeNil())
+			Expect(triggersCollection).ToNot(BeNil())
 		})
 	})
 
@@ -521,7 +523,7 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 		It(`CreateTektonPipelineTrigger(createTektonPipelineTriggerOptions *CreateTektonPipelineTriggerOptions)`, func() {
 			triggerModel := &cdtektonpipelinev2.TriggerDuplicateTrigger{
 				SourceTriggerID: core.StringPtr("b3a8228f-1c82-409b-b249-7639166a0300"),
-				Name: core.StringPtr("Generic Trigger- duplicated"),
+				Name: core.StringPtr("Trigger Name"),
 			}
 
 			createTektonPipelineTriggerOptions := &cdtektonpipelinev2.CreateTektonPipelineTriggerOptions{
@@ -553,7 +555,7 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`UpdateTektonPipelineTrigger - Edit a single trigger entry`, func() {
+	Describe(`UpdateTektonPipelineTrigger - Edit a trigger`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
@@ -562,10 +564,6 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 				Name: core.StringPtr("testString"),
 				Type: core.StringPtr("private"),
 				ID: core.StringPtr("testString"),
-			}
-
-			concurrencyModel := &cdtektonpipelinev2.Concurrency{
-				MaxConcurrentRuns: core.Int64Ptr(int64(20)),
 			}
 
 			genericSecretModel := &cdtektonpipelinev2.GenericSecret{
@@ -598,7 +596,7 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 				EventListener: core.StringPtr("testString"),
 				Tags: []string{"testString"},
 				Worker: workerModel,
-				Concurrency: concurrencyModel,
+				MaxConcurrentRuns: core.Int64Ptr(int64(38)),
 				Disabled: core.BoolPtr(true),
 				Secret: genericSecretModel,
 				Cron: core.StringPtr("testString"),
@@ -614,7 +612,7 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`ListTektonPipelineTriggerProperties - List trigger environment properties`, func() {
+	Describe(`ListTektonPipelineTriggerProperties - List trigger properties`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
@@ -627,14 +625,14 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 				Sort: core.StringPtr("name"),
 			}
 
-			triggerProperties, response, err := cdTektonPipelineService.ListTektonPipelineTriggerProperties(listTektonPipelineTriggerPropertiesOptions)
+			triggerPropertiesCollection, response, err := cdTektonPipelineService.ListTektonPipelineTriggerProperties(listTektonPipelineTriggerPropertiesOptions)
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
-			Expect(triggerProperties).ToNot(BeNil())
+			Expect(triggerPropertiesCollection).ToNot(BeNil())
 		})
 	})
 
-	Describe(`CreateTektonPipelineTriggerProperties - Create trigger's environment property`, func() {
+	Describe(`CreateTektonPipelineTriggerProperties - Create a trigger property`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
@@ -657,7 +655,7 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`GetTektonPipelineTriggerProperty - Get a trigger's environment property`, func() {
+	Describe(`GetTektonPipelineTriggerProperty - Get a trigger property`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
@@ -675,7 +673,7 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`ReplaceTektonPipelineTriggerProperty - Replace a trigger's environment property value`, func() {
+	Describe(`ReplaceTektonPipelineTriggerProperty - Replace a trigger property value`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
@@ -699,7 +697,7 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`DeleteTektonPipelineTriggerProperty - Delete a trigger's property`, func() {
+	Describe(`DeleteTektonPipelineTriggerProperty - Delete a trigger property`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
@@ -780,7 +778,7 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`DeleteTektonPipeline - Delete tekton pipeline instance`, func() {
+	Describe(`DeleteTektonPipeline - Delete Tekton pipeline instance`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})

--- a/cdtektonpipelinev2/cd_tekton_pipeline_v2_integration_test.go
+++ b/cdtektonpipelinev2/cd_tekton_pipeline_v2_integration_test.go
@@ -138,6 +138,9 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 			}
 
 			tektonPipelinePatchModel := &cdtektonpipelinev2.TektonPipelinePatch{
+				EnableSlackNotifications: core.BoolPtr(true),
+				EnablePartialCloning: core.BoolPtr(true),
+				Enabled: core.BoolPtr(true),
 				Worker: workerWithIDModel,
 			}
 			tektonPipelinePatchModelAsPatch, asPatchErr := tektonPipelinePatchModel.AsPatch()
@@ -447,7 +450,6 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 				Name: core.StringPtr("key1"),
 				Value: core.StringPtr("https://github.com/IBM/tekton-tutorial.git"),
 				Enum: []string{"testString"},
-				Default: core.StringPtr("testString"),
 				Type: core.StringPtr("text"),
 				Path: core.StringPtr("testString"),
 			}
@@ -487,7 +489,6 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 				Name: core.StringPtr("key1"),
 				Value: core.StringPtr("https://github.com/IBM/tekton-tutorial.git"),
 				Enum: []string{"testString"},
-				Default: core.StringPtr("testString"),
 				Type: core.StringPtr("text"),
 				Path: core.StringPtr("testString"),
 			}
@@ -656,7 +657,6 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 				Name: core.StringPtr("key1"),
 				Value: core.StringPtr("https://github.com/IBM/tekton-tutorial.git"),
 				Enum: []string{"testString"},
-				Default: core.StringPtr("testString"),
 				Type: core.StringPtr("text"),
 				Path: core.StringPtr("testString"),
 			}
@@ -698,7 +698,6 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 				Name: core.StringPtr("key1"),
 				Value: core.StringPtr("https://github.com/IBM/tekton-tutorial.git"),
 				Enum: []string{"testString"},
-				Default: core.StringPtr("testString"),
 				Type: core.StringPtr("text"),
 				Path: core.StringPtr("testString"),
 			}

--- a/cdtektonpipelinev2/cd_tekton_pipeline_v2_integration_test.go
+++ b/cdtektonpipelinev2/cd_tekton_pipeline_v2_integration_test.go
@@ -526,14 +526,46 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`CreateTektonPipelineTrigger - Create a trigger or duplicate a trigger`, func() {
+	Describe(`CreateTektonPipelineTrigger - Create a trigger`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
 		It(`CreateTektonPipelineTrigger(createTektonPipelineTriggerOptions *CreateTektonPipelineTriggerOptions)`, func() {
-			triggerModel := &cdtektonpipelinev2.TriggerDuplicateTrigger{
-				SourceTriggerID: core.StringPtr("b3a8228f-1c82-409b-b249-7639166a0300"),
-				Name: core.StringPtr("Trigger Name"),
+			triggerGenericTriggerPropertiesItemModel := &cdtektonpipelinev2.TriggerGenericTriggerPropertiesItem{
+				Name: core.StringPtr("testString"),
+				Value: core.StringPtr("testString"),
+				Enum: []string{"testString"},
+				Type: core.StringPtr("secure"),
+				Path: core.StringPtr("testString"),
+				Href: core.StringPtr("testString"),
+			}
+
+			workerModel := &cdtektonpipelinev2.Worker{
+				Name: core.StringPtr("testString"),
+				Type: core.StringPtr("private"),
+				ID: core.StringPtr("5df804a4-9d7b-44e1-874f-3810866fb80b"),
+			}
+
+			genericSecretModel := &cdtektonpipelinev2.GenericSecret{
+				Type: core.StringPtr("token_matches"),
+				Value: core.StringPtr("secret"),
+				Source: core.StringPtr("query"),
+				KeyName: core.StringPtr("auth"),
+				Algorithm: core.StringPtr("md4"),
+			}
+
+			triggerModel := &cdtektonpipelinev2.TriggerGenericTrigger{
+				Type: core.StringPtr("generic"),
+				Name: core.StringPtr("Generic Webhook Trigger"),
+				Href: core.StringPtr("testString"),
+				EventListener: core.StringPtr("pr-listener"),
+				ID: core.StringPtr("testString"),
+				Properties: []cdtektonpipelinev2.TriggerGenericTriggerPropertiesItem{*triggerGenericTriggerPropertiesItemModel},
+				Tags: []string{"prod", "dev"},
+				Worker: workerModel,
+				MaxConcurrentRuns: core.Int64Ptr(int64(4)),
+				Disabled: core.BoolPtr(false),
+				Secret: genericSecretModel,
 			}
 
 			createTektonPipelineTriggerOptions := &cdtektonpipelinev2.CreateTektonPipelineTriggerOptions{
@@ -625,6 +657,24 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 			trigger, response, err := cdTektonPipelineService.UpdateTektonPipelineTrigger(updateTektonPipelineTriggerOptions)
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
+			Expect(trigger).ToNot(BeNil())
+		})
+	})
+
+	Describe(`DuplicateTektonPipelineTrigger - Duplicate a trigger`, func() {
+		BeforeEach(func() {
+			shouldSkipTest()
+		})
+		It(`DuplicateTektonPipelineTrigger(duplicateTektonPipelineTriggerOptions *DuplicateTektonPipelineTriggerOptions)`, func() {
+			duplicateTektonPipelineTriggerOptions := &cdtektonpipelinev2.DuplicateTektonPipelineTriggerOptions{
+				PipelineID: core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90"),
+				SourceTriggerID: core.StringPtr("1bb892a1-2e04-4768-a369-b1159eace147"),
+				Name: core.StringPtr("triggerName"),
+			}
+
+			trigger, response, err := cdTektonPipelineService.DuplicateTektonPipelineTrigger(duplicateTektonPipelineTriggerOptions)
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(201))
 			Expect(trigger).ToNot(BeNil())
 		})
 	})

--- a/cdtektonpipelinev2/cd_tekton_pipeline_v2_integration_test.go
+++ b/cdtektonpipelinev2/cd_tekton_pipeline_v2_integration_test.go
@@ -101,6 +101,8 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 			}
 
 			createTektonPipelineOptions := &cdtektonpipelinev2.CreateTektonPipelineOptions{
+				EnableSlackNotifications: core.BoolPtr(false),
+				EnablePartialCloning: core.BoolPtr(false),
 				ID: core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90"),
 				Worker: workerWithIDModel,
 			}
@@ -138,9 +140,8 @@ var _ = Describe(`CdTektonPipelineV2 Integration Tests`, func() {
 			}
 
 			tektonPipelinePatchModel := &cdtektonpipelinev2.TektonPipelinePatch{
-				EnableSlackNotifications: core.BoolPtr(true),
-				EnablePartialCloning: core.BoolPtr(true),
-				Enabled: core.BoolPtr(true),
+				EnableSlackNotifications: core.BoolPtr(false),
+				EnablePartialCloning: core.BoolPtr(false),
 				Worker: workerWithIDModel,
 			}
 			tektonPipelinePatchModelAsPatch, asPatchErr := tektonPipelinePatchModel.AsPatch()

--- a/cdtektonpipelinev2/cd_tekton_pipeline_v2_test.go
+++ b/cdtektonpipelinev2/cd_tekton_pipeline_v2_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -229,6 +228,8 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 
 				// Construct an instance of the CreateTektonPipelineOptions model
 				createTektonPipelineOptionsModel := new(cdtektonpipelinev2.CreateTektonPipelineOptions)
+				createTektonPipelineOptionsModel.EnableSlackNotifications = core.BoolPtr(false)
+				createTektonPipelineOptionsModel.EnablePartialCloning = core.BoolPtr(false)
 				createTektonPipelineOptionsModel.ID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				createTektonPipelineOptionsModel.Worker = workerWithIDModel
 				createTektonPipelineOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -301,6 +302,8 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 
 				// Construct an instance of the CreateTektonPipelineOptions model
 				createTektonPipelineOptionsModel := new(cdtektonpipelinev2.CreateTektonPipelineOptions)
+				createTektonPipelineOptionsModel.EnableSlackNotifications = core.BoolPtr(false)
+				createTektonPipelineOptionsModel.EnablePartialCloning = core.BoolPtr(false)
 				createTektonPipelineOptionsModel.ID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				createTektonPipelineOptionsModel.Worker = workerWithIDModel
 				createTektonPipelineOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -381,6 +384,8 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 
 				// Construct an instance of the CreateTektonPipelineOptions model
 				createTektonPipelineOptionsModel := new(cdtektonpipelinev2.CreateTektonPipelineOptions)
+				createTektonPipelineOptionsModel.EnableSlackNotifications = core.BoolPtr(false)
+				createTektonPipelineOptionsModel.EnablePartialCloning = core.BoolPtr(false)
 				createTektonPipelineOptionsModel.ID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				createTektonPipelineOptionsModel.Worker = workerWithIDModel
 				createTektonPipelineOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -406,6 +411,8 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 
 				// Construct an instance of the CreateTektonPipelineOptions model
 				createTektonPipelineOptionsModel := new(cdtektonpipelinev2.CreateTektonPipelineOptions)
+				createTektonPipelineOptionsModel.EnableSlackNotifications = core.BoolPtr(false)
+				createTektonPipelineOptionsModel.EnablePartialCloning = core.BoolPtr(false)
 				createTektonPipelineOptionsModel.ID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				createTektonPipelineOptionsModel.Worker = workerWithIDModel
 				createTektonPipelineOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -445,6 +452,8 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 
 				// Construct an instance of the CreateTektonPipelineOptions model
 				createTektonPipelineOptionsModel := new(cdtektonpipelinev2.CreateTektonPipelineOptions)
+				createTektonPipelineOptionsModel.EnableSlackNotifications = core.BoolPtr(false)
+				createTektonPipelineOptionsModel.EnablePartialCloning = core.BoolPtr(false)
 				createTektonPipelineOptionsModel.ID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				createTektonPipelineOptionsModel.Worker = workerWithIDModel
 				createTektonPipelineOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -703,9 +712,8 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 
 				// Construct an instance of the TektonPipelinePatch model
 				tektonPipelinePatchModel := new(cdtektonpipelinev2.TektonPipelinePatch)
-				tektonPipelinePatchModel.EnableSlackNotifications = core.BoolPtr(true)
-				tektonPipelinePatchModel.EnablePartialCloning = core.BoolPtr(true)
-				tektonPipelinePatchModel.Enabled = core.BoolPtr(true)
+				tektonPipelinePatchModel.EnableSlackNotifications = core.BoolPtr(false)
+				tektonPipelinePatchModel.EnablePartialCloning = core.BoolPtr(false)
 				tektonPipelinePatchModel.Worker = workerWithIDModel
 				tektonPipelinePatchModelAsPatch, asPatchErr := tektonPipelinePatchModel.AsPatch()
 				Expect(asPatchErr).To(BeNil())
@@ -784,9 +792,8 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 
 				// Construct an instance of the TektonPipelinePatch model
 				tektonPipelinePatchModel := new(cdtektonpipelinev2.TektonPipelinePatch)
-				tektonPipelinePatchModel.EnableSlackNotifications = core.BoolPtr(true)
-				tektonPipelinePatchModel.EnablePartialCloning = core.BoolPtr(true)
-				tektonPipelinePatchModel.Enabled = core.BoolPtr(true)
+				tektonPipelinePatchModel.EnableSlackNotifications = core.BoolPtr(false)
+				tektonPipelinePatchModel.EnablePartialCloning = core.BoolPtr(false)
 				tektonPipelinePatchModel.Worker = workerWithIDModel
 				tektonPipelinePatchModelAsPatch, asPatchErr := tektonPipelinePatchModel.AsPatch()
 				Expect(asPatchErr).To(BeNil())
@@ -873,9 +880,8 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 
 				// Construct an instance of the TektonPipelinePatch model
 				tektonPipelinePatchModel := new(cdtektonpipelinev2.TektonPipelinePatch)
-				tektonPipelinePatchModel.EnableSlackNotifications = core.BoolPtr(true)
-				tektonPipelinePatchModel.EnablePartialCloning = core.BoolPtr(true)
-				tektonPipelinePatchModel.Enabled = core.BoolPtr(true)
+				tektonPipelinePatchModel.EnableSlackNotifications = core.BoolPtr(false)
+				tektonPipelinePatchModel.EnablePartialCloning = core.BoolPtr(false)
 				tektonPipelinePatchModel.Worker = workerWithIDModel
 				tektonPipelinePatchModelAsPatch, asPatchErr := tektonPipelinePatchModel.AsPatch()
 				Expect(asPatchErr).To(BeNil())
@@ -907,9 +913,8 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 
 				// Construct an instance of the TektonPipelinePatch model
 				tektonPipelinePatchModel := new(cdtektonpipelinev2.TektonPipelinePatch)
-				tektonPipelinePatchModel.EnableSlackNotifications = core.BoolPtr(true)
-				tektonPipelinePatchModel.EnablePartialCloning = core.BoolPtr(true)
-				tektonPipelinePatchModel.Enabled = core.BoolPtr(true)
+				tektonPipelinePatchModel.EnableSlackNotifications = core.BoolPtr(false)
+				tektonPipelinePatchModel.EnablePartialCloning = core.BoolPtr(false)
 				tektonPipelinePatchModel.Worker = workerWithIDModel
 				tektonPipelinePatchModelAsPatch, asPatchErr := tektonPipelinePatchModel.AsPatch()
 				Expect(asPatchErr).To(BeNil())
@@ -962,9 +967,8 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 
 				// Construct an instance of the TektonPipelinePatch model
 				tektonPipelinePatchModel := new(cdtektonpipelinev2.TektonPipelinePatch)
-				tektonPipelinePatchModel.EnableSlackNotifications = core.BoolPtr(true)
-				tektonPipelinePatchModel.EnablePartialCloning = core.BoolPtr(true)
-				tektonPipelinePatchModel.Enabled = core.BoolPtr(true)
+				tektonPipelinePatchModel.EnableSlackNotifications = core.BoolPtr(false)
+				tektonPipelinePatchModel.EnablePartialCloning = core.BoolPtr(false)
 				tektonPipelinePatchModel.Worker = workerWithIDModel
 				tektonPipelinePatchModelAsPatch, asPatchErr := tektonPipelinePatchModel.AsPatch()
 				Expect(asPatchErr).To(BeNil())
@@ -7503,10 +7507,14 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 
 				// Construct an instance of the CreateTektonPipelineOptions model
 				createTektonPipelineOptionsModel := cdTektonPipelineService.NewCreateTektonPipelineOptions()
+				createTektonPipelineOptionsModel.SetEnableSlackNotifications(false)
+				createTektonPipelineOptionsModel.SetEnablePartialCloning(false)
 				createTektonPipelineOptionsModel.SetID("94619026-912b-4d92-8f51-6c74f0692d90")
 				createTektonPipelineOptionsModel.SetWorker(workerWithIDModel)
 				createTektonPipelineOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(createTektonPipelineOptionsModel).ToNot(BeNil())
+				Expect(createTektonPipelineOptionsModel.EnableSlackNotifications).To(Equal(core.BoolPtr(false)))
+				Expect(createTektonPipelineOptionsModel.EnablePartialCloning).To(Equal(core.BoolPtr(false)))
 				Expect(createTektonPipelineOptionsModel.ID).To(Equal(core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")))
 				Expect(createTektonPipelineOptionsModel.Worker).To(Equal(workerWithIDModel))
 				Expect(createTektonPipelineOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
@@ -8136,7 +8144,7 @@ func CreateMockUUID(mockData string) *strfmt.UUID {
 }
 
 func CreateMockReader(mockData string) io.ReadCloser {
-	return ioutil.NopCloser(bytes.NewReader([]byte(mockData)))
+	return io.NopCloser(bytes.NewReader([]byte(mockData)))
 }
 
 func CreateMockDate(mockData string) *strfmt.Date {

--- a/cdtektonpipelinev2/cd_tekton_pipeline_v2_test.go
+++ b/cdtektonpipelinev2/cd_tekton_pipeline_v2_test.go
@@ -159,39 +159,39 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 			var url string
 			var err error
 			url, err = cdtektonpipelinev2.GetServiceURLForRegion("us-south")
-			Expect(url).To(Equal("https://api.us-south.devops.cloud.ibm.com/v2"))
+			Expect(url).To(Equal("https://api.us-south.devops.cloud.ibm.com/pipeline/v2"))
 			Expect(err).To(BeNil())
 
 			url, err = cdtektonpipelinev2.GetServiceURLForRegion("us-east")
-			Expect(url).To(Equal("https://api.us-east.devops.cloud.ibm.com/v2"))
+			Expect(url).To(Equal("https://api.us-east.devops.cloud.ibm.com/pipeline/v2"))
 			Expect(err).To(BeNil())
 
 			url, err = cdtektonpipelinev2.GetServiceURLForRegion("eu-de")
-			Expect(url).To(Equal("https://api.eu-de.devops.cloud.ibm.com/v2"))
+			Expect(url).To(Equal("https://api.eu-de.devops.cloud.ibm.com/pipeline/v2"))
 			Expect(err).To(BeNil())
 
 			url, err = cdtektonpipelinev2.GetServiceURLForRegion("eu-gb")
-			Expect(url).To(Equal("https://api.eu-gb.devops.cloud.ibm.com/v2"))
+			Expect(url).To(Equal("https://api.eu-gb.devops.cloud.ibm.com/pipeline/v2"))
 			Expect(err).To(BeNil())
 
 			url, err = cdtektonpipelinev2.GetServiceURLForRegion("jp-osa")
-			Expect(url).To(Equal("https://api.jp-osa.devops.cloud.ibm.com/v2"))
+			Expect(url).To(Equal("https://api.jp-osa.devops.cloud.ibm.com/pipeline/v2"))
 			Expect(err).To(BeNil())
 
 			url, err = cdtektonpipelinev2.GetServiceURLForRegion("jp-tok")
-			Expect(url).To(Equal("https://api.jp-tok.devops.cloud.ibm.com/v2"))
+			Expect(url).To(Equal("https://api.jp-tok.devops.cloud.ibm.com/pipeline/v2"))
 			Expect(err).To(BeNil())
 
 			url, err = cdtektonpipelinev2.GetServiceURLForRegion("au-syd")
-			Expect(url).To(Equal("https://api.au-syd.devops.cloud.ibm.com/v2"))
+			Expect(url).To(Equal("https://api.au-syd.devops.cloud.ibm.com/pipeline/v2"))
 			Expect(err).To(BeNil())
 
 			url, err = cdtektonpipelinev2.GetServiceURLForRegion("ca-tor")
-			Expect(url).To(Equal("https://api.ca-tor.devops.cloud.ibm.com/v2"))
+			Expect(url).To(Equal("https://api.ca-tor.devops.cloud.ibm.com/pipeline/v2"))
 			Expect(err).To(BeNil())
 
 			url, err = cdtektonpipelinev2.GetServiceURLForRegion("br-sao")
-			Expect(url).To(Equal("https://api.br-sao.devops.cloud.ibm.com/v2"))
+			Expect(url).To(Equal("https://api.br-sao.devops.cloud.ibm.com/pipeline/v2"))
 			Expect(err).To(BeNil())
 
 			url, err = cdtektonpipelinev2.GetServiceURLForRegion("INVALID_REGION")
@@ -283,7 +283,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "runs_url": "RunsURL", "build_number": 1, "enabled": false}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "runs_url": "RunsURL", "build_number": 1, "enable_slack_notifications": true, "enable_partial_cloning": true, "enabled": false}`)
 				}))
 			})
 			It(`Invoke CreateTektonPipeline successfully with retries`, func() {
@@ -358,7 +358,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "runs_url": "RunsURL", "build_number": 1, "enabled": false}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "runs_url": "RunsURL", "build_number": 1, "enable_slack_notifications": true, "enable_partial_cloning": true, "enabled": false}`)
 				}))
 			})
 			It(`Invoke CreateTektonPipeline successfully`, func() {
@@ -524,7 +524,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "runs_url": "RunsURL", "build_number": 1, "enabled": false}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "runs_url": "RunsURL", "build_number": 1, "enable_slack_notifications": true, "enable_partial_cloning": true, "enabled": false}`)
 				}))
 			})
 			It(`Invoke GetTektonPipeline successfully with retries`, func() {
@@ -578,7 +578,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "runs_url": "RunsURL", "build_number": 1, "enabled": false}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "runs_url": "RunsURL", "build_number": 1, "enable_slack_notifications": true, "enable_partial_cloning": true, "enabled": false}`)
 				}))
 			})
 			It(`Invoke GetTektonPipeline successfully`, func() {
@@ -703,6 +703,9 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 
 				// Construct an instance of the TektonPipelinePatch model
 				tektonPipelinePatchModel := new(cdtektonpipelinev2.TektonPipelinePatch)
+				tektonPipelinePatchModel.EnableSlackNotifications = core.BoolPtr(true)
+				tektonPipelinePatchModel.EnablePartialCloning = core.BoolPtr(true)
+				tektonPipelinePatchModel.Enabled = core.BoolPtr(true)
 				tektonPipelinePatchModel.Worker = workerWithIDModel
 				tektonPipelinePatchModelAsPatch, asPatchErr := tektonPipelinePatchModel.AsPatch()
 				Expect(asPatchErr).To(BeNil())
@@ -763,7 +766,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "runs_url": "RunsURL", "build_number": 1, "enabled": false}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "runs_url": "RunsURL", "build_number": 1, "enable_slack_notifications": true, "enable_partial_cloning": true, "enabled": false}`)
 				}))
 			})
 			It(`Invoke UpdateTektonPipeline successfully with retries`, func() {
@@ -781,6 +784,9 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 
 				// Construct an instance of the TektonPipelinePatch model
 				tektonPipelinePatchModel := new(cdtektonpipelinev2.TektonPipelinePatch)
+				tektonPipelinePatchModel.EnableSlackNotifications = core.BoolPtr(true)
+				tektonPipelinePatchModel.EnablePartialCloning = core.BoolPtr(true)
+				tektonPipelinePatchModel.Enabled = core.BoolPtr(true)
 				tektonPipelinePatchModel.Worker = workerWithIDModel
 				tektonPipelinePatchModelAsPatch, asPatchErr := tektonPipelinePatchModel.AsPatch()
 				Expect(asPatchErr).To(BeNil())
@@ -844,7 +850,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "runs_url": "RunsURL", "build_number": 1, "enabled": false}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "runs_url": "RunsURL", "build_number": 1, "enable_slack_notifications": true, "enable_partial_cloning": true, "enabled": false}`)
 				}))
 			})
 			It(`Invoke UpdateTektonPipeline successfully`, func() {
@@ -867,6 +873,9 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 
 				// Construct an instance of the TektonPipelinePatch model
 				tektonPipelinePatchModel := new(cdtektonpipelinev2.TektonPipelinePatch)
+				tektonPipelinePatchModel.EnableSlackNotifications = core.BoolPtr(true)
+				tektonPipelinePatchModel.EnablePartialCloning = core.BoolPtr(true)
+				tektonPipelinePatchModel.Enabled = core.BoolPtr(true)
 				tektonPipelinePatchModel.Worker = workerWithIDModel
 				tektonPipelinePatchModelAsPatch, asPatchErr := tektonPipelinePatchModel.AsPatch()
 				Expect(asPatchErr).To(BeNil())
@@ -898,6 +907,9 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 
 				// Construct an instance of the TektonPipelinePatch model
 				tektonPipelinePatchModel := new(cdtektonpipelinev2.TektonPipelinePatch)
+				tektonPipelinePatchModel.EnableSlackNotifications = core.BoolPtr(true)
+				tektonPipelinePatchModel.EnablePartialCloning = core.BoolPtr(true)
+				tektonPipelinePatchModel.Enabled = core.BoolPtr(true)
 				tektonPipelinePatchModel.Worker = workerWithIDModel
 				tektonPipelinePatchModelAsPatch, asPatchErr := tektonPipelinePatchModel.AsPatch()
 				Expect(asPatchErr).To(BeNil())
@@ -950,6 +962,9 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 
 				// Construct an instance of the TektonPipelinePatch model
 				tektonPipelinePatchModel := new(cdtektonpipelinev2.TektonPipelinePatch)
+				tektonPipelinePatchModel.EnableSlackNotifications = core.BoolPtr(true)
+				tektonPipelinePatchModel.EnablePartialCloning = core.BoolPtr(true)
+				tektonPipelinePatchModel.Enabled = core.BoolPtr(true)
 				tektonPipelinePatchModel.Worker = workerWithIDModel
 				tektonPipelinePatchModelAsPatch, asPatchErr := tektonPipelinePatchModel.AsPatch()
 				Expect(asPatchErr).To(BeNil())
@@ -1115,7 +1130,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"pipeline_runs": [{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL", "href": "Href"}], "offset": 20, "limit": 20, "first": {"href": "Href"}, "next": {"href": "Href"}}`)
+					fmt.Fprintf(res, "%s", `{"pipeline_runs": [{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL", "href": "Href"}], "offset": 20, "limit": 20, "first": {"href": "Href"}, "next": {"href": "Href"}}`)
 				}))
 			})
 			It(`Invoke ListTektonPipelineRuns successfully with retries`, func() {
@@ -1177,7 +1192,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"pipeline_runs": [{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL", "href": "Href"}], "offset": 20, "limit": 20, "first": {"href": "Href"}, "next": {"href": "Href"}}`)
+					fmt.Fprintf(res, "%s", `{"pipeline_runs": [{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL", "href": "Href"}], "offset": 20, "limit": 20, "first": {"href": "Href"}, "next": {"href": "Href"}}`)
 				}))
 			})
 			It(`Invoke ListTektonPipelineRuns successfully`, func() {
@@ -1338,9 +1353,9 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					res.WriteHeader(200)
 					requestNumber++
 					if requestNumber == 1 {
-						fmt.Fprintf(res, "%s", `{"next":{"href":"https://myhost.com/somePath?offset=1"},"total_count":2,"limit":1,"pipeline_runs":[{"id":"ID","user_info":{"iam_id":"IamID","sub":"Sub"},"status":"pending","definition_id":"DefinitionID","worker":{"name":"Name","agent":"Agent","service_id":"ServiceID","id":"ID"},"pipeline_id":"PipelineID","listener_name":"ListenerName","trigger":{"source_trigger_id":"SourceTriggerID","name":"start-deploy"},"event_params_blob":"EventParamsBlob","event_header_params_blob":"EventHeaderParamsBlob","properties":[{"name":"Name","value":"Value","enum":["Enum"],"default":"Default","type":"secure","path":"Path"}],"created_at":"2019-01-01T12:00:00.000Z","updated_at":"2019-01-01T12:00:00.000Z","run_url":"RunURL","href":"Href"}]}`)
+						fmt.Fprintf(res, "%s", `{"next":{"href":"https://myhost.com/somePath?offset=1"},"total_count":2,"limit":1,"pipeline_runs":[{"id":"ID","user_info":{"iam_id":"IamID","sub":"Sub"},"status":"pending","definition_id":"DefinitionID","worker":{"name":"Name","agent":"Agent","service_id":"ServiceID","id":"ID"},"pipeline_id":"PipelineID","listener_name":"ListenerName","trigger":{"source_trigger_id":"SourceTriggerID","name":"start-deploy"},"event_params_blob":"EventParamsBlob","event_header_params_blob":"EventHeaderParamsBlob","properties":[{"name":"Name","value":"Value","enum":["Enum"],"type":"secure","path":"Path"}],"created_at":"2019-01-01T12:00:00.000Z","updated_at":"2019-01-01T12:00:00.000Z","run_url":"RunURL","href":"Href"}]}`)
 					} else if requestNumber == 2 {
-						fmt.Fprintf(res, "%s", `{"total_count":2,"limit":1,"pipeline_runs":[{"id":"ID","user_info":{"iam_id":"IamID","sub":"Sub"},"status":"pending","definition_id":"DefinitionID","worker":{"name":"Name","agent":"Agent","service_id":"ServiceID","id":"ID"},"pipeline_id":"PipelineID","listener_name":"ListenerName","trigger":{"source_trigger_id":"SourceTriggerID","name":"start-deploy"},"event_params_blob":"EventParamsBlob","event_header_params_blob":"EventHeaderParamsBlob","properties":[{"name":"Name","value":"Value","enum":["Enum"],"default":"Default","type":"secure","path":"Path"}],"created_at":"2019-01-01T12:00:00.000Z","updated_at":"2019-01-01T12:00:00.000Z","run_url":"RunURL","href":"Href"}]}`)
+						fmt.Fprintf(res, "%s", `{"total_count":2,"limit":1,"pipeline_runs":[{"id":"ID","user_info":{"iam_id":"IamID","sub":"Sub"},"status":"pending","definition_id":"DefinitionID","worker":{"name":"Name","agent":"Agent","service_id":"ServiceID","id":"ID"},"pipeline_id":"PipelineID","listener_name":"ListenerName","trigger":{"source_trigger_id":"SourceTriggerID","name":"start-deploy"},"event_params_blob":"EventParamsBlob","event_header_params_blob":"EventHeaderParamsBlob","properties":[{"name":"Name","value":"Value","enum":["Enum"],"type":"secure","path":"Path"}],"created_at":"2019-01-01T12:00:00.000Z","updated_at":"2019-01-01T12:00:00.000Z","run_url":"RunURL","href":"Href"}]}`)
 					} else {
 						res.WriteHeader(400)
 					}
@@ -1483,7 +1498,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
 				}))
 			})
 			It(`Invoke CreateTektonPipelineRun successfully with retries`, func() {
@@ -1558,7 +1573,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
 				}))
 			})
 			It(`Invoke CreateTektonPipelineRun successfully`, func() {
@@ -1735,7 +1750,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
 				}))
 			})
 			It(`Invoke GetTektonPipelineRun successfully with retries`, func() {
@@ -1792,7 +1807,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
 				}))
 			})
 			It(`Invoke GetTektonPipelineRun successfully`, func() {
@@ -2044,7 +2059,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
 				}))
 			})
 			It(`Invoke CancelTektonPipelineRun successfully with retries`, func() {
@@ -2116,7 +2131,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
 				}))
 			})
 			It(`Invoke CancelTektonPipelineRun successfully`, func() {
@@ -2281,7 +2296,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
 				}))
 			})
 			It(`Invoke RerunTektonPipelineRun successfully with retries`, func() {
@@ -2336,7 +2351,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
 				}))
 			})
 			It(`Invoke RerunTektonPipelineRun successfully`, func() {
@@ -4035,7 +4050,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}]}`)
+					fmt.Fprintf(res, "%s", `{"properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}]}`)
 				}))
 			})
 			It(`Invoke ListTektonPipelineProperties successfully with retries`, func() {
@@ -4094,7 +4109,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}]}`)
+					fmt.Fprintf(res, "%s", `{"properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}]}`)
 				}))
 			})
 			It(`Invoke ListTektonPipelineProperties successfully`, func() {
@@ -4228,7 +4243,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelinePropertiesOptionsModel.Name = core.StringPtr("key1")
 				createTektonPipelinePropertiesOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				createTektonPipelinePropertiesOptionsModel.Enum = []string{"testString"}
-				createTektonPipelinePropertiesOptionsModel.Default = core.StringPtr("testString")
 				createTektonPipelinePropertiesOptionsModel.Type = core.StringPtr("text")
 				createTektonPipelinePropertiesOptionsModel.Path = core.StringPtr("testString")
 				createTektonPipelinePropertiesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -4283,7 +4297,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}`)
 				}))
 			})
 			It(`Invoke CreateTektonPipelineProperties successfully with retries`, func() {
@@ -4301,7 +4315,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelinePropertiesOptionsModel.Name = core.StringPtr("key1")
 				createTektonPipelinePropertiesOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				createTektonPipelinePropertiesOptionsModel.Enum = []string{"testString"}
-				createTektonPipelinePropertiesOptionsModel.Default = core.StringPtr("testString")
 				createTektonPipelinePropertiesOptionsModel.Type = core.StringPtr("text")
 				createTektonPipelinePropertiesOptionsModel.Path = core.StringPtr("testString")
 				createTektonPipelinePropertiesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -4359,7 +4372,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}`)
 				}))
 			})
 			It(`Invoke CreateTektonPipelineProperties successfully`, func() {
@@ -4382,7 +4395,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelinePropertiesOptionsModel.Name = core.StringPtr("key1")
 				createTektonPipelinePropertiesOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				createTektonPipelinePropertiesOptionsModel.Enum = []string{"testString"}
-				createTektonPipelinePropertiesOptionsModel.Default = core.StringPtr("testString")
 				createTektonPipelinePropertiesOptionsModel.Type = core.StringPtr("text")
 				createTektonPipelinePropertiesOptionsModel.Path = core.StringPtr("testString")
 				createTektonPipelinePropertiesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -4408,7 +4420,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelinePropertiesOptionsModel.Name = core.StringPtr("key1")
 				createTektonPipelinePropertiesOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				createTektonPipelinePropertiesOptionsModel.Enum = []string{"testString"}
-				createTektonPipelinePropertiesOptionsModel.Default = core.StringPtr("testString")
 				createTektonPipelinePropertiesOptionsModel.Type = core.StringPtr("text")
 				createTektonPipelinePropertiesOptionsModel.Path = core.StringPtr("testString")
 				createTektonPipelinePropertiesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -4455,7 +4466,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelinePropertiesOptionsModel.Name = core.StringPtr("key1")
 				createTektonPipelinePropertiesOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				createTektonPipelinePropertiesOptionsModel.Enum = []string{"testString"}
-				createTektonPipelinePropertiesOptionsModel.Default = core.StringPtr("testString")
 				createTektonPipelinePropertiesOptionsModel.Type = core.StringPtr("text")
 				createTektonPipelinePropertiesOptionsModel.Path = core.StringPtr("testString")
 				createTektonPipelinePropertiesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -4536,7 +4546,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}`)
 				}))
 			})
 			It(`Invoke GetTektonPipelineProperty successfully with retries`, func() {
@@ -4591,7 +4601,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}`)
 				}))
 			})
 			It(`Invoke GetTektonPipelineProperty successfully`, func() {
@@ -4720,7 +4730,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				replaceTektonPipelinePropertyOptionsModel.Name = core.StringPtr("key1")
 				replaceTektonPipelinePropertyOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				replaceTektonPipelinePropertyOptionsModel.Enum = []string{"testString"}
-				replaceTektonPipelinePropertyOptionsModel.Default = core.StringPtr("testString")
 				replaceTektonPipelinePropertyOptionsModel.Type = core.StringPtr("text")
 				replaceTektonPipelinePropertyOptionsModel.Path = core.StringPtr("testString")
 				replaceTektonPipelinePropertyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -4775,7 +4784,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}`)
 				}))
 			})
 			It(`Invoke ReplaceTektonPipelineProperty successfully with retries`, func() {
@@ -4794,7 +4803,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				replaceTektonPipelinePropertyOptionsModel.Name = core.StringPtr("key1")
 				replaceTektonPipelinePropertyOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				replaceTektonPipelinePropertyOptionsModel.Enum = []string{"testString"}
-				replaceTektonPipelinePropertyOptionsModel.Default = core.StringPtr("testString")
 				replaceTektonPipelinePropertyOptionsModel.Type = core.StringPtr("text")
 				replaceTektonPipelinePropertyOptionsModel.Path = core.StringPtr("testString")
 				replaceTektonPipelinePropertyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -4852,7 +4860,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}`)
 				}))
 			})
 			It(`Invoke ReplaceTektonPipelineProperty successfully`, func() {
@@ -4876,7 +4884,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				replaceTektonPipelinePropertyOptionsModel.Name = core.StringPtr("key1")
 				replaceTektonPipelinePropertyOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				replaceTektonPipelinePropertyOptionsModel.Enum = []string{"testString"}
-				replaceTektonPipelinePropertyOptionsModel.Default = core.StringPtr("testString")
 				replaceTektonPipelinePropertyOptionsModel.Type = core.StringPtr("text")
 				replaceTektonPipelinePropertyOptionsModel.Path = core.StringPtr("testString")
 				replaceTektonPipelinePropertyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -4903,7 +4910,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				replaceTektonPipelinePropertyOptionsModel.Name = core.StringPtr("key1")
 				replaceTektonPipelinePropertyOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				replaceTektonPipelinePropertyOptionsModel.Enum = []string{"testString"}
-				replaceTektonPipelinePropertyOptionsModel.Default = core.StringPtr("testString")
 				replaceTektonPipelinePropertyOptionsModel.Type = core.StringPtr("text")
 				replaceTektonPipelinePropertyOptionsModel.Path = core.StringPtr("testString")
 				replaceTektonPipelinePropertyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -4951,7 +4957,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				replaceTektonPipelinePropertyOptionsModel.Name = core.StringPtr("key1")
 				replaceTektonPipelinePropertyOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				replaceTektonPipelinePropertyOptionsModel.Enum = []string{"testString"}
-				replaceTektonPipelinePropertyOptionsModel.Default = core.StringPtr("testString")
 				replaceTektonPipelinePropertyOptionsModel.Type = core.StringPtr("text")
 				replaceTektonPipelinePropertyOptionsModel.Path = core.StringPtr("testString")
 				replaceTektonPipelinePropertyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -6424,7 +6429,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path", "href": "Href"}]}`)
+					fmt.Fprintf(res, "%s", `{"properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path", "href": "Href"}]}`)
 				}))
 			})
 			It(`Invoke ListTektonPipelineTriggerProperties successfully with retries`, func() {
@@ -6485,7 +6490,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path", "href": "Href"}]}`)
+					fmt.Fprintf(res, "%s", `{"properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path", "href": "Href"}]}`)
 				}))
 			})
 			It(`Invoke ListTektonPipelineTriggerProperties successfully`, func() {
@@ -6623,7 +6628,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelineTriggerPropertiesOptionsModel.Name = core.StringPtr("key1")
 				createTektonPipelineTriggerPropertiesOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				createTektonPipelineTriggerPropertiesOptionsModel.Enum = []string{"testString"}
-				createTektonPipelineTriggerPropertiesOptionsModel.Default = core.StringPtr("testString")
 				createTektonPipelineTriggerPropertiesOptionsModel.Type = core.StringPtr("text")
 				createTektonPipelineTriggerPropertiesOptionsModel.Path = core.StringPtr("testString")
 				createTektonPipelineTriggerPropertiesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -6678,7 +6682,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}`)
 				}))
 			})
 			It(`Invoke CreateTektonPipelineTriggerProperties successfully with retries`, func() {
@@ -6697,7 +6701,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelineTriggerPropertiesOptionsModel.Name = core.StringPtr("key1")
 				createTektonPipelineTriggerPropertiesOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				createTektonPipelineTriggerPropertiesOptionsModel.Enum = []string{"testString"}
-				createTektonPipelineTriggerPropertiesOptionsModel.Default = core.StringPtr("testString")
 				createTektonPipelineTriggerPropertiesOptionsModel.Type = core.StringPtr("text")
 				createTektonPipelineTriggerPropertiesOptionsModel.Path = core.StringPtr("testString")
 				createTektonPipelineTriggerPropertiesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -6755,7 +6758,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}`)
 				}))
 			})
 			It(`Invoke CreateTektonPipelineTriggerProperties successfully`, func() {
@@ -6779,7 +6782,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelineTriggerPropertiesOptionsModel.Name = core.StringPtr("key1")
 				createTektonPipelineTriggerPropertiesOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				createTektonPipelineTriggerPropertiesOptionsModel.Enum = []string{"testString"}
-				createTektonPipelineTriggerPropertiesOptionsModel.Default = core.StringPtr("testString")
 				createTektonPipelineTriggerPropertiesOptionsModel.Type = core.StringPtr("text")
 				createTektonPipelineTriggerPropertiesOptionsModel.Path = core.StringPtr("testString")
 				createTektonPipelineTriggerPropertiesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -6806,7 +6808,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelineTriggerPropertiesOptionsModel.Name = core.StringPtr("key1")
 				createTektonPipelineTriggerPropertiesOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				createTektonPipelineTriggerPropertiesOptionsModel.Enum = []string{"testString"}
-				createTektonPipelineTriggerPropertiesOptionsModel.Default = core.StringPtr("testString")
 				createTektonPipelineTriggerPropertiesOptionsModel.Type = core.StringPtr("text")
 				createTektonPipelineTriggerPropertiesOptionsModel.Path = core.StringPtr("testString")
 				createTektonPipelineTriggerPropertiesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -6854,7 +6855,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelineTriggerPropertiesOptionsModel.Name = core.StringPtr("key1")
 				createTektonPipelineTriggerPropertiesOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				createTektonPipelineTriggerPropertiesOptionsModel.Enum = []string{"testString"}
-				createTektonPipelineTriggerPropertiesOptionsModel.Default = core.StringPtr("testString")
 				createTektonPipelineTriggerPropertiesOptionsModel.Type = core.StringPtr("text")
 				createTektonPipelineTriggerPropertiesOptionsModel.Path = core.StringPtr("testString")
 				createTektonPipelineTriggerPropertiesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -6936,7 +6936,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}`)
 				}))
 			})
 			It(`Invoke GetTektonPipelineTriggerProperty successfully with retries`, func() {
@@ -6992,7 +6992,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}`)
 				}))
 			})
 			It(`Invoke GetTektonPipelineTriggerProperty successfully`, func() {
@@ -7125,7 +7125,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				replaceTektonPipelineTriggerPropertyOptionsModel.Name = core.StringPtr("key1")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Enum = []string{"testString"}
-				replaceTektonPipelineTriggerPropertyOptionsModel.Default = core.StringPtr("testString")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Type = core.StringPtr("text")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Path = core.StringPtr("testString")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -7180,7 +7179,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}`)
 				}))
 			})
 			It(`Invoke ReplaceTektonPipelineTriggerProperty successfully with retries`, func() {
@@ -7200,7 +7199,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				replaceTektonPipelineTriggerPropertyOptionsModel.Name = core.StringPtr("key1")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Enum = []string{"testString"}
-				replaceTektonPipelineTriggerPropertyOptionsModel.Default = core.StringPtr("testString")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Type = core.StringPtr("text")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Path = core.StringPtr("testString")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -7258,7 +7256,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}`)
 				}))
 			})
 			It(`Invoke ReplaceTektonPipelineTriggerProperty successfully`, func() {
@@ -7283,7 +7281,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				replaceTektonPipelineTriggerPropertyOptionsModel.Name = core.StringPtr("key1")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Enum = []string{"testString"}
-				replaceTektonPipelineTriggerPropertyOptionsModel.Default = core.StringPtr("testString")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Type = core.StringPtr("text")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Path = core.StringPtr("testString")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -7311,7 +7308,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				replaceTektonPipelineTriggerPropertyOptionsModel.Name = core.StringPtr("key1")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Enum = []string{"testString"}
-				replaceTektonPipelineTriggerPropertyOptionsModel.Default = core.StringPtr("testString")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Type = core.StringPtr("text")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Path = core.StringPtr("testString")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -7360,7 +7356,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				replaceTektonPipelineTriggerPropertyOptionsModel.Name = core.StringPtr("key1")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Enum = []string{"testString"}
-				replaceTektonPipelineTriggerPropertyOptionsModel.Default = core.StringPtr("testString")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Type = core.StringPtr("text")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Path = core.StringPtr("testString")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -7524,7 +7519,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelinePropertiesOptionsModel.SetName("key1")
 				createTektonPipelinePropertiesOptionsModel.SetValue("https://github.com/IBM/tekton-tutorial.git")
 				createTektonPipelinePropertiesOptionsModel.SetEnum([]string{"testString"})
-				createTektonPipelinePropertiesOptionsModel.SetDefault("testString")
 				createTektonPipelinePropertiesOptionsModel.SetType("text")
 				createTektonPipelinePropertiesOptionsModel.SetPath("testString")
 				createTektonPipelinePropertiesOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
@@ -7533,7 +7527,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(createTektonPipelinePropertiesOptionsModel.Name).To(Equal(core.StringPtr("key1")))
 				Expect(createTektonPipelinePropertiesOptionsModel.Value).To(Equal(core.StringPtr("https://github.com/IBM/tekton-tutorial.git")))
 				Expect(createTektonPipelinePropertiesOptionsModel.Enum).To(Equal([]string{"testString"}))
-				Expect(createTektonPipelinePropertiesOptionsModel.Default).To(Equal(core.StringPtr("testString")))
 				Expect(createTektonPipelinePropertiesOptionsModel.Type).To(Equal(core.StringPtr("text")))
 				Expect(createTektonPipelinePropertiesOptionsModel.Path).To(Equal(core.StringPtr("testString")))
 				Expect(createTektonPipelinePropertiesOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
@@ -7588,7 +7581,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelineTriggerPropertiesOptionsModel.SetName("key1")
 				createTektonPipelineTriggerPropertiesOptionsModel.SetValue("https://github.com/IBM/tekton-tutorial.git")
 				createTektonPipelineTriggerPropertiesOptionsModel.SetEnum([]string{"testString"})
-				createTektonPipelineTriggerPropertiesOptionsModel.SetDefault("testString")
 				createTektonPipelineTriggerPropertiesOptionsModel.SetType("text")
 				createTektonPipelineTriggerPropertiesOptionsModel.SetPath("testString")
 				createTektonPipelineTriggerPropertiesOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
@@ -7598,7 +7590,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(createTektonPipelineTriggerPropertiesOptionsModel.Name).To(Equal(core.StringPtr("key1")))
 				Expect(createTektonPipelineTriggerPropertiesOptionsModel.Value).To(Equal(core.StringPtr("https://github.com/IBM/tekton-tutorial.git")))
 				Expect(createTektonPipelineTriggerPropertiesOptionsModel.Enum).To(Equal([]string{"testString"}))
-				Expect(createTektonPipelineTriggerPropertiesOptionsModel.Default).To(Equal(core.StringPtr("testString")))
 				Expect(createTektonPipelineTriggerPropertiesOptionsModel.Type).To(Equal(core.StringPtr("text")))
 				Expect(createTektonPipelineTriggerPropertiesOptionsModel.Path).To(Equal(core.StringPtr("testString")))
 				Expect(createTektonPipelineTriggerPropertiesOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
@@ -7928,7 +7919,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				replaceTektonPipelinePropertyOptionsModel.SetName("key1")
 				replaceTektonPipelinePropertyOptionsModel.SetValue("https://github.com/IBM/tekton-tutorial.git")
 				replaceTektonPipelinePropertyOptionsModel.SetEnum([]string{"testString"})
-				replaceTektonPipelinePropertyOptionsModel.SetDefault("testString")
 				replaceTektonPipelinePropertyOptionsModel.SetType("text")
 				replaceTektonPipelinePropertyOptionsModel.SetPath("testString")
 				replaceTektonPipelinePropertyOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
@@ -7938,7 +7928,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(replaceTektonPipelinePropertyOptionsModel.Name).To(Equal(core.StringPtr("key1")))
 				Expect(replaceTektonPipelinePropertyOptionsModel.Value).To(Equal(core.StringPtr("https://github.com/IBM/tekton-tutorial.git")))
 				Expect(replaceTektonPipelinePropertyOptionsModel.Enum).To(Equal([]string{"testString"}))
-				Expect(replaceTektonPipelinePropertyOptionsModel.Default).To(Equal(core.StringPtr("testString")))
 				Expect(replaceTektonPipelinePropertyOptionsModel.Type).To(Equal(core.StringPtr("text")))
 				Expect(replaceTektonPipelinePropertyOptionsModel.Path).To(Equal(core.StringPtr("testString")))
 				Expect(replaceTektonPipelinePropertyOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
@@ -7955,7 +7944,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				replaceTektonPipelineTriggerPropertyOptionsModel.SetName("key1")
 				replaceTektonPipelineTriggerPropertyOptionsModel.SetValue("https://github.com/IBM/tekton-tutorial.git")
 				replaceTektonPipelineTriggerPropertyOptionsModel.SetEnum([]string{"testString"})
-				replaceTektonPipelineTriggerPropertyOptionsModel.SetDefault("testString")
 				replaceTektonPipelineTriggerPropertyOptionsModel.SetType("text")
 				replaceTektonPipelineTriggerPropertyOptionsModel.SetPath("testString")
 				replaceTektonPipelineTriggerPropertyOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
@@ -7966,7 +7954,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(replaceTektonPipelineTriggerPropertyOptionsModel.Name).To(Equal(core.StringPtr("key1")))
 				Expect(replaceTektonPipelineTriggerPropertyOptionsModel.Value).To(Equal(core.StringPtr("https://github.com/IBM/tekton-tutorial.git")))
 				Expect(replaceTektonPipelineTriggerPropertyOptionsModel.Enum).To(Equal([]string{"testString"}))
-				Expect(replaceTektonPipelineTriggerPropertyOptionsModel.Default).To(Equal(core.StringPtr("testString")))
 				Expect(replaceTektonPipelineTriggerPropertyOptionsModel.Type).To(Equal(core.StringPtr("text")))
 				Expect(replaceTektonPipelineTriggerPropertyOptionsModel.Path).To(Equal(core.StringPtr("testString")))
 				Expect(replaceTektonPipelineTriggerPropertyOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))

--- a/cdtektonpipelinev2/cd_tekton_pipeline_v2_test.go
+++ b/cdtektonpipelinev2/cd_tekton_pipeline_v2_test.go
@@ -283,7 +283,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path"}, "service_instance_id": "ServiceInstanceID", "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "html_url": "HTMLURL", "build_number": 1, "enabled": false}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "runs_url": "RunsURL", "build_number": 1, "enabled": false}`)
 				}))
 			})
 			It(`Invoke CreateTektonPipeline successfully with retries`, func() {
@@ -358,7 +358,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path"}, "service_instance_id": "ServiceInstanceID", "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "html_url": "HTMLURL", "build_number": 1, "enabled": false}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "runs_url": "RunsURL", "build_number": 1, "enabled": false}`)
 				}))
 			})
 			It(`Invoke CreateTektonPipeline successfully`, func() {
@@ -524,7 +524,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path"}, "service_instance_id": "ServiceInstanceID", "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "html_url": "HTMLURL", "build_number": 1, "enabled": false}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "runs_url": "RunsURL", "build_number": 1, "enabled": false}`)
 				}))
 			})
 			It(`Invoke GetTektonPipeline successfully with retries`, func() {
@@ -578,7 +578,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path"}, "service_instance_id": "ServiceInstanceID", "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "html_url": "HTMLURL", "build_number": 1, "enabled": false}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "runs_url": "RunsURL", "build_number": 1, "enabled": false}`)
 				}))
 			})
 			It(`Invoke GetTektonPipeline successfully`, func() {
@@ -701,10 +701,16 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				workerWithIDModel := new(cdtektonpipelinev2.WorkerWithID)
 				workerWithIDModel.ID = core.StringPtr("public")
 
+				// Construct an instance of the TektonPipelinePatch model
+				tektonPipelinePatchModel := new(cdtektonpipelinev2.TektonPipelinePatch)
+				tektonPipelinePatchModel.Worker = workerWithIDModel
+				tektonPipelinePatchModelAsPatch, asPatchErr := tektonPipelinePatchModel.AsPatch()
+				Expect(asPatchErr).To(BeNil())
+
 				// Construct an instance of the UpdateTektonPipelineOptions model
 				updateTektonPipelineOptionsModel := new(cdtektonpipelinev2.UpdateTektonPipelineOptions)
 				updateTektonPipelineOptionsModel.ID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
-				updateTektonPipelineOptionsModel.Worker = workerWithIDModel
+				updateTektonPipelineOptionsModel.TektonPipelinePatch = tektonPipelinePatchModelAsPatch
 				updateTektonPipelineOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
 				result, response, operationErr := cdTektonPipelineService.UpdateTektonPipeline(updateTektonPipelineOptionsModel)
@@ -757,7 +763,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path"}, "service_instance_id": "ServiceInstanceID", "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "html_url": "HTMLURL", "build_number": 1, "enabled": false}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "runs_url": "RunsURL", "build_number": 1, "enabled": false}`)
 				}))
 			})
 			It(`Invoke UpdateTektonPipeline successfully with retries`, func() {
@@ -773,10 +779,16 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				workerWithIDModel := new(cdtektonpipelinev2.WorkerWithID)
 				workerWithIDModel.ID = core.StringPtr("public")
 
+				// Construct an instance of the TektonPipelinePatch model
+				tektonPipelinePatchModel := new(cdtektonpipelinev2.TektonPipelinePatch)
+				tektonPipelinePatchModel.Worker = workerWithIDModel
+				tektonPipelinePatchModelAsPatch, asPatchErr := tektonPipelinePatchModel.AsPatch()
+				Expect(asPatchErr).To(BeNil())
+
 				// Construct an instance of the UpdateTektonPipelineOptions model
 				updateTektonPipelineOptionsModel := new(cdtektonpipelinev2.UpdateTektonPipelineOptions)
 				updateTektonPipelineOptionsModel.ID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
-				updateTektonPipelineOptionsModel.Worker = workerWithIDModel
+				updateTektonPipelineOptionsModel.TektonPipelinePatch = tektonPipelinePatchModelAsPatch
 				updateTektonPipelineOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with a Context to test a timeout error
@@ -832,7 +844,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path"}, "service_instance_id": "ServiceInstanceID", "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "html_url": "HTMLURL", "build_number": 1, "enabled": false}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "runs_url": "RunsURL", "build_number": 1, "enabled": false}`)
 				}))
 			})
 			It(`Invoke UpdateTektonPipeline successfully`, func() {
@@ -853,10 +865,16 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				workerWithIDModel := new(cdtektonpipelinev2.WorkerWithID)
 				workerWithIDModel.ID = core.StringPtr("public")
 
+				// Construct an instance of the TektonPipelinePatch model
+				tektonPipelinePatchModel := new(cdtektonpipelinev2.TektonPipelinePatch)
+				tektonPipelinePatchModel.Worker = workerWithIDModel
+				tektonPipelinePatchModelAsPatch, asPatchErr := tektonPipelinePatchModel.AsPatch()
+				Expect(asPatchErr).To(BeNil())
+
 				// Construct an instance of the UpdateTektonPipelineOptions model
 				updateTektonPipelineOptionsModel := new(cdtektonpipelinev2.UpdateTektonPipelineOptions)
 				updateTektonPipelineOptionsModel.ID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
-				updateTektonPipelineOptionsModel.Worker = workerWithIDModel
+				updateTektonPipelineOptionsModel.TektonPipelinePatch = tektonPipelinePatchModelAsPatch
 				updateTektonPipelineOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with valid options model (positive test)
@@ -878,10 +896,16 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				workerWithIDModel := new(cdtektonpipelinev2.WorkerWithID)
 				workerWithIDModel.ID = core.StringPtr("public")
 
+				// Construct an instance of the TektonPipelinePatch model
+				tektonPipelinePatchModel := new(cdtektonpipelinev2.TektonPipelinePatch)
+				tektonPipelinePatchModel.Worker = workerWithIDModel
+				tektonPipelinePatchModelAsPatch, asPatchErr := tektonPipelinePatchModel.AsPatch()
+				Expect(asPatchErr).To(BeNil())
+
 				// Construct an instance of the UpdateTektonPipelineOptions model
 				updateTektonPipelineOptionsModel := new(cdtektonpipelinev2.UpdateTektonPipelineOptions)
 				updateTektonPipelineOptionsModel.ID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
-				updateTektonPipelineOptionsModel.Worker = workerWithIDModel
+				updateTektonPipelineOptionsModel.TektonPipelinePatch = tektonPipelinePatchModelAsPatch
 				updateTektonPipelineOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
 				err := cdTektonPipelineService.SetServiceURL("")
@@ -924,10 +948,16 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				workerWithIDModel := new(cdtektonpipelinev2.WorkerWithID)
 				workerWithIDModel.ID = core.StringPtr("public")
 
+				// Construct an instance of the TektonPipelinePatch model
+				tektonPipelinePatchModel := new(cdtektonpipelinev2.TektonPipelinePatch)
+				tektonPipelinePatchModel.Worker = workerWithIDModel
+				tektonPipelinePatchModelAsPatch, asPatchErr := tektonPipelinePatchModel.AsPatch()
+				Expect(asPatchErr).To(BeNil())
+
 				// Construct an instance of the UpdateTektonPipelineOptions model
 				updateTektonPipelineOptionsModel := new(cdtektonpipelinev2.UpdateTektonPipelineOptions)
 				updateTektonPipelineOptionsModel.ID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
-				updateTektonPipelineOptionsModel.Worker = workerWithIDModel
+				updateTektonPipelineOptionsModel.TektonPipelinePatch = tektonPipelinePatchModelAsPatch
 				updateTektonPipelineOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation
@@ -1085,7 +1115,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"pipeline_runs": [{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "html_url": "HTMLURL", "href": "Href"}], "offset": 20, "limit": 20, "first": {"href": "Href"}, "next": {"href": "Href"}}`)
+					fmt.Fprintf(res, "%s", `{"pipeline_runs": [{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL", "href": "Href"}], "offset": 20, "limit": 20, "first": {"href": "Href"}, "next": {"href": "Href"}}`)
 				}))
 			})
 			It(`Invoke ListTektonPipelineRuns successfully with retries`, func() {
@@ -1147,7 +1177,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"pipeline_runs": [{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "html_url": "HTMLURL", "href": "Href"}], "offset": 20, "limit": 20, "first": {"href": "Href"}, "next": {"href": "Href"}}`)
+					fmt.Fprintf(res, "%s", `{"pipeline_runs": [{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL", "href": "Href"}], "offset": 20, "limit": 20, "first": {"href": "Href"}, "next": {"href": "Href"}}`)
 				}))
 			})
 			It(`Invoke ListTektonPipelineRuns successfully`, func() {
@@ -1308,9 +1338,9 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					res.WriteHeader(200)
 					requestNumber++
 					if requestNumber == 1 {
-						fmt.Fprintf(res, "%s", `{"next":{"href":"https://myhost.com/somePath?offset=1"},"total_count":2,"limit":1,"pipeline_runs":[{"id":"ID","user_info":{"iam_id":"IamID","sub":"Sub"},"status":"pending","definition_id":"DefinitionID","worker":{"name":"Name","agent":"Agent","service_id":"ServiceID","id":"ID"},"pipeline_id":"PipelineID","listener_name":"ListenerName","trigger":{"source_trigger_id":"SourceTriggerID","name":"start-deploy"},"event_params_blob":"EventParamsBlob","event_header_params_blob":"EventHeaderParamsBlob","properties":[{"name":"Name","value":"Value","enum":["Enum"],"default":"Default","type":"SECURE","path":"Path"}],"created_at":"2019-01-01T12:00:00.000Z","updated_at":"2019-01-01T12:00:00.000Z","html_url":"HTMLURL","href":"Href"}]}`)
+						fmt.Fprintf(res, "%s", `{"next":{"href":"https://myhost.com/somePath?offset=1"},"total_count":2,"limit":1,"pipeline_runs":[{"id":"ID","user_info":{"iam_id":"IamID","sub":"Sub"},"status":"pending","definition_id":"DefinitionID","worker":{"name":"Name","agent":"Agent","service_id":"ServiceID","id":"ID"},"pipeline_id":"PipelineID","listener_name":"ListenerName","trigger":{"source_trigger_id":"SourceTriggerID","name":"start-deploy"},"event_params_blob":"EventParamsBlob","event_header_params_blob":"EventHeaderParamsBlob","properties":[{"name":"Name","value":"Value","enum":["Enum"],"default":"Default","type":"secure","path":"Path"}],"created_at":"2019-01-01T12:00:00.000Z","updated_at":"2019-01-01T12:00:00.000Z","run_url":"RunURL","href":"Href"}]}`)
 					} else if requestNumber == 2 {
-						fmt.Fprintf(res, "%s", `{"total_count":2,"limit":1,"pipeline_runs":[{"id":"ID","user_info":{"iam_id":"IamID","sub":"Sub"},"status":"pending","definition_id":"DefinitionID","worker":{"name":"Name","agent":"Agent","service_id":"ServiceID","id":"ID"},"pipeline_id":"PipelineID","listener_name":"ListenerName","trigger":{"source_trigger_id":"SourceTriggerID","name":"start-deploy"},"event_params_blob":"EventParamsBlob","event_header_params_blob":"EventHeaderParamsBlob","properties":[{"name":"Name","value":"Value","enum":["Enum"],"default":"Default","type":"SECURE","path":"Path"}],"created_at":"2019-01-01T12:00:00.000Z","updated_at":"2019-01-01T12:00:00.000Z","html_url":"HTMLURL","href":"Href"}]}`)
+						fmt.Fprintf(res, "%s", `{"total_count":2,"limit":1,"pipeline_runs":[{"id":"ID","user_info":{"iam_id":"IamID","sub":"Sub"},"status":"pending","definition_id":"DefinitionID","worker":{"name":"Name","agent":"Agent","service_id":"ServiceID","id":"ID"},"pipeline_id":"PipelineID","listener_name":"ListenerName","trigger":{"source_trigger_id":"SourceTriggerID","name":"start-deploy"},"event_params_blob":"EventParamsBlob","event_header_params_blob":"EventHeaderParamsBlob","properties":[{"name":"Name","value":"Value","enum":["Enum"],"default":"Default","type":"secure","path":"Path"}],"created_at":"2019-01-01T12:00:00.000Z","updated_at":"2019-01-01T12:00:00.000Z","run_url":"RunURL","href":"Href"}]}`)
 					} else {
 						res.WriteHeader(400)
 					}
@@ -1453,7 +1483,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "html_url": "HTMLURL"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
 				}))
 			})
 			It(`Invoke CreateTektonPipelineRun successfully with retries`, func() {
@@ -1528,7 +1558,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "html_url": "HTMLURL"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
 				}))
 			})
 			It(`Invoke CreateTektonPipelineRun successfully`, func() {
@@ -1705,7 +1735,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "html_url": "HTMLURL"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
 				}))
 			})
 			It(`Invoke GetTektonPipelineRun successfully with retries`, func() {
@@ -1762,7 +1792,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "html_url": "HTMLURL"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
 				}))
 			})
 			It(`Invoke GetTektonPipelineRun successfully`, func() {
@@ -2014,7 +2044,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "html_url": "HTMLURL"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
 				}))
 			})
 			It(`Invoke CancelTektonPipelineRun successfully with retries`, func() {
@@ -2086,7 +2116,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "html_url": "HTMLURL"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
 				}))
 			})
 			It(`Invoke CancelTektonPipelineRun successfully`, func() {
@@ -2251,7 +2281,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "html_url": "HTMLURL"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
 				}))
 			})
 			It(`Invoke RerunTektonPipelineRun successfully with retries`, func() {
@@ -2306,7 +2336,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "html_url": "HTMLURL"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
 				}))
 			})
 			It(`Invoke RerunTektonPipelineRun successfully`, func() {
@@ -2468,7 +2498,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"logs": [{"name": "Name", "id": "ID", "href": "Href"}]}`)
+					fmt.Fprintf(res, "%s", `{"logs": [{"data": "Data", "href": "Href", "id": "ID", "name": "Name"}]}`)
 				}))
 			})
 			It(`Invoke GetTektonPipelineRunLogs successfully with retries`, func() {
@@ -2523,7 +2553,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"logs": [{"name": "Name", "id": "ID", "href": "Href"}]}`)
+					fmt.Fprintf(res, "%s", `{"logs": [{"data": "Data", "href": "Href", "id": "ID", "name": "Name"}]}`)
 				}))
 			})
 			It(`Invoke GetTektonPipelineRunLogs successfully`, func() {
@@ -2686,7 +2716,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "data": "Data"}`)
+					fmt.Fprintf(res, "%s", `{"data": "Data", "href": "Href", "id": "ID", "name": "Name"}`)
 				}))
 			})
 			It(`Invoke GetTektonPipelineRunLogContent successfully with retries`, func() {
@@ -2742,7 +2772,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "data": "Data"}`)
+					fmt.Fprintf(res, "%s", `{"data": "Data", "href": "Href", "id": "ID", "name": "Name"}`)
 				}))
 			})
 			It(`Invoke GetTektonPipelineRunLogContent successfully`, func() {
@@ -2906,7 +2936,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path"}, "service_instance_id": "ServiceInstanceID", "id": "ID", "href": "Href"}]}`)
+					fmt.Fprintf(res, "%s", `{"definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID", "href": "Href"}]}`)
 				}))
 			})
 			It(`Invoke ListTektonPipelineDefinitions successfully with retries`, func() {
@@ -2960,7 +2990,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path"}, "service_instance_id": "ServiceInstanceID", "id": "ID", "href": "Href"}]}`)
+					fmt.Fprintf(res, "%s", `{"definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID", "href": "Href"}]}`)
 				}))
 			})
 			It(`Invoke ListTektonPipelineDefinitions successfully`, func() {
@@ -3085,12 +3115,12 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				definitionScmSourceModel.Branch = core.StringPtr("master")
 				definitionScmSourceModel.Tag = core.StringPtr("testString")
 				definitionScmSourceModel.Path = core.StringPtr(".tekton")
+				definitionScmSourceModel.ServiceInstanceID = core.StringPtr("testString")
 
 				// Construct an instance of the CreateTektonPipelineDefinitionOptions model
 				createTektonPipelineDefinitionOptionsModel := new(cdtektonpipelinev2.CreateTektonPipelineDefinitionOptions)
 				createTektonPipelineDefinitionOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				createTektonPipelineDefinitionOptionsModel.ScmSource = definitionScmSourceModel
-				createTektonPipelineDefinitionOptionsModel.ServiceInstanceID = core.StringPtr("testString")
 				createTektonPipelineDefinitionOptionsModel.ID = core.StringPtr("testString")
 				createTektonPipelineDefinitionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
@@ -3144,7 +3174,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path"}, "service_instance_id": "ServiceInstanceID", "id": "ID"}`)
+					fmt.Fprintf(res, "%s", `{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}`)
 				}))
 			})
 			It(`Invoke CreateTektonPipelineDefinition successfully with retries`, func() {
@@ -3162,12 +3192,12 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				definitionScmSourceModel.Branch = core.StringPtr("master")
 				definitionScmSourceModel.Tag = core.StringPtr("testString")
 				definitionScmSourceModel.Path = core.StringPtr(".tekton")
+				definitionScmSourceModel.ServiceInstanceID = core.StringPtr("testString")
 
 				// Construct an instance of the CreateTektonPipelineDefinitionOptions model
 				createTektonPipelineDefinitionOptionsModel := new(cdtektonpipelinev2.CreateTektonPipelineDefinitionOptions)
 				createTektonPipelineDefinitionOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				createTektonPipelineDefinitionOptionsModel.ScmSource = definitionScmSourceModel
-				createTektonPipelineDefinitionOptionsModel.ServiceInstanceID = core.StringPtr("testString")
 				createTektonPipelineDefinitionOptionsModel.ID = core.StringPtr("testString")
 				createTektonPipelineDefinitionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -3224,7 +3254,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path"}, "service_instance_id": "ServiceInstanceID", "id": "ID"}`)
+					fmt.Fprintf(res, "%s", `{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}`)
 				}))
 			})
 			It(`Invoke CreateTektonPipelineDefinition successfully`, func() {
@@ -3247,12 +3277,12 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				definitionScmSourceModel.Branch = core.StringPtr("master")
 				definitionScmSourceModel.Tag = core.StringPtr("testString")
 				definitionScmSourceModel.Path = core.StringPtr(".tekton")
+				definitionScmSourceModel.ServiceInstanceID = core.StringPtr("testString")
 
 				// Construct an instance of the CreateTektonPipelineDefinitionOptions model
 				createTektonPipelineDefinitionOptionsModel := new(cdtektonpipelinev2.CreateTektonPipelineDefinitionOptions)
 				createTektonPipelineDefinitionOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				createTektonPipelineDefinitionOptionsModel.ScmSource = definitionScmSourceModel
-				createTektonPipelineDefinitionOptionsModel.ServiceInstanceID = core.StringPtr("testString")
 				createTektonPipelineDefinitionOptionsModel.ID = core.StringPtr("testString")
 				createTektonPipelineDefinitionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -3277,12 +3307,12 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				definitionScmSourceModel.Branch = core.StringPtr("master")
 				definitionScmSourceModel.Tag = core.StringPtr("testString")
 				definitionScmSourceModel.Path = core.StringPtr(".tekton")
+				definitionScmSourceModel.ServiceInstanceID = core.StringPtr("testString")
 
 				// Construct an instance of the CreateTektonPipelineDefinitionOptions model
 				createTektonPipelineDefinitionOptionsModel := new(cdtektonpipelinev2.CreateTektonPipelineDefinitionOptions)
 				createTektonPipelineDefinitionOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				createTektonPipelineDefinitionOptionsModel.ScmSource = definitionScmSourceModel
-				createTektonPipelineDefinitionOptionsModel.ServiceInstanceID = core.StringPtr("testString")
 				createTektonPipelineDefinitionOptionsModel.ID = core.StringPtr("testString")
 				createTektonPipelineDefinitionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
@@ -3328,12 +3358,12 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				definitionScmSourceModel.Branch = core.StringPtr("master")
 				definitionScmSourceModel.Tag = core.StringPtr("testString")
 				definitionScmSourceModel.Path = core.StringPtr(".tekton")
+				definitionScmSourceModel.ServiceInstanceID = core.StringPtr("testString")
 
 				// Construct an instance of the CreateTektonPipelineDefinitionOptions model
 				createTektonPipelineDefinitionOptionsModel := new(cdtektonpipelinev2.CreateTektonPipelineDefinitionOptions)
 				createTektonPipelineDefinitionOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				createTektonPipelineDefinitionOptionsModel.ScmSource = definitionScmSourceModel
-				createTektonPipelineDefinitionOptionsModel.ServiceInstanceID = core.StringPtr("testString")
 				createTektonPipelineDefinitionOptionsModel.ID = core.StringPtr("testString")
 				createTektonPipelineDefinitionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -3413,7 +3443,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path"}, "service_instance_id": "ServiceInstanceID", "id": "ID"}`)
+					fmt.Fprintf(res, "%s", `{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}`)
 				}))
 			})
 			It(`Invoke GetTektonPipelineDefinition successfully with retries`, func() {
@@ -3468,7 +3498,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path"}, "service_instance_id": "ServiceInstanceID", "id": "ID"}`)
+					fmt.Fprintf(res, "%s", `{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}`)
 				}))
 			})
 			It(`Invoke GetTektonPipelineDefinition successfully`, func() {
@@ -3596,13 +3626,13 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				definitionScmSourceModel.Branch = core.StringPtr("master")
 				definitionScmSourceModel.Tag = core.StringPtr("testString")
 				definitionScmSourceModel.Path = core.StringPtr(".tekton")
+				definitionScmSourceModel.ServiceInstanceID = core.StringPtr("071d8049-d984-4feb-a2ed-2a1e938918ba")
 
 				// Construct an instance of the ReplaceTektonPipelineDefinitionOptions model
 				replaceTektonPipelineDefinitionOptionsModel := new(cdtektonpipelinev2.ReplaceTektonPipelineDefinitionOptions)
 				replaceTektonPipelineDefinitionOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				replaceTektonPipelineDefinitionOptionsModel.DefinitionID = core.StringPtr("94299034-d45f-4e9a-8ed5-6bd5c7bb7ada")
 				replaceTektonPipelineDefinitionOptionsModel.ScmSource = definitionScmSourceModel
-				replaceTektonPipelineDefinitionOptionsModel.ServiceInstanceID = core.StringPtr("071d8049-d984-4feb-a2ed-2a1e938918ba")
 				replaceTektonPipelineDefinitionOptionsModel.ID = core.StringPtr("22f92ab1-e0ac-4c65-84e7-8a4cb32dba0f")
 				replaceTektonPipelineDefinitionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
@@ -3656,7 +3686,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path"}, "service_instance_id": "ServiceInstanceID", "id": "ID"}`)
+					fmt.Fprintf(res, "%s", `{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}`)
 				}))
 			})
 			It(`Invoke ReplaceTektonPipelineDefinition successfully with retries`, func() {
@@ -3674,13 +3704,13 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				definitionScmSourceModel.Branch = core.StringPtr("master")
 				definitionScmSourceModel.Tag = core.StringPtr("testString")
 				definitionScmSourceModel.Path = core.StringPtr(".tekton")
+				definitionScmSourceModel.ServiceInstanceID = core.StringPtr("071d8049-d984-4feb-a2ed-2a1e938918ba")
 
 				// Construct an instance of the ReplaceTektonPipelineDefinitionOptions model
 				replaceTektonPipelineDefinitionOptionsModel := new(cdtektonpipelinev2.ReplaceTektonPipelineDefinitionOptions)
 				replaceTektonPipelineDefinitionOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				replaceTektonPipelineDefinitionOptionsModel.DefinitionID = core.StringPtr("94299034-d45f-4e9a-8ed5-6bd5c7bb7ada")
 				replaceTektonPipelineDefinitionOptionsModel.ScmSource = definitionScmSourceModel
-				replaceTektonPipelineDefinitionOptionsModel.ServiceInstanceID = core.StringPtr("071d8049-d984-4feb-a2ed-2a1e938918ba")
 				replaceTektonPipelineDefinitionOptionsModel.ID = core.StringPtr("22f92ab1-e0ac-4c65-84e7-8a4cb32dba0f")
 				replaceTektonPipelineDefinitionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -3737,7 +3767,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path"}, "service_instance_id": "ServiceInstanceID", "id": "ID"}`)
+					fmt.Fprintf(res, "%s", `{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}`)
 				}))
 			})
 			It(`Invoke ReplaceTektonPipelineDefinition successfully`, func() {
@@ -3760,13 +3790,13 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				definitionScmSourceModel.Branch = core.StringPtr("master")
 				definitionScmSourceModel.Tag = core.StringPtr("testString")
 				definitionScmSourceModel.Path = core.StringPtr(".tekton")
+				definitionScmSourceModel.ServiceInstanceID = core.StringPtr("071d8049-d984-4feb-a2ed-2a1e938918ba")
 
 				// Construct an instance of the ReplaceTektonPipelineDefinitionOptions model
 				replaceTektonPipelineDefinitionOptionsModel := new(cdtektonpipelinev2.ReplaceTektonPipelineDefinitionOptions)
 				replaceTektonPipelineDefinitionOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				replaceTektonPipelineDefinitionOptionsModel.DefinitionID = core.StringPtr("94299034-d45f-4e9a-8ed5-6bd5c7bb7ada")
 				replaceTektonPipelineDefinitionOptionsModel.ScmSource = definitionScmSourceModel
-				replaceTektonPipelineDefinitionOptionsModel.ServiceInstanceID = core.StringPtr("071d8049-d984-4feb-a2ed-2a1e938918ba")
 				replaceTektonPipelineDefinitionOptionsModel.ID = core.StringPtr("22f92ab1-e0ac-4c65-84e7-8a4cb32dba0f")
 				replaceTektonPipelineDefinitionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -3791,13 +3821,13 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				definitionScmSourceModel.Branch = core.StringPtr("master")
 				definitionScmSourceModel.Tag = core.StringPtr("testString")
 				definitionScmSourceModel.Path = core.StringPtr(".tekton")
+				definitionScmSourceModel.ServiceInstanceID = core.StringPtr("071d8049-d984-4feb-a2ed-2a1e938918ba")
 
 				// Construct an instance of the ReplaceTektonPipelineDefinitionOptions model
 				replaceTektonPipelineDefinitionOptionsModel := new(cdtektonpipelinev2.ReplaceTektonPipelineDefinitionOptions)
 				replaceTektonPipelineDefinitionOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				replaceTektonPipelineDefinitionOptionsModel.DefinitionID = core.StringPtr("94299034-d45f-4e9a-8ed5-6bd5c7bb7ada")
 				replaceTektonPipelineDefinitionOptionsModel.ScmSource = definitionScmSourceModel
-				replaceTektonPipelineDefinitionOptionsModel.ServiceInstanceID = core.StringPtr("071d8049-d984-4feb-a2ed-2a1e938918ba")
 				replaceTektonPipelineDefinitionOptionsModel.ID = core.StringPtr("22f92ab1-e0ac-4c65-84e7-8a4cb32dba0f")
 				replaceTektonPipelineDefinitionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
@@ -3843,13 +3873,13 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				definitionScmSourceModel.Branch = core.StringPtr("master")
 				definitionScmSourceModel.Tag = core.StringPtr("testString")
 				definitionScmSourceModel.Path = core.StringPtr(".tekton")
+				definitionScmSourceModel.ServiceInstanceID = core.StringPtr("071d8049-d984-4feb-a2ed-2a1e938918ba")
 
 				// Construct an instance of the ReplaceTektonPipelineDefinitionOptions model
 				replaceTektonPipelineDefinitionOptionsModel := new(cdtektonpipelinev2.ReplaceTektonPipelineDefinitionOptions)
 				replaceTektonPipelineDefinitionOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				replaceTektonPipelineDefinitionOptionsModel.DefinitionID = core.StringPtr("94299034-d45f-4e9a-8ed5-6bd5c7bb7ada")
 				replaceTektonPipelineDefinitionOptionsModel.ScmSource = definitionScmSourceModel
-				replaceTektonPipelineDefinitionOptionsModel.ServiceInstanceID = core.StringPtr("071d8049-d984-4feb-a2ed-2a1e938918ba")
 				replaceTektonPipelineDefinitionOptionsModel.ID = core.StringPtr("22f92ab1-e0ac-4c65-84e7-8a4cb32dba0f")
 				replaceTektonPipelineDefinitionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -3965,7 +3995,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				listTektonPipelinePropertiesOptionsModel := new(cdtektonpipelinev2.ListTektonPipelinePropertiesOptions)
 				listTektonPipelinePropertiesOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				listTektonPipelinePropertiesOptionsModel.Name = core.StringPtr("prod")
-				listTektonPipelinePropertiesOptionsModel.Type = []string{"SECURE", "TEXT"}
+				listTektonPipelinePropertiesOptionsModel.Type = []string{"secure", "text"}
 				listTektonPipelinePropertiesOptionsModel.Sort = core.StringPtr("name")
 				listTektonPipelinePropertiesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
@@ -4005,7 +4035,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}]}`)
+					fmt.Fprintf(res, "%s", `{"properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}]}`)
 				}))
 			})
 			It(`Invoke ListTektonPipelineProperties successfully with retries`, func() {
@@ -4021,7 +4051,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				listTektonPipelinePropertiesOptionsModel := new(cdtektonpipelinev2.ListTektonPipelinePropertiesOptions)
 				listTektonPipelinePropertiesOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				listTektonPipelinePropertiesOptionsModel.Name = core.StringPtr("prod")
-				listTektonPipelinePropertiesOptionsModel.Type = []string{"SECURE", "TEXT"}
+				listTektonPipelinePropertiesOptionsModel.Type = []string{"secure", "text"}
 				listTektonPipelinePropertiesOptionsModel.Sort = core.StringPtr("name")
 				listTektonPipelinePropertiesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -4064,7 +4094,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}]}`)
+					fmt.Fprintf(res, "%s", `{"properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}]}`)
 				}))
 			})
 			It(`Invoke ListTektonPipelineProperties successfully`, func() {
@@ -4085,7 +4115,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				listTektonPipelinePropertiesOptionsModel := new(cdtektonpipelinev2.ListTektonPipelinePropertiesOptions)
 				listTektonPipelinePropertiesOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				listTektonPipelinePropertiesOptionsModel.Name = core.StringPtr("prod")
-				listTektonPipelinePropertiesOptionsModel.Type = []string{"SECURE", "TEXT"}
+				listTektonPipelinePropertiesOptionsModel.Type = []string{"secure", "text"}
 				listTektonPipelinePropertiesOptionsModel.Sort = core.StringPtr("name")
 				listTektonPipelinePropertiesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -4108,7 +4138,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				listTektonPipelinePropertiesOptionsModel := new(cdtektonpipelinev2.ListTektonPipelinePropertiesOptions)
 				listTektonPipelinePropertiesOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				listTektonPipelinePropertiesOptionsModel.Name = core.StringPtr("prod")
-				listTektonPipelinePropertiesOptionsModel.Type = []string{"SECURE", "TEXT"}
+				listTektonPipelinePropertiesOptionsModel.Type = []string{"secure", "text"}
 				listTektonPipelinePropertiesOptionsModel.Sort = core.StringPtr("name")
 				listTektonPipelinePropertiesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
@@ -4152,7 +4182,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				listTektonPipelinePropertiesOptionsModel := new(cdtektonpipelinev2.ListTektonPipelinePropertiesOptions)
 				listTektonPipelinePropertiesOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				listTektonPipelinePropertiesOptionsModel.Name = core.StringPtr("prod")
-				listTektonPipelinePropertiesOptionsModel.Type = []string{"SECURE", "TEXT"}
+				listTektonPipelinePropertiesOptionsModel.Type = []string{"secure", "text"}
 				listTektonPipelinePropertiesOptionsModel.Sort = core.StringPtr("name")
 				listTektonPipelinePropertiesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -4199,7 +4229,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelinePropertiesOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				createTektonPipelinePropertiesOptionsModel.Enum = []string{"testString"}
 				createTektonPipelinePropertiesOptionsModel.Default = core.StringPtr("testString")
-				createTektonPipelinePropertiesOptionsModel.Type = core.StringPtr("TEXT")
+				createTektonPipelinePropertiesOptionsModel.Type = core.StringPtr("text")
 				createTektonPipelinePropertiesOptionsModel.Path = core.StringPtr("testString")
 				createTektonPipelinePropertiesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
@@ -4253,7 +4283,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}`)
 				}))
 			})
 			It(`Invoke CreateTektonPipelineProperties successfully with retries`, func() {
@@ -4272,7 +4302,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelinePropertiesOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				createTektonPipelinePropertiesOptionsModel.Enum = []string{"testString"}
 				createTektonPipelinePropertiesOptionsModel.Default = core.StringPtr("testString")
-				createTektonPipelinePropertiesOptionsModel.Type = core.StringPtr("TEXT")
+				createTektonPipelinePropertiesOptionsModel.Type = core.StringPtr("text")
 				createTektonPipelinePropertiesOptionsModel.Path = core.StringPtr("testString")
 				createTektonPipelinePropertiesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -4329,7 +4359,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}`)
 				}))
 			})
 			It(`Invoke CreateTektonPipelineProperties successfully`, func() {
@@ -4353,7 +4383,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelinePropertiesOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				createTektonPipelinePropertiesOptionsModel.Enum = []string{"testString"}
 				createTektonPipelinePropertiesOptionsModel.Default = core.StringPtr("testString")
-				createTektonPipelinePropertiesOptionsModel.Type = core.StringPtr("TEXT")
+				createTektonPipelinePropertiesOptionsModel.Type = core.StringPtr("text")
 				createTektonPipelinePropertiesOptionsModel.Path = core.StringPtr("testString")
 				createTektonPipelinePropertiesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -4379,7 +4409,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelinePropertiesOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				createTektonPipelinePropertiesOptionsModel.Enum = []string{"testString"}
 				createTektonPipelinePropertiesOptionsModel.Default = core.StringPtr("testString")
-				createTektonPipelinePropertiesOptionsModel.Type = core.StringPtr("TEXT")
+				createTektonPipelinePropertiesOptionsModel.Type = core.StringPtr("text")
 				createTektonPipelinePropertiesOptionsModel.Path = core.StringPtr("testString")
 				createTektonPipelinePropertiesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
@@ -4426,7 +4456,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelinePropertiesOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				createTektonPipelinePropertiesOptionsModel.Enum = []string{"testString"}
 				createTektonPipelinePropertiesOptionsModel.Default = core.StringPtr("testString")
-				createTektonPipelinePropertiesOptionsModel.Type = core.StringPtr("TEXT")
+				createTektonPipelinePropertiesOptionsModel.Type = core.StringPtr("text")
 				createTektonPipelinePropertiesOptionsModel.Path = core.StringPtr("testString")
 				createTektonPipelinePropertiesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -4506,7 +4536,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}`)
 				}))
 			})
 			It(`Invoke GetTektonPipelineProperty successfully with retries`, func() {
@@ -4561,7 +4591,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}`)
 				}))
 			})
 			It(`Invoke GetTektonPipelineProperty successfully`, func() {
@@ -4691,7 +4721,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				replaceTektonPipelinePropertyOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				replaceTektonPipelinePropertyOptionsModel.Enum = []string{"testString"}
 				replaceTektonPipelinePropertyOptionsModel.Default = core.StringPtr("testString")
-				replaceTektonPipelinePropertyOptionsModel.Type = core.StringPtr("TEXT")
+				replaceTektonPipelinePropertyOptionsModel.Type = core.StringPtr("text")
 				replaceTektonPipelinePropertyOptionsModel.Path = core.StringPtr("testString")
 				replaceTektonPipelinePropertyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
@@ -4745,7 +4775,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}`)
 				}))
 			})
 			It(`Invoke ReplaceTektonPipelineProperty successfully with retries`, func() {
@@ -4765,7 +4795,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				replaceTektonPipelinePropertyOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				replaceTektonPipelinePropertyOptionsModel.Enum = []string{"testString"}
 				replaceTektonPipelinePropertyOptionsModel.Default = core.StringPtr("testString")
-				replaceTektonPipelinePropertyOptionsModel.Type = core.StringPtr("TEXT")
+				replaceTektonPipelinePropertyOptionsModel.Type = core.StringPtr("text")
 				replaceTektonPipelinePropertyOptionsModel.Path = core.StringPtr("testString")
 				replaceTektonPipelinePropertyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -4822,7 +4852,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}`)
 				}))
 			})
 			It(`Invoke ReplaceTektonPipelineProperty successfully`, func() {
@@ -4847,7 +4877,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				replaceTektonPipelinePropertyOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				replaceTektonPipelinePropertyOptionsModel.Enum = []string{"testString"}
 				replaceTektonPipelinePropertyOptionsModel.Default = core.StringPtr("testString")
-				replaceTektonPipelinePropertyOptionsModel.Type = core.StringPtr("TEXT")
+				replaceTektonPipelinePropertyOptionsModel.Type = core.StringPtr("text")
 				replaceTektonPipelinePropertyOptionsModel.Path = core.StringPtr("testString")
 				replaceTektonPipelinePropertyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -4874,7 +4904,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				replaceTektonPipelinePropertyOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				replaceTektonPipelinePropertyOptionsModel.Enum = []string{"testString"}
 				replaceTektonPipelinePropertyOptionsModel.Default = core.StringPtr("testString")
-				replaceTektonPipelinePropertyOptionsModel.Type = core.StringPtr("TEXT")
+				replaceTektonPipelinePropertyOptionsModel.Type = core.StringPtr("text")
 				replaceTektonPipelinePropertyOptionsModel.Path = core.StringPtr("testString")
 				replaceTektonPipelinePropertyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
@@ -4922,7 +4952,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				replaceTektonPipelinePropertyOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				replaceTektonPipelinePropertyOptionsModel.Enum = []string{"testString"}
 				replaceTektonPipelinePropertyOptionsModel.Default = core.StringPtr("testString")
-				replaceTektonPipelinePropertyOptionsModel.Type = core.StringPtr("TEXT")
+				replaceTektonPipelinePropertyOptionsModel.Type = core.StringPtr("text")
 				replaceTektonPipelinePropertyOptionsModel.Path = core.StringPtr("testString")
 				replaceTektonPipelinePropertyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -5799,7 +5829,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 
 				// Construct an instance of the GenericSecret model
 				genericSecretModel := new(cdtektonpipelinev2.GenericSecret)
-				genericSecretModel.Type = core.StringPtr("tokenMatches")
+				genericSecretModel.Type = core.StringPtr("token_matches")
 				genericSecretModel.Value = core.StringPtr("testString")
 				genericSecretModel.Source = core.StringPtr("header")
 				genericSecretModel.KeyName = core.StringPtr("testString")
@@ -5812,6 +5842,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				triggerScmSourceModel.Pattern = core.StringPtr("testString")
 				triggerScmSourceModel.BlindConnection = core.BoolPtr(true)
 				triggerScmSourceModel.HookID = core.StringPtr("testString")
+				triggerScmSourceModel.ServiceInstanceID = core.StringPtr("testString")
 
 				// Construct an instance of the Events model
 				eventsModel := new(cdtektonpipelinev2.Events)
@@ -5819,22 +5850,28 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				eventsModel.PullRequestClosed = core.BoolPtr(true)
 				eventsModel.PullRequest = core.BoolPtr(true)
 
+				// Construct an instance of the TriggerPatch model
+				triggerPatchModel := new(cdtektonpipelinev2.TriggerPatch)
+				triggerPatchModel.Type = core.StringPtr("manual")
+				triggerPatchModel.Name = core.StringPtr("start-deploy")
+				triggerPatchModel.EventListener = core.StringPtr("testString")
+				triggerPatchModel.Tags = []string{"testString"}
+				triggerPatchModel.Worker = workerModel
+				triggerPatchModel.MaxConcurrentRuns = core.Int64Ptr(int64(4))
+				triggerPatchModel.Disabled = core.BoolPtr(true)
+				triggerPatchModel.Secret = genericSecretModel
+				triggerPatchModel.Cron = core.StringPtr("testString")
+				triggerPatchModel.Timezone = core.StringPtr("America/Los_Angeles, CET, Europe/London, GMT, US/Eastern, or UTC")
+				triggerPatchModel.ScmSource = triggerScmSourceModel
+				triggerPatchModel.Events = eventsModel
+				triggerPatchModelAsPatch, asPatchErr := triggerPatchModel.AsPatch()
+				Expect(asPatchErr).To(BeNil())
+
 				// Construct an instance of the UpdateTektonPipelineTriggerOptions model
 				updateTektonPipelineTriggerOptionsModel := new(cdtektonpipelinev2.UpdateTektonPipelineTriggerOptions)
 				updateTektonPipelineTriggerOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				updateTektonPipelineTriggerOptionsModel.TriggerID = core.StringPtr("1bb892a1-2e04-4768-a369-b1159eace147")
-				updateTektonPipelineTriggerOptionsModel.Type = core.StringPtr("manual")
-				updateTektonPipelineTriggerOptionsModel.Name = core.StringPtr("start-deploy")
-				updateTektonPipelineTriggerOptionsModel.EventListener = core.StringPtr("testString")
-				updateTektonPipelineTriggerOptionsModel.Tags = []string{"testString"}
-				updateTektonPipelineTriggerOptionsModel.Worker = workerModel
-				updateTektonPipelineTriggerOptionsModel.MaxConcurrentRuns = core.Int64Ptr(int64(38))
-				updateTektonPipelineTriggerOptionsModel.Disabled = core.BoolPtr(true)
-				updateTektonPipelineTriggerOptionsModel.Secret = genericSecretModel
-				updateTektonPipelineTriggerOptionsModel.Cron = core.StringPtr("testString")
-				updateTektonPipelineTriggerOptionsModel.Timezone = core.StringPtr("Africa/Abidjan")
-				updateTektonPipelineTriggerOptionsModel.ScmSource = triggerScmSourceModel
-				updateTektonPipelineTriggerOptionsModel.Events = eventsModel
+				updateTektonPipelineTriggerOptionsModel.TriggerPatch = triggerPatchModelAsPatch
 				updateTektonPipelineTriggerOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
 				result, response, operationErr := cdTektonPipelineService.UpdateTektonPipelineTrigger(updateTektonPipelineTriggerOptionsModel)
@@ -5907,7 +5944,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 
 				// Construct an instance of the GenericSecret model
 				genericSecretModel := new(cdtektonpipelinev2.GenericSecret)
-				genericSecretModel.Type = core.StringPtr("tokenMatches")
+				genericSecretModel.Type = core.StringPtr("token_matches")
 				genericSecretModel.Value = core.StringPtr("testString")
 				genericSecretModel.Source = core.StringPtr("header")
 				genericSecretModel.KeyName = core.StringPtr("testString")
@@ -5920,6 +5957,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				triggerScmSourceModel.Pattern = core.StringPtr("testString")
 				triggerScmSourceModel.BlindConnection = core.BoolPtr(true)
 				triggerScmSourceModel.HookID = core.StringPtr("testString")
+				triggerScmSourceModel.ServiceInstanceID = core.StringPtr("testString")
 
 				// Construct an instance of the Events model
 				eventsModel := new(cdtektonpipelinev2.Events)
@@ -5927,22 +5965,28 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				eventsModel.PullRequestClosed = core.BoolPtr(true)
 				eventsModel.PullRequest = core.BoolPtr(true)
 
+				// Construct an instance of the TriggerPatch model
+				triggerPatchModel := new(cdtektonpipelinev2.TriggerPatch)
+				triggerPatchModel.Type = core.StringPtr("manual")
+				triggerPatchModel.Name = core.StringPtr("start-deploy")
+				triggerPatchModel.EventListener = core.StringPtr("testString")
+				triggerPatchModel.Tags = []string{"testString"}
+				triggerPatchModel.Worker = workerModel
+				triggerPatchModel.MaxConcurrentRuns = core.Int64Ptr(int64(4))
+				triggerPatchModel.Disabled = core.BoolPtr(true)
+				triggerPatchModel.Secret = genericSecretModel
+				triggerPatchModel.Cron = core.StringPtr("testString")
+				triggerPatchModel.Timezone = core.StringPtr("America/Los_Angeles, CET, Europe/London, GMT, US/Eastern, or UTC")
+				triggerPatchModel.ScmSource = triggerScmSourceModel
+				triggerPatchModel.Events = eventsModel
+				triggerPatchModelAsPatch, asPatchErr := triggerPatchModel.AsPatch()
+				Expect(asPatchErr).To(BeNil())
+
 				// Construct an instance of the UpdateTektonPipelineTriggerOptions model
 				updateTektonPipelineTriggerOptionsModel := new(cdtektonpipelinev2.UpdateTektonPipelineTriggerOptions)
 				updateTektonPipelineTriggerOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				updateTektonPipelineTriggerOptionsModel.TriggerID = core.StringPtr("1bb892a1-2e04-4768-a369-b1159eace147")
-				updateTektonPipelineTriggerOptionsModel.Type = core.StringPtr("manual")
-				updateTektonPipelineTriggerOptionsModel.Name = core.StringPtr("start-deploy")
-				updateTektonPipelineTriggerOptionsModel.EventListener = core.StringPtr("testString")
-				updateTektonPipelineTriggerOptionsModel.Tags = []string{"testString"}
-				updateTektonPipelineTriggerOptionsModel.Worker = workerModel
-				updateTektonPipelineTriggerOptionsModel.MaxConcurrentRuns = core.Int64Ptr(int64(38))
-				updateTektonPipelineTriggerOptionsModel.Disabled = core.BoolPtr(true)
-				updateTektonPipelineTriggerOptionsModel.Secret = genericSecretModel
-				updateTektonPipelineTriggerOptionsModel.Cron = core.StringPtr("testString")
-				updateTektonPipelineTriggerOptionsModel.Timezone = core.StringPtr("Africa/Abidjan")
-				updateTektonPipelineTriggerOptionsModel.ScmSource = triggerScmSourceModel
-				updateTektonPipelineTriggerOptionsModel.Events = eventsModel
+				updateTektonPipelineTriggerOptionsModel.TriggerPatch = triggerPatchModelAsPatch
 				updateTektonPipelineTriggerOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with a Context to test a timeout error
@@ -6023,7 +6067,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 
 				// Construct an instance of the GenericSecret model
 				genericSecretModel := new(cdtektonpipelinev2.GenericSecret)
-				genericSecretModel.Type = core.StringPtr("tokenMatches")
+				genericSecretModel.Type = core.StringPtr("token_matches")
 				genericSecretModel.Value = core.StringPtr("testString")
 				genericSecretModel.Source = core.StringPtr("header")
 				genericSecretModel.KeyName = core.StringPtr("testString")
@@ -6036,6 +6080,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				triggerScmSourceModel.Pattern = core.StringPtr("testString")
 				triggerScmSourceModel.BlindConnection = core.BoolPtr(true)
 				triggerScmSourceModel.HookID = core.StringPtr("testString")
+				triggerScmSourceModel.ServiceInstanceID = core.StringPtr("testString")
 
 				// Construct an instance of the Events model
 				eventsModel := new(cdtektonpipelinev2.Events)
@@ -6043,22 +6088,28 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				eventsModel.PullRequestClosed = core.BoolPtr(true)
 				eventsModel.PullRequest = core.BoolPtr(true)
 
+				// Construct an instance of the TriggerPatch model
+				triggerPatchModel := new(cdtektonpipelinev2.TriggerPatch)
+				triggerPatchModel.Type = core.StringPtr("manual")
+				triggerPatchModel.Name = core.StringPtr("start-deploy")
+				triggerPatchModel.EventListener = core.StringPtr("testString")
+				triggerPatchModel.Tags = []string{"testString"}
+				triggerPatchModel.Worker = workerModel
+				triggerPatchModel.MaxConcurrentRuns = core.Int64Ptr(int64(4))
+				triggerPatchModel.Disabled = core.BoolPtr(true)
+				triggerPatchModel.Secret = genericSecretModel
+				triggerPatchModel.Cron = core.StringPtr("testString")
+				triggerPatchModel.Timezone = core.StringPtr("America/Los_Angeles, CET, Europe/London, GMT, US/Eastern, or UTC")
+				triggerPatchModel.ScmSource = triggerScmSourceModel
+				triggerPatchModel.Events = eventsModel
+				triggerPatchModelAsPatch, asPatchErr := triggerPatchModel.AsPatch()
+				Expect(asPatchErr).To(BeNil())
+
 				// Construct an instance of the UpdateTektonPipelineTriggerOptions model
 				updateTektonPipelineTriggerOptionsModel := new(cdtektonpipelinev2.UpdateTektonPipelineTriggerOptions)
 				updateTektonPipelineTriggerOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				updateTektonPipelineTriggerOptionsModel.TriggerID = core.StringPtr("1bb892a1-2e04-4768-a369-b1159eace147")
-				updateTektonPipelineTriggerOptionsModel.Type = core.StringPtr("manual")
-				updateTektonPipelineTriggerOptionsModel.Name = core.StringPtr("start-deploy")
-				updateTektonPipelineTriggerOptionsModel.EventListener = core.StringPtr("testString")
-				updateTektonPipelineTriggerOptionsModel.Tags = []string{"testString"}
-				updateTektonPipelineTriggerOptionsModel.Worker = workerModel
-				updateTektonPipelineTriggerOptionsModel.MaxConcurrentRuns = core.Int64Ptr(int64(38))
-				updateTektonPipelineTriggerOptionsModel.Disabled = core.BoolPtr(true)
-				updateTektonPipelineTriggerOptionsModel.Secret = genericSecretModel
-				updateTektonPipelineTriggerOptionsModel.Cron = core.StringPtr("testString")
-				updateTektonPipelineTriggerOptionsModel.Timezone = core.StringPtr("Africa/Abidjan")
-				updateTektonPipelineTriggerOptionsModel.ScmSource = triggerScmSourceModel
-				updateTektonPipelineTriggerOptionsModel.Events = eventsModel
+				updateTektonPipelineTriggerOptionsModel.TriggerPatch = triggerPatchModelAsPatch
 				updateTektonPipelineTriggerOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with valid options model (positive test)
@@ -6084,7 +6135,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 
 				// Construct an instance of the GenericSecret model
 				genericSecretModel := new(cdtektonpipelinev2.GenericSecret)
-				genericSecretModel.Type = core.StringPtr("tokenMatches")
+				genericSecretModel.Type = core.StringPtr("token_matches")
 				genericSecretModel.Value = core.StringPtr("testString")
 				genericSecretModel.Source = core.StringPtr("header")
 				genericSecretModel.KeyName = core.StringPtr("testString")
@@ -6097,6 +6148,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				triggerScmSourceModel.Pattern = core.StringPtr("testString")
 				triggerScmSourceModel.BlindConnection = core.BoolPtr(true)
 				triggerScmSourceModel.HookID = core.StringPtr("testString")
+				triggerScmSourceModel.ServiceInstanceID = core.StringPtr("testString")
 
 				// Construct an instance of the Events model
 				eventsModel := new(cdtektonpipelinev2.Events)
@@ -6104,22 +6156,28 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				eventsModel.PullRequestClosed = core.BoolPtr(true)
 				eventsModel.PullRequest = core.BoolPtr(true)
 
+				// Construct an instance of the TriggerPatch model
+				triggerPatchModel := new(cdtektonpipelinev2.TriggerPatch)
+				triggerPatchModel.Type = core.StringPtr("manual")
+				triggerPatchModel.Name = core.StringPtr("start-deploy")
+				triggerPatchModel.EventListener = core.StringPtr("testString")
+				triggerPatchModel.Tags = []string{"testString"}
+				triggerPatchModel.Worker = workerModel
+				triggerPatchModel.MaxConcurrentRuns = core.Int64Ptr(int64(4))
+				triggerPatchModel.Disabled = core.BoolPtr(true)
+				triggerPatchModel.Secret = genericSecretModel
+				triggerPatchModel.Cron = core.StringPtr("testString")
+				triggerPatchModel.Timezone = core.StringPtr("America/Los_Angeles, CET, Europe/London, GMT, US/Eastern, or UTC")
+				triggerPatchModel.ScmSource = triggerScmSourceModel
+				triggerPatchModel.Events = eventsModel
+				triggerPatchModelAsPatch, asPatchErr := triggerPatchModel.AsPatch()
+				Expect(asPatchErr).To(BeNil())
+
 				// Construct an instance of the UpdateTektonPipelineTriggerOptions model
 				updateTektonPipelineTriggerOptionsModel := new(cdtektonpipelinev2.UpdateTektonPipelineTriggerOptions)
 				updateTektonPipelineTriggerOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				updateTektonPipelineTriggerOptionsModel.TriggerID = core.StringPtr("1bb892a1-2e04-4768-a369-b1159eace147")
-				updateTektonPipelineTriggerOptionsModel.Type = core.StringPtr("manual")
-				updateTektonPipelineTriggerOptionsModel.Name = core.StringPtr("start-deploy")
-				updateTektonPipelineTriggerOptionsModel.EventListener = core.StringPtr("testString")
-				updateTektonPipelineTriggerOptionsModel.Tags = []string{"testString"}
-				updateTektonPipelineTriggerOptionsModel.Worker = workerModel
-				updateTektonPipelineTriggerOptionsModel.MaxConcurrentRuns = core.Int64Ptr(int64(38))
-				updateTektonPipelineTriggerOptionsModel.Disabled = core.BoolPtr(true)
-				updateTektonPipelineTriggerOptionsModel.Secret = genericSecretModel
-				updateTektonPipelineTriggerOptionsModel.Cron = core.StringPtr("testString")
-				updateTektonPipelineTriggerOptionsModel.Timezone = core.StringPtr("Africa/Abidjan")
-				updateTektonPipelineTriggerOptionsModel.ScmSource = triggerScmSourceModel
-				updateTektonPipelineTriggerOptionsModel.Events = eventsModel
+				updateTektonPipelineTriggerOptionsModel.TriggerPatch = triggerPatchModelAsPatch
 				updateTektonPipelineTriggerOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
 				err := cdTektonPipelineService.SetServiceURL("")
@@ -6166,7 +6224,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 
 				// Construct an instance of the GenericSecret model
 				genericSecretModel := new(cdtektonpipelinev2.GenericSecret)
-				genericSecretModel.Type = core.StringPtr("tokenMatches")
+				genericSecretModel.Type = core.StringPtr("token_matches")
 				genericSecretModel.Value = core.StringPtr("testString")
 				genericSecretModel.Source = core.StringPtr("header")
 				genericSecretModel.KeyName = core.StringPtr("testString")
@@ -6179,6 +6237,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				triggerScmSourceModel.Pattern = core.StringPtr("testString")
 				triggerScmSourceModel.BlindConnection = core.BoolPtr(true)
 				triggerScmSourceModel.HookID = core.StringPtr("testString")
+				triggerScmSourceModel.ServiceInstanceID = core.StringPtr("testString")
 
 				// Construct an instance of the Events model
 				eventsModel := new(cdtektonpipelinev2.Events)
@@ -6186,22 +6245,28 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				eventsModel.PullRequestClosed = core.BoolPtr(true)
 				eventsModel.PullRequest = core.BoolPtr(true)
 
+				// Construct an instance of the TriggerPatch model
+				triggerPatchModel := new(cdtektonpipelinev2.TriggerPatch)
+				triggerPatchModel.Type = core.StringPtr("manual")
+				triggerPatchModel.Name = core.StringPtr("start-deploy")
+				triggerPatchModel.EventListener = core.StringPtr("testString")
+				triggerPatchModel.Tags = []string{"testString"}
+				triggerPatchModel.Worker = workerModel
+				triggerPatchModel.MaxConcurrentRuns = core.Int64Ptr(int64(4))
+				triggerPatchModel.Disabled = core.BoolPtr(true)
+				triggerPatchModel.Secret = genericSecretModel
+				triggerPatchModel.Cron = core.StringPtr("testString")
+				triggerPatchModel.Timezone = core.StringPtr("America/Los_Angeles, CET, Europe/London, GMT, US/Eastern, or UTC")
+				triggerPatchModel.ScmSource = triggerScmSourceModel
+				triggerPatchModel.Events = eventsModel
+				triggerPatchModelAsPatch, asPatchErr := triggerPatchModel.AsPatch()
+				Expect(asPatchErr).To(BeNil())
+
 				// Construct an instance of the UpdateTektonPipelineTriggerOptions model
 				updateTektonPipelineTriggerOptionsModel := new(cdtektonpipelinev2.UpdateTektonPipelineTriggerOptions)
 				updateTektonPipelineTriggerOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				updateTektonPipelineTriggerOptionsModel.TriggerID = core.StringPtr("1bb892a1-2e04-4768-a369-b1159eace147")
-				updateTektonPipelineTriggerOptionsModel.Type = core.StringPtr("manual")
-				updateTektonPipelineTriggerOptionsModel.Name = core.StringPtr("start-deploy")
-				updateTektonPipelineTriggerOptionsModel.EventListener = core.StringPtr("testString")
-				updateTektonPipelineTriggerOptionsModel.Tags = []string{"testString"}
-				updateTektonPipelineTriggerOptionsModel.Worker = workerModel
-				updateTektonPipelineTriggerOptionsModel.MaxConcurrentRuns = core.Int64Ptr(int64(38))
-				updateTektonPipelineTriggerOptionsModel.Disabled = core.BoolPtr(true)
-				updateTektonPipelineTriggerOptionsModel.Secret = genericSecretModel
-				updateTektonPipelineTriggerOptionsModel.Cron = core.StringPtr("testString")
-				updateTektonPipelineTriggerOptionsModel.Timezone = core.StringPtr("Africa/Abidjan")
-				updateTektonPipelineTriggerOptionsModel.ScmSource = triggerScmSourceModel
-				updateTektonPipelineTriggerOptionsModel.Events = eventsModel
+				updateTektonPipelineTriggerOptionsModel.TriggerPatch = triggerPatchModelAsPatch
 				updateTektonPipelineTriggerOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation
@@ -6298,7 +6363,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					Expect(req.URL.EscapedPath()).To(Equal(listTektonPipelineTriggerPropertiesPath))
 					Expect(req.Method).To(Equal("GET"))
 					Expect(req.URL.Query()["name"]).To(Equal([]string{"prod"}))
-					Expect(req.URL.Query()["type"]).To(Equal([]string{"SECURE,TEXT"}))
+					Expect(req.URL.Query()["type"]).To(Equal([]string{"secure,text"}))
 					Expect(req.URL.Query()["sort"]).To(Equal([]string{"name"}))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
@@ -6318,7 +6383,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				listTektonPipelineTriggerPropertiesOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				listTektonPipelineTriggerPropertiesOptionsModel.TriggerID = core.StringPtr("1bb892a1-2e04-4768-a369-b1159eace147")
 				listTektonPipelineTriggerPropertiesOptionsModel.Name = core.StringPtr("prod")
-				listTektonPipelineTriggerPropertiesOptionsModel.Type = core.StringPtr("SECURE,TEXT")
+				listTektonPipelineTriggerPropertiesOptionsModel.Type = core.StringPtr("secure,text")
 				listTektonPipelineTriggerPropertiesOptionsModel.Sort = core.StringPtr("name")
 				listTektonPipelineTriggerPropertiesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
@@ -6351,7 +6416,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					Expect(req.Method).To(Equal("GET"))
 
 					Expect(req.URL.Query()["name"]).To(Equal([]string{"prod"}))
-					Expect(req.URL.Query()["type"]).To(Equal([]string{"SECURE,TEXT"}))
+					Expect(req.URL.Query()["type"]).To(Equal([]string{"secure,text"}))
 					Expect(req.URL.Query()["sort"]).To(Equal([]string{"name"}))
 					// Sleep a short time to support a timeout test
 					time.Sleep(100 * time.Millisecond)
@@ -6359,7 +6424,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path", "href": "Href"}]}`)
+					fmt.Fprintf(res, "%s", `{"properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path", "href": "Href"}]}`)
 				}))
 			})
 			It(`Invoke ListTektonPipelineTriggerProperties successfully with retries`, func() {
@@ -6376,7 +6441,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				listTektonPipelineTriggerPropertiesOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				listTektonPipelineTriggerPropertiesOptionsModel.TriggerID = core.StringPtr("1bb892a1-2e04-4768-a369-b1159eace147")
 				listTektonPipelineTriggerPropertiesOptionsModel.Name = core.StringPtr("prod")
-				listTektonPipelineTriggerPropertiesOptionsModel.Type = core.StringPtr("SECURE,TEXT")
+				listTektonPipelineTriggerPropertiesOptionsModel.Type = core.StringPtr("secure,text")
 				listTektonPipelineTriggerPropertiesOptionsModel.Sort = core.StringPtr("name")
 				listTektonPipelineTriggerPropertiesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -6415,12 +6480,12 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					Expect(req.Method).To(Equal("GET"))
 
 					Expect(req.URL.Query()["name"]).To(Equal([]string{"prod"}))
-					Expect(req.URL.Query()["type"]).To(Equal([]string{"SECURE,TEXT"}))
+					Expect(req.URL.Query()["type"]).To(Equal([]string{"secure,text"}))
 					Expect(req.URL.Query()["sort"]).To(Equal([]string{"name"}))
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path", "href": "Href"}]}`)
+					fmt.Fprintf(res, "%s", `{"properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path", "href": "Href"}]}`)
 				}))
 			})
 			It(`Invoke ListTektonPipelineTriggerProperties successfully`, func() {
@@ -6442,7 +6507,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				listTektonPipelineTriggerPropertiesOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				listTektonPipelineTriggerPropertiesOptionsModel.TriggerID = core.StringPtr("1bb892a1-2e04-4768-a369-b1159eace147")
 				listTektonPipelineTriggerPropertiesOptionsModel.Name = core.StringPtr("prod")
-				listTektonPipelineTriggerPropertiesOptionsModel.Type = core.StringPtr("SECURE,TEXT")
+				listTektonPipelineTriggerPropertiesOptionsModel.Type = core.StringPtr("secure,text")
 				listTektonPipelineTriggerPropertiesOptionsModel.Sort = core.StringPtr("name")
 				listTektonPipelineTriggerPropertiesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -6466,7 +6531,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				listTektonPipelineTriggerPropertiesOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				listTektonPipelineTriggerPropertiesOptionsModel.TriggerID = core.StringPtr("1bb892a1-2e04-4768-a369-b1159eace147")
 				listTektonPipelineTriggerPropertiesOptionsModel.Name = core.StringPtr("prod")
-				listTektonPipelineTriggerPropertiesOptionsModel.Type = core.StringPtr("SECURE,TEXT")
+				listTektonPipelineTriggerPropertiesOptionsModel.Type = core.StringPtr("secure,text")
 				listTektonPipelineTriggerPropertiesOptionsModel.Sort = core.StringPtr("name")
 				listTektonPipelineTriggerPropertiesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
@@ -6511,7 +6576,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				listTektonPipelineTriggerPropertiesOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				listTektonPipelineTriggerPropertiesOptionsModel.TriggerID = core.StringPtr("1bb892a1-2e04-4768-a369-b1159eace147")
 				listTektonPipelineTriggerPropertiesOptionsModel.Name = core.StringPtr("prod")
-				listTektonPipelineTriggerPropertiesOptionsModel.Type = core.StringPtr("SECURE,TEXT")
+				listTektonPipelineTriggerPropertiesOptionsModel.Type = core.StringPtr("secure,text")
 				listTektonPipelineTriggerPropertiesOptionsModel.Sort = core.StringPtr("name")
 				listTektonPipelineTriggerPropertiesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -6559,7 +6624,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelineTriggerPropertiesOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				createTektonPipelineTriggerPropertiesOptionsModel.Enum = []string{"testString"}
 				createTektonPipelineTriggerPropertiesOptionsModel.Default = core.StringPtr("testString")
-				createTektonPipelineTriggerPropertiesOptionsModel.Type = core.StringPtr("TEXT")
+				createTektonPipelineTriggerPropertiesOptionsModel.Type = core.StringPtr("text")
 				createTektonPipelineTriggerPropertiesOptionsModel.Path = core.StringPtr("testString")
 				createTektonPipelineTriggerPropertiesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
@@ -6613,7 +6678,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}`)
 				}))
 			})
 			It(`Invoke CreateTektonPipelineTriggerProperties successfully with retries`, func() {
@@ -6633,7 +6698,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelineTriggerPropertiesOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				createTektonPipelineTriggerPropertiesOptionsModel.Enum = []string{"testString"}
 				createTektonPipelineTriggerPropertiesOptionsModel.Default = core.StringPtr("testString")
-				createTektonPipelineTriggerPropertiesOptionsModel.Type = core.StringPtr("TEXT")
+				createTektonPipelineTriggerPropertiesOptionsModel.Type = core.StringPtr("text")
 				createTektonPipelineTriggerPropertiesOptionsModel.Path = core.StringPtr("testString")
 				createTektonPipelineTriggerPropertiesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -6690,7 +6755,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}`)
 				}))
 			})
 			It(`Invoke CreateTektonPipelineTriggerProperties successfully`, func() {
@@ -6715,7 +6780,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelineTriggerPropertiesOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				createTektonPipelineTriggerPropertiesOptionsModel.Enum = []string{"testString"}
 				createTektonPipelineTriggerPropertiesOptionsModel.Default = core.StringPtr("testString")
-				createTektonPipelineTriggerPropertiesOptionsModel.Type = core.StringPtr("TEXT")
+				createTektonPipelineTriggerPropertiesOptionsModel.Type = core.StringPtr("text")
 				createTektonPipelineTriggerPropertiesOptionsModel.Path = core.StringPtr("testString")
 				createTektonPipelineTriggerPropertiesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -6742,7 +6807,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelineTriggerPropertiesOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				createTektonPipelineTriggerPropertiesOptionsModel.Enum = []string{"testString"}
 				createTektonPipelineTriggerPropertiesOptionsModel.Default = core.StringPtr("testString")
-				createTektonPipelineTriggerPropertiesOptionsModel.Type = core.StringPtr("TEXT")
+				createTektonPipelineTriggerPropertiesOptionsModel.Type = core.StringPtr("text")
 				createTektonPipelineTriggerPropertiesOptionsModel.Path = core.StringPtr("testString")
 				createTektonPipelineTriggerPropertiesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
@@ -6790,7 +6855,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelineTriggerPropertiesOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				createTektonPipelineTriggerPropertiesOptionsModel.Enum = []string{"testString"}
 				createTektonPipelineTriggerPropertiesOptionsModel.Default = core.StringPtr("testString")
-				createTektonPipelineTriggerPropertiesOptionsModel.Type = core.StringPtr("TEXT")
+				createTektonPipelineTriggerPropertiesOptionsModel.Type = core.StringPtr("text")
 				createTektonPipelineTriggerPropertiesOptionsModel.Path = core.StringPtr("testString")
 				createTektonPipelineTriggerPropertiesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -6871,7 +6936,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}`)
 				}))
 			})
 			It(`Invoke GetTektonPipelineTriggerProperty successfully with retries`, func() {
@@ -6927,7 +6992,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}`)
 				}))
 			})
 			It(`Invoke GetTektonPipelineTriggerProperty successfully`, func() {
@@ -7061,7 +7126,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				replaceTektonPipelineTriggerPropertyOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Enum = []string{"testString"}
 				replaceTektonPipelineTriggerPropertyOptionsModel.Default = core.StringPtr("testString")
-				replaceTektonPipelineTriggerPropertyOptionsModel.Type = core.StringPtr("TEXT")
+				replaceTektonPipelineTriggerPropertyOptionsModel.Type = core.StringPtr("text")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Path = core.StringPtr("testString")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
@@ -7115,7 +7180,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}`)
 				}))
 			})
 			It(`Invoke ReplaceTektonPipelineTriggerProperty successfully with retries`, func() {
@@ -7136,7 +7201,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				replaceTektonPipelineTriggerPropertyOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Enum = []string{"testString"}
 				replaceTektonPipelineTriggerPropertyOptionsModel.Default = core.StringPtr("testString")
-				replaceTektonPipelineTriggerPropertyOptionsModel.Type = core.StringPtr("TEXT")
+				replaceTektonPipelineTriggerPropertyOptionsModel.Type = core.StringPtr("text")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Path = core.StringPtr("testString")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -7193,7 +7258,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "secure", "path": "Path"}`)
 				}))
 			})
 			It(`Invoke ReplaceTektonPipelineTriggerProperty successfully`, func() {
@@ -7219,7 +7284,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				replaceTektonPipelineTriggerPropertyOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Enum = []string{"testString"}
 				replaceTektonPipelineTriggerPropertyOptionsModel.Default = core.StringPtr("testString")
-				replaceTektonPipelineTriggerPropertyOptionsModel.Type = core.StringPtr("TEXT")
+				replaceTektonPipelineTriggerPropertyOptionsModel.Type = core.StringPtr("text")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Path = core.StringPtr("testString")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -7247,7 +7312,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				replaceTektonPipelineTriggerPropertyOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Enum = []string{"testString"}
 				replaceTektonPipelineTriggerPropertyOptionsModel.Default = core.StringPtr("testString")
-				replaceTektonPipelineTriggerPropertyOptionsModel.Type = core.StringPtr("TEXT")
+				replaceTektonPipelineTriggerPropertyOptionsModel.Type = core.StringPtr("text")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Path = core.StringPtr("testString")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
@@ -7296,7 +7361,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				replaceTektonPipelineTriggerPropertyOptionsModel.Value = core.StringPtr("https://github.com/IBM/tekton-tutorial.git")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Enum = []string{"testString"}
 				replaceTektonPipelineTriggerPropertyOptionsModel.Default = core.StringPtr("testString")
-				replaceTektonPipelineTriggerPropertyOptionsModel.Type = core.StringPtr("TEXT")
+				replaceTektonPipelineTriggerPropertyOptionsModel.Type = core.StringPtr("text")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Path = core.StringPtr("testString")
 				replaceTektonPipelineTriggerPropertyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -7414,23 +7479,23 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				definitionScmSourceModel.Branch = core.StringPtr("master")
 				definitionScmSourceModel.Tag = core.StringPtr("testString")
 				definitionScmSourceModel.Path = core.StringPtr(".tekton")
+				definitionScmSourceModel.ServiceInstanceID = core.StringPtr("testString")
 				Expect(definitionScmSourceModel.URL).To(Equal(core.StringPtr("https://github.com/IBM/tekton-tutorial.git")))
 				Expect(definitionScmSourceModel.Branch).To(Equal(core.StringPtr("master")))
 				Expect(definitionScmSourceModel.Tag).To(Equal(core.StringPtr("testString")))
 				Expect(definitionScmSourceModel.Path).To(Equal(core.StringPtr(".tekton")))
+				Expect(definitionScmSourceModel.ServiceInstanceID).To(Equal(core.StringPtr("testString")))
 
 				// Construct an instance of the CreateTektonPipelineDefinitionOptions model
 				pipelineID := "94619026-912b-4d92-8f51-6c74f0692d90"
 				createTektonPipelineDefinitionOptionsModel := cdTektonPipelineService.NewCreateTektonPipelineDefinitionOptions(pipelineID)
 				createTektonPipelineDefinitionOptionsModel.SetPipelineID("94619026-912b-4d92-8f51-6c74f0692d90")
 				createTektonPipelineDefinitionOptionsModel.SetScmSource(definitionScmSourceModel)
-				createTektonPipelineDefinitionOptionsModel.SetServiceInstanceID("testString")
 				createTektonPipelineDefinitionOptionsModel.SetID("testString")
 				createTektonPipelineDefinitionOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(createTektonPipelineDefinitionOptionsModel).ToNot(BeNil())
 				Expect(createTektonPipelineDefinitionOptionsModel.PipelineID).To(Equal(core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")))
 				Expect(createTektonPipelineDefinitionOptionsModel.ScmSource).To(Equal(definitionScmSourceModel))
-				Expect(createTektonPipelineDefinitionOptionsModel.ServiceInstanceID).To(Equal(core.StringPtr("testString")))
 				Expect(createTektonPipelineDefinitionOptionsModel.ID).To(Equal(core.StringPtr("testString")))
 				Expect(createTektonPipelineDefinitionOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
@@ -7460,7 +7525,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelinePropertiesOptionsModel.SetValue("https://github.com/IBM/tekton-tutorial.git")
 				createTektonPipelinePropertiesOptionsModel.SetEnum([]string{"testString"})
 				createTektonPipelinePropertiesOptionsModel.SetDefault("testString")
-				createTektonPipelinePropertiesOptionsModel.SetType("TEXT")
+				createTektonPipelinePropertiesOptionsModel.SetType("text")
 				createTektonPipelinePropertiesOptionsModel.SetPath("testString")
 				createTektonPipelinePropertiesOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(createTektonPipelinePropertiesOptionsModel).ToNot(BeNil())
@@ -7469,7 +7534,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(createTektonPipelinePropertiesOptionsModel.Value).To(Equal(core.StringPtr("https://github.com/IBM/tekton-tutorial.git")))
 				Expect(createTektonPipelinePropertiesOptionsModel.Enum).To(Equal([]string{"testString"}))
 				Expect(createTektonPipelinePropertiesOptionsModel.Default).To(Equal(core.StringPtr("testString")))
-				Expect(createTektonPipelinePropertiesOptionsModel.Type).To(Equal(core.StringPtr("TEXT")))
+				Expect(createTektonPipelinePropertiesOptionsModel.Type).To(Equal(core.StringPtr("text")))
 				Expect(createTektonPipelinePropertiesOptionsModel.Path).To(Equal(core.StringPtr("testString")))
 				Expect(createTektonPipelinePropertiesOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
@@ -7524,7 +7589,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelineTriggerPropertiesOptionsModel.SetValue("https://github.com/IBM/tekton-tutorial.git")
 				createTektonPipelineTriggerPropertiesOptionsModel.SetEnum([]string{"testString"})
 				createTektonPipelineTriggerPropertiesOptionsModel.SetDefault("testString")
-				createTektonPipelineTriggerPropertiesOptionsModel.SetType("TEXT")
+				createTektonPipelineTriggerPropertiesOptionsModel.SetType("text")
 				createTektonPipelineTriggerPropertiesOptionsModel.SetPath("testString")
 				createTektonPipelineTriggerPropertiesOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(createTektonPipelineTriggerPropertiesOptionsModel).ToNot(BeNil())
@@ -7534,7 +7599,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(createTektonPipelineTriggerPropertiesOptionsModel.Value).To(Equal(core.StringPtr("https://github.com/IBM/tekton-tutorial.git")))
 				Expect(createTektonPipelineTriggerPropertiesOptionsModel.Enum).To(Equal([]string{"testString"}))
 				Expect(createTektonPipelineTriggerPropertiesOptionsModel.Default).To(Equal(core.StringPtr("testString")))
-				Expect(createTektonPipelineTriggerPropertiesOptionsModel.Type).To(Equal(core.StringPtr("TEXT")))
+				Expect(createTektonPipelineTriggerPropertiesOptionsModel.Type).To(Equal(core.StringPtr("text")))
 				Expect(createTektonPipelineTriggerPropertiesOptionsModel.Path).To(Equal(core.StringPtr("testString")))
 				Expect(createTektonPipelineTriggerPropertiesOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
@@ -7748,13 +7813,13 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				listTektonPipelinePropertiesOptionsModel := cdTektonPipelineService.NewListTektonPipelinePropertiesOptions(pipelineID)
 				listTektonPipelinePropertiesOptionsModel.SetPipelineID("94619026-912b-4d92-8f51-6c74f0692d90")
 				listTektonPipelinePropertiesOptionsModel.SetName("prod")
-				listTektonPipelinePropertiesOptionsModel.SetType([]string{"SECURE", "TEXT"})
+				listTektonPipelinePropertiesOptionsModel.SetType([]string{"secure", "text"})
 				listTektonPipelinePropertiesOptionsModel.SetSort("name")
 				listTektonPipelinePropertiesOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(listTektonPipelinePropertiesOptionsModel).ToNot(BeNil())
 				Expect(listTektonPipelinePropertiesOptionsModel.PipelineID).To(Equal(core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")))
 				Expect(listTektonPipelinePropertiesOptionsModel.Name).To(Equal(core.StringPtr("prod")))
-				Expect(listTektonPipelinePropertiesOptionsModel.Type).To(Equal([]string{"SECURE", "TEXT"}))
+				Expect(listTektonPipelinePropertiesOptionsModel.Type).To(Equal([]string{"secure", "text"}))
 				Expect(listTektonPipelinePropertiesOptionsModel.Sort).To(Equal(core.StringPtr("name")))
 				Expect(listTektonPipelinePropertiesOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
@@ -7781,20 +7846,20 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				pipelineID := "94619026-912b-4d92-8f51-6c74f0692d90"
 				triggerID := "1bb892a1-2e04-4768-a369-b1159eace147"
 				name := "prod"
-				typeVar := "SECURE,TEXT"
+				typeVar := "secure,text"
 				sort := "name"
 				listTektonPipelineTriggerPropertiesOptionsModel := cdTektonPipelineService.NewListTektonPipelineTriggerPropertiesOptions(pipelineID, triggerID, name, typeVar, sort)
 				listTektonPipelineTriggerPropertiesOptionsModel.SetPipelineID("94619026-912b-4d92-8f51-6c74f0692d90")
 				listTektonPipelineTriggerPropertiesOptionsModel.SetTriggerID("1bb892a1-2e04-4768-a369-b1159eace147")
 				listTektonPipelineTriggerPropertiesOptionsModel.SetName("prod")
-				listTektonPipelineTriggerPropertiesOptionsModel.SetType("SECURE,TEXT")
+				listTektonPipelineTriggerPropertiesOptionsModel.SetType("secure,text")
 				listTektonPipelineTriggerPropertiesOptionsModel.SetSort("name")
 				listTektonPipelineTriggerPropertiesOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(listTektonPipelineTriggerPropertiesOptionsModel).ToNot(BeNil())
 				Expect(listTektonPipelineTriggerPropertiesOptionsModel.PipelineID).To(Equal(core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")))
 				Expect(listTektonPipelineTriggerPropertiesOptionsModel.TriggerID).To(Equal(core.StringPtr("1bb892a1-2e04-4768-a369-b1159eace147")))
 				Expect(listTektonPipelineTriggerPropertiesOptionsModel.Name).To(Equal(core.StringPtr("prod")))
-				Expect(listTektonPipelineTriggerPropertiesOptionsModel.Type).To(Equal(core.StringPtr("SECURE,TEXT")))
+				Expect(listTektonPipelineTriggerPropertiesOptionsModel.Type).To(Equal(core.StringPtr("secure,text")))
 				Expect(listTektonPipelineTriggerPropertiesOptionsModel.Sort).To(Equal(core.StringPtr("name")))
 				Expect(listTektonPipelineTriggerPropertiesOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
@@ -7830,10 +7895,12 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				definitionScmSourceModel.Branch = core.StringPtr("master")
 				definitionScmSourceModel.Tag = core.StringPtr("testString")
 				definitionScmSourceModel.Path = core.StringPtr(".tekton")
+				definitionScmSourceModel.ServiceInstanceID = core.StringPtr("071d8049-d984-4feb-a2ed-2a1e938918ba")
 				Expect(definitionScmSourceModel.URL).To(Equal(core.StringPtr("https://github.com/IBM/tekton-tutorial.git")))
 				Expect(definitionScmSourceModel.Branch).To(Equal(core.StringPtr("master")))
 				Expect(definitionScmSourceModel.Tag).To(Equal(core.StringPtr("testString")))
 				Expect(definitionScmSourceModel.Path).To(Equal(core.StringPtr(".tekton")))
+				Expect(definitionScmSourceModel.ServiceInstanceID).To(Equal(core.StringPtr("071d8049-d984-4feb-a2ed-2a1e938918ba")))
 
 				// Construct an instance of the ReplaceTektonPipelineDefinitionOptions model
 				pipelineID := "94619026-912b-4d92-8f51-6c74f0692d90"
@@ -7842,14 +7909,12 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				replaceTektonPipelineDefinitionOptionsModel.SetPipelineID("94619026-912b-4d92-8f51-6c74f0692d90")
 				replaceTektonPipelineDefinitionOptionsModel.SetDefinitionID("94299034-d45f-4e9a-8ed5-6bd5c7bb7ada")
 				replaceTektonPipelineDefinitionOptionsModel.SetScmSource(definitionScmSourceModel)
-				replaceTektonPipelineDefinitionOptionsModel.SetServiceInstanceID("071d8049-d984-4feb-a2ed-2a1e938918ba")
 				replaceTektonPipelineDefinitionOptionsModel.SetID("22f92ab1-e0ac-4c65-84e7-8a4cb32dba0f")
 				replaceTektonPipelineDefinitionOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(replaceTektonPipelineDefinitionOptionsModel).ToNot(BeNil())
 				Expect(replaceTektonPipelineDefinitionOptionsModel.PipelineID).To(Equal(core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")))
 				Expect(replaceTektonPipelineDefinitionOptionsModel.DefinitionID).To(Equal(core.StringPtr("94299034-d45f-4e9a-8ed5-6bd5c7bb7ada")))
 				Expect(replaceTektonPipelineDefinitionOptionsModel.ScmSource).To(Equal(definitionScmSourceModel))
-				Expect(replaceTektonPipelineDefinitionOptionsModel.ServiceInstanceID).To(Equal(core.StringPtr("071d8049-d984-4feb-a2ed-2a1e938918ba")))
 				Expect(replaceTektonPipelineDefinitionOptionsModel.ID).To(Equal(core.StringPtr("22f92ab1-e0ac-4c65-84e7-8a4cb32dba0f")))
 				Expect(replaceTektonPipelineDefinitionOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
@@ -7864,7 +7929,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				replaceTektonPipelinePropertyOptionsModel.SetValue("https://github.com/IBM/tekton-tutorial.git")
 				replaceTektonPipelinePropertyOptionsModel.SetEnum([]string{"testString"})
 				replaceTektonPipelinePropertyOptionsModel.SetDefault("testString")
-				replaceTektonPipelinePropertyOptionsModel.SetType("TEXT")
+				replaceTektonPipelinePropertyOptionsModel.SetType("text")
 				replaceTektonPipelinePropertyOptionsModel.SetPath("testString")
 				replaceTektonPipelinePropertyOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(replaceTektonPipelinePropertyOptionsModel).ToNot(BeNil())
@@ -7874,7 +7939,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(replaceTektonPipelinePropertyOptionsModel.Value).To(Equal(core.StringPtr("https://github.com/IBM/tekton-tutorial.git")))
 				Expect(replaceTektonPipelinePropertyOptionsModel.Enum).To(Equal([]string{"testString"}))
 				Expect(replaceTektonPipelinePropertyOptionsModel.Default).To(Equal(core.StringPtr("testString")))
-				Expect(replaceTektonPipelinePropertyOptionsModel.Type).To(Equal(core.StringPtr("TEXT")))
+				Expect(replaceTektonPipelinePropertyOptionsModel.Type).To(Equal(core.StringPtr("text")))
 				Expect(replaceTektonPipelinePropertyOptionsModel.Path).To(Equal(core.StringPtr("testString")))
 				Expect(replaceTektonPipelinePropertyOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
@@ -7891,7 +7956,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				replaceTektonPipelineTriggerPropertyOptionsModel.SetValue("https://github.com/IBM/tekton-tutorial.git")
 				replaceTektonPipelineTriggerPropertyOptionsModel.SetEnum([]string{"testString"})
 				replaceTektonPipelineTriggerPropertyOptionsModel.SetDefault("testString")
-				replaceTektonPipelineTriggerPropertyOptionsModel.SetType("TEXT")
+				replaceTektonPipelineTriggerPropertyOptionsModel.SetType("text")
 				replaceTektonPipelineTriggerPropertyOptionsModel.SetPath("testString")
 				replaceTektonPipelineTriggerPropertyOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(replaceTektonPipelineTriggerPropertyOptionsModel).ToNot(BeNil())
@@ -7902,7 +7967,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(replaceTektonPipelineTriggerPropertyOptionsModel.Value).To(Equal(core.StringPtr("https://github.com/IBM/tekton-tutorial.git")))
 				Expect(replaceTektonPipelineTriggerPropertyOptionsModel.Enum).To(Equal([]string{"testString"}))
 				Expect(replaceTektonPipelineTriggerPropertyOptionsModel.Default).To(Equal(core.StringPtr("testString")))
-				Expect(replaceTektonPipelineTriggerPropertyOptionsModel.Type).To(Equal(core.StringPtr("TEXT")))
+				Expect(replaceTektonPipelineTriggerPropertyOptionsModel.Type).To(Equal(core.StringPtr("text")))
 				Expect(replaceTektonPipelineTriggerPropertyOptionsModel.Path).To(Equal(core.StringPtr("testString")))
 				Expect(replaceTektonPipelineTriggerPropertyOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
@@ -7921,21 +7986,21 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 			})
 			It(`Invoke NewTriggerGenericTriggerPropertiesItem successfully`, func() {
 				name := "testString"
-				typeVar := "SECURE"
+				typeVar := "secure"
 				_model, err := cdTektonPipelineService.NewTriggerGenericTriggerPropertiesItem(name, typeVar)
 				Expect(_model).ToNot(BeNil())
 				Expect(err).To(BeNil())
 			})
 			It(`Invoke NewTriggerManualTriggerPropertiesItem successfully`, func() {
 				name := "testString"
-				typeVar := "SECURE"
+				typeVar := "secure"
 				_model, err := cdTektonPipelineService.NewTriggerManualTriggerPropertiesItem(name, typeVar)
 				Expect(_model).ToNot(BeNil())
 				Expect(err).To(BeNil())
 			})
 			It(`Invoke NewTriggerPropertiesItem successfully`, func() {
 				name := "testString"
-				typeVar := "SECURE"
+				typeVar := "secure"
 				_model, err := cdTektonPipelineService.NewTriggerPropertiesItem(name, typeVar)
 				Expect(_model).ToNot(BeNil())
 				Expect(err).To(BeNil())
@@ -7948,119 +8013,43 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 			})
 			It(`Invoke NewTriggerScmTriggerPropertiesItem successfully`, func() {
 				name := "testString"
-				typeVar := "SECURE"
+				typeVar := "secure"
 				_model, err := cdTektonPipelineService.NewTriggerScmTriggerPropertiesItem(name, typeVar)
 				Expect(_model).ToNot(BeNil())
 				Expect(err).To(BeNil())
 			})
 			It(`Invoke NewTriggerTimerTriggerPropertiesItem successfully`, func() {
 				name := "testString"
-				typeVar := "SECURE"
+				typeVar := "secure"
 				_model, err := cdTektonPipelineService.NewTriggerTimerTriggerPropertiesItem(name, typeVar)
 				Expect(_model).ToNot(BeNil())
 				Expect(err).To(BeNil())
 			})
 			It(`Invoke NewUpdateTektonPipelineOptions successfully`, func() {
-				// Construct an instance of the WorkerWithID model
-				workerWithIDModel := new(cdtektonpipelinev2.WorkerWithID)
-				Expect(workerWithIDModel).ToNot(BeNil())
-				workerWithIDModel.ID = core.StringPtr("public")
-				Expect(workerWithIDModel.ID).To(Equal(core.StringPtr("public")))
-
 				// Construct an instance of the UpdateTektonPipelineOptions model
 				id := "94619026-912b-4d92-8f51-6c74f0692d90"
 				updateTektonPipelineOptionsModel := cdTektonPipelineService.NewUpdateTektonPipelineOptions(id)
 				updateTektonPipelineOptionsModel.SetID("94619026-912b-4d92-8f51-6c74f0692d90")
-				updateTektonPipelineOptionsModel.SetWorker(workerWithIDModel)
+				updateTektonPipelineOptionsModel.SetTektonPipelinePatch(make(map[string]interface{}))
 				updateTektonPipelineOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(updateTektonPipelineOptionsModel).ToNot(BeNil())
 				Expect(updateTektonPipelineOptionsModel.ID).To(Equal(core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")))
-				Expect(updateTektonPipelineOptionsModel.Worker).To(Equal(workerWithIDModel))
+				Expect(updateTektonPipelineOptionsModel.TektonPipelinePatch).To(Equal(make(map[string]interface{})))
 				Expect(updateTektonPipelineOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewUpdateTektonPipelineTriggerOptions successfully`, func() {
-				// Construct an instance of the Worker model
-				workerModel := new(cdtektonpipelinev2.Worker)
-				Expect(workerModel).ToNot(BeNil())
-				workerModel.Name = core.StringPtr("testString")
-				workerModel.Type = core.StringPtr("private")
-				workerModel.ID = core.StringPtr("testString")
-				Expect(workerModel.Name).To(Equal(core.StringPtr("testString")))
-				Expect(workerModel.Type).To(Equal(core.StringPtr("private")))
-				Expect(workerModel.ID).To(Equal(core.StringPtr("testString")))
-
-				// Construct an instance of the GenericSecret model
-				genericSecretModel := new(cdtektonpipelinev2.GenericSecret)
-				Expect(genericSecretModel).ToNot(BeNil())
-				genericSecretModel.Type = core.StringPtr("tokenMatches")
-				genericSecretModel.Value = core.StringPtr("testString")
-				genericSecretModel.Source = core.StringPtr("header")
-				genericSecretModel.KeyName = core.StringPtr("testString")
-				genericSecretModel.Algorithm = core.StringPtr("md4")
-				Expect(genericSecretModel.Type).To(Equal(core.StringPtr("tokenMatches")))
-				Expect(genericSecretModel.Value).To(Equal(core.StringPtr("testString")))
-				Expect(genericSecretModel.Source).To(Equal(core.StringPtr("header")))
-				Expect(genericSecretModel.KeyName).To(Equal(core.StringPtr("testString")))
-				Expect(genericSecretModel.Algorithm).To(Equal(core.StringPtr("md4")))
-
-				// Construct an instance of the TriggerScmSource model
-				triggerScmSourceModel := new(cdtektonpipelinev2.TriggerScmSource)
-				Expect(triggerScmSourceModel).ToNot(BeNil())
-				triggerScmSourceModel.URL = core.StringPtr("testString")
-				triggerScmSourceModel.Branch = core.StringPtr("testString")
-				triggerScmSourceModel.Pattern = core.StringPtr("testString")
-				triggerScmSourceModel.BlindConnection = core.BoolPtr(true)
-				triggerScmSourceModel.HookID = core.StringPtr("testString")
-				Expect(triggerScmSourceModel.URL).To(Equal(core.StringPtr("testString")))
-				Expect(triggerScmSourceModel.Branch).To(Equal(core.StringPtr("testString")))
-				Expect(triggerScmSourceModel.Pattern).To(Equal(core.StringPtr("testString")))
-				Expect(triggerScmSourceModel.BlindConnection).To(Equal(core.BoolPtr(true)))
-				Expect(triggerScmSourceModel.HookID).To(Equal(core.StringPtr("testString")))
-
-				// Construct an instance of the Events model
-				eventsModel := new(cdtektonpipelinev2.Events)
-				Expect(eventsModel).ToNot(BeNil())
-				eventsModel.Push = core.BoolPtr(true)
-				eventsModel.PullRequestClosed = core.BoolPtr(true)
-				eventsModel.PullRequest = core.BoolPtr(true)
-				Expect(eventsModel.Push).To(Equal(core.BoolPtr(true)))
-				Expect(eventsModel.PullRequestClosed).To(Equal(core.BoolPtr(true)))
-				Expect(eventsModel.PullRequest).To(Equal(core.BoolPtr(true)))
-
 				// Construct an instance of the UpdateTektonPipelineTriggerOptions model
 				pipelineID := "94619026-912b-4d92-8f51-6c74f0692d90"
 				triggerID := "1bb892a1-2e04-4768-a369-b1159eace147"
 				updateTektonPipelineTriggerOptionsModel := cdTektonPipelineService.NewUpdateTektonPipelineTriggerOptions(pipelineID, triggerID)
 				updateTektonPipelineTriggerOptionsModel.SetPipelineID("94619026-912b-4d92-8f51-6c74f0692d90")
 				updateTektonPipelineTriggerOptionsModel.SetTriggerID("1bb892a1-2e04-4768-a369-b1159eace147")
-				updateTektonPipelineTriggerOptionsModel.SetType("manual")
-				updateTektonPipelineTriggerOptionsModel.SetName("start-deploy")
-				updateTektonPipelineTriggerOptionsModel.SetEventListener("testString")
-				updateTektonPipelineTriggerOptionsModel.SetTags([]string{"testString"})
-				updateTektonPipelineTriggerOptionsModel.SetWorker(workerModel)
-				updateTektonPipelineTriggerOptionsModel.SetMaxConcurrentRuns(int64(38))
-				updateTektonPipelineTriggerOptionsModel.SetDisabled(true)
-				updateTektonPipelineTriggerOptionsModel.SetSecret(genericSecretModel)
-				updateTektonPipelineTriggerOptionsModel.SetCron("testString")
-				updateTektonPipelineTriggerOptionsModel.SetTimezone("Africa/Abidjan")
-				updateTektonPipelineTriggerOptionsModel.SetScmSource(triggerScmSourceModel)
-				updateTektonPipelineTriggerOptionsModel.SetEvents(eventsModel)
+				updateTektonPipelineTriggerOptionsModel.SetTriggerPatch(make(map[string]interface{}))
 				updateTektonPipelineTriggerOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(updateTektonPipelineTriggerOptionsModel).ToNot(BeNil())
 				Expect(updateTektonPipelineTriggerOptionsModel.PipelineID).To(Equal(core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")))
 				Expect(updateTektonPipelineTriggerOptionsModel.TriggerID).To(Equal(core.StringPtr("1bb892a1-2e04-4768-a369-b1159eace147")))
-				Expect(updateTektonPipelineTriggerOptionsModel.Type).To(Equal(core.StringPtr("manual")))
-				Expect(updateTektonPipelineTriggerOptionsModel.Name).To(Equal(core.StringPtr("start-deploy")))
-				Expect(updateTektonPipelineTriggerOptionsModel.EventListener).To(Equal(core.StringPtr("testString")))
-				Expect(updateTektonPipelineTriggerOptionsModel.Tags).To(Equal([]string{"testString"}))
-				Expect(updateTektonPipelineTriggerOptionsModel.Worker).To(Equal(workerModel))
-				Expect(updateTektonPipelineTriggerOptionsModel.MaxConcurrentRuns).To(Equal(core.Int64Ptr(int64(38))))
-				Expect(updateTektonPipelineTriggerOptionsModel.Disabled).To(Equal(core.BoolPtr(true)))
-				Expect(updateTektonPipelineTriggerOptionsModel.Secret).To(Equal(genericSecretModel))
-				Expect(updateTektonPipelineTriggerOptionsModel.Cron).To(Equal(core.StringPtr("testString")))
-				Expect(updateTektonPipelineTriggerOptionsModel.Timezone).To(Equal(core.StringPtr("Africa/Abidjan")))
-				Expect(updateTektonPipelineTriggerOptionsModel.ScmSource).To(Equal(triggerScmSourceModel))
-				Expect(updateTektonPipelineTriggerOptionsModel.Events).To(Equal(eventsModel))
+				Expect(updateTektonPipelineTriggerOptionsModel.TriggerPatch).To(Equal(make(map[string]interface{})))
 				Expect(updateTektonPipelineTriggerOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewWorker successfully`, func() {

--- a/cdtektonpipelinev2/cd_tekton_pipeline_v2_test.go
+++ b/cdtektonpipelinev2/cd_tekton_pipeline_v2_test.go
@@ -284,7 +284,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "runs_url": "RunsURL", "build_number": 1, "enable_slack_notifications": true, "enable_partial_cloning": true, "enabled": false}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"type": "Type", "name": "start-deploy", "href": "Href", "event_listener": "EventListener", "id": "ID", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path", "href": "Href"}], "tags": ["Tags"], "worker": {"name": "Name", "type": "private", "id": "ID"}, "max_concurrent_runs": 4, "disabled": true}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "runs_url": "RunsURL", "build_number": 1, "enable_slack_notifications": true, "enable_partial_cloning": true, "enabled": false}`)
 				}))
 			})
 			It(`Invoke CreateTektonPipeline successfully with retries`, func() {
@@ -361,7 +361,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "runs_url": "RunsURL", "build_number": 1, "enable_slack_notifications": true, "enable_partial_cloning": true, "enabled": false}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"type": "Type", "name": "start-deploy", "href": "Href", "event_listener": "EventListener", "id": "ID", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path", "href": "Href"}], "tags": ["Tags"], "worker": {"name": "Name", "type": "private", "id": "ID"}, "max_concurrent_runs": 4, "disabled": true}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "runs_url": "RunsURL", "build_number": 1, "enable_slack_notifications": true, "enable_partial_cloning": true, "enabled": false}`)
 				}))
 			})
 			It(`Invoke CreateTektonPipeline successfully`, func() {
@@ -533,7 +533,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "runs_url": "RunsURL", "build_number": 1, "enable_slack_notifications": true, "enable_partial_cloning": true, "enabled": false}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"type": "Type", "name": "start-deploy", "href": "Href", "event_listener": "EventListener", "id": "ID", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path", "href": "Href"}], "tags": ["Tags"], "worker": {"name": "Name", "type": "private", "id": "ID"}, "max_concurrent_runs": 4, "disabled": true}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "runs_url": "RunsURL", "build_number": 1, "enable_slack_notifications": true, "enable_partial_cloning": true, "enabled": false}`)
 				}))
 			})
 			It(`Invoke GetTektonPipeline successfully with retries`, func() {
@@ -587,7 +587,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "runs_url": "RunsURL", "build_number": 1, "enable_slack_notifications": true, "enable_partial_cloning": true, "enabled": false}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"type": "Type", "name": "start-deploy", "href": "Href", "event_listener": "EventListener", "id": "ID", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path", "href": "Href"}], "tags": ["Tags"], "worker": {"name": "Name", "type": "private", "id": "ID"}, "max_concurrent_runs": 4, "disabled": true}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "runs_url": "RunsURL", "build_number": 1, "enable_slack_notifications": true, "enable_partial_cloning": true, "enabled": false}`)
 				}))
 			})
 			It(`Invoke GetTektonPipeline successfully`, func() {
@@ -774,7 +774,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "runs_url": "RunsURL", "build_number": 1, "enable_slack_notifications": true, "enable_partial_cloning": true, "enabled": false}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"type": "Type", "name": "start-deploy", "href": "Href", "event_listener": "EventListener", "id": "ID", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path", "href": "Href"}], "tags": ["Tags"], "worker": {"name": "Name", "type": "private", "id": "ID"}, "max_concurrent_runs": 4, "disabled": true}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "runs_url": "RunsURL", "build_number": 1, "enable_slack_notifications": true, "enable_partial_cloning": true, "enabled": false}`)
 				}))
 			})
 			It(`Invoke UpdateTektonPipeline successfully with retries`, func() {
@@ -857,7 +857,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "runs_url": "RunsURL", "build_number": 1, "enable_slack_notifications": true, "enable_partial_cloning": true, "enabled": false}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path", "service_instance_id": "ServiceInstanceID"}, "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"type": "Type", "name": "start-deploy", "href": "Href", "event_listener": "EventListener", "id": "ID", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path", "href": "Href"}], "tags": ["Tags"], "worker": {"name": "Name", "type": "private", "id": "ID"}, "max_concurrent_runs": 4, "disabled": true}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "runs_url": "RunsURL", "build_number": 1, "enable_slack_notifications": true, "enable_partial_cloning": true, "enabled": false}`)
 				}))
 			})
 			It(`Invoke UpdateTektonPipeline successfully`, func() {
@@ -1137,7 +1137,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"pipeline_runs": [{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL", "href": "Href"}], "offset": 20, "limit": 20, "first": {"href": "Href"}, "next": {"href": "Href"}, "last": {"href": "Href"}}`)
+					fmt.Fprintf(res, "%s", `{"pipeline_runs": [{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"type": "Type", "name": "start-deploy", "href": "Href", "event_listener": "EventListener", "id": "ID", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path", "href": "Href"}], "tags": ["Tags"], "worker": {"name": "Name", "type": "private", "id": "ID"}, "max_concurrent_runs": 4, "disabled": true}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL", "href": "Href"}], "offset": 20, "limit": 20, "first": {"href": "Href"}, "next": {"href": "Href"}, "last": {"href": "Href"}}`)
 				}))
 			})
 			It(`Invoke ListTektonPipelineRuns successfully with retries`, func() {
@@ -1201,7 +1201,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"pipeline_runs": [{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL", "href": "Href"}], "offset": 20, "limit": 20, "first": {"href": "Href"}, "next": {"href": "Href"}, "last": {"href": "Href"}}`)
+					fmt.Fprintf(res, "%s", `{"pipeline_runs": [{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"type": "Type", "name": "start-deploy", "href": "Href", "event_listener": "EventListener", "id": "ID", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path", "href": "Href"}], "tags": ["Tags"], "worker": {"name": "Name", "type": "private", "id": "ID"}, "max_concurrent_runs": 4, "disabled": true}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL", "href": "Href"}], "offset": 20, "limit": 20, "first": {"href": "Href"}, "next": {"href": "Href"}, "last": {"href": "Href"}}`)
 				}))
 			})
 			It(`Invoke ListTektonPipelineRuns successfully`, func() {
@@ -1355,9 +1355,9 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					res.WriteHeader(200)
 					requestNumber++
 					if requestNumber == 1 {
-						fmt.Fprintf(res, "%s", `{"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1,"pipeline_runs":[{"id":"ID","user_info":{"iam_id":"IamID","sub":"Sub"},"status":"pending","definition_id":"DefinitionID","worker":{"name":"Name","agent":"Agent","service_id":"ServiceID","id":"ID"},"pipeline_id":"PipelineID","listener_name":"ListenerName","trigger":{"source_trigger_id":"SourceTriggerID","name":"start-deploy"},"event_params_blob":"EventParamsBlob","event_header_params_blob":"EventHeaderParamsBlob","properties":[{"name":"Name","value":"Value","enum":["Enum"],"type":"secure","path":"Path"}],"created_at":"2019-01-01T12:00:00.000Z","updated_at":"2019-01-01T12:00:00.000Z","run_url":"RunURL","href":"Href"}]}`)
+						fmt.Fprintf(res, "%s", `{"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1,"pipeline_runs":[{"id":"ID","user_info":{"iam_id":"IamID","sub":"Sub"},"status":"pending","definition_id":"DefinitionID","worker":{"name":"Name","agent":"Agent","service_id":"ServiceID","id":"ID"},"pipeline_id":"PipelineID","listener_name":"ListenerName","trigger":{"type":"Type","name":"start-deploy","href":"Href","event_listener":"EventListener","id":"ID","properties":[{"name":"Name","value":"Value","enum":["Enum"],"type":"secure","path":"Path","href":"Href"}],"tags":["Tags"],"worker":{"name":"Name","type":"private","id":"ID"},"max_concurrent_runs":4,"disabled":true},"event_params_blob":"EventParamsBlob","event_header_params_blob":"EventHeaderParamsBlob","properties":[{"name":"Name","value":"Value","enum":["Enum"],"type":"secure","path":"Path"}],"created_at":"2019-01-01T12:00:00.000Z","updated_at":"2019-01-01T12:00:00.000Z","run_url":"RunURL","href":"Href"}]}`)
 					} else if requestNumber == 2 {
-						fmt.Fprintf(res, "%s", `{"total_count":2,"limit":1,"pipeline_runs":[{"id":"ID","user_info":{"iam_id":"IamID","sub":"Sub"},"status":"pending","definition_id":"DefinitionID","worker":{"name":"Name","agent":"Agent","service_id":"ServiceID","id":"ID"},"pipeline_id":"PipelineID","listener_name":"ListenerName","trigger":{"source_trigger_id":"SourceTriggerID","name":"start-deploy"},"event_params_blob":"EventParamsBlob","event_header_params_blob":"EventHeaderParamsBlob","properties":[{"name":"Name","value":"Value","enum":["Enum"],"type":"secure","path":"Path"}],"created_at":"2019-01-01T12:00:00.000Z","updated_at":"2019-01-01T12:00:00.000Z","run_url":"RunURL","href":"Href"}]}`)
+						fmt.Fprintf(res, "%s", `{"total_count":2,"limit":1,"pipeline_runs":[{"id":"ID","user_info":{"iam_id":"IamID","sub":"Sub"},"status":"pending","definition_id":"DefinitionID","worker":{"name":"Name","agent":"Agent","service_id":"ServiceID","id":"ID"},"pipeline_id":"PipelineID","listener_name":"ListenerName","trigger":{"type":"Type","name":"start-deploy","href":"Href","event_listener":"EventListener","id":"ID","properties":[{"name":"Name","value":"Value","enum":["Enum"],"type":"secure","path":"Path","href":"Href"}],"tags":["Tags"],"worker":{"name":"Name","type":"private","id":"ID"},"max_concurrent_runs":4,"disabled":true},"event_params_blob":"EventParamsBlob","event_header_params_blob":"EventHeaderParamsBlob","properties":[{"name":"Name","value":"Value","enum":["Enum"],"type":"secure","path":"Path"}],"created_at":"2019-01-01T12:00:00.000Z","updated_at":"2019-01-01T12:00:00.000Z","run_url":"RunURL","href":"Href"}]}`)
 					} else {
 						res.WriteHeader(400)
 					}
@@ -1502,7 +1502,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"type": "Type", "name": "start-deploy", "href": "Href", "event_listener": "EventListener", "id": "ID", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path", "href": "Href"}], "tags": ["Tags"], "worker": {"name": "Name", "type": "private", "id": "ID"}, "max_concurrent_runs": 4, "disabled": true}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
 				}))
 			})
 			It(`Invoke CreateTektonPipelineRun successfully with retries`, func() {
@@ -1577,7 +1577,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"type": "Type", "name": "start-deploy", "href": "Href", "event_listener": "EventListener", "id": "ID", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path", "href": "Href"}], "tags": ["Tags"], "worker": {"name": "Name", "type": "private", "id": "ID"}, "max_concurrent_runs": 4, "disabled": true}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
 				}))
 			})
 			It(`Invoke CreateTektonPipelineRun successfully`, func() {
@@ -1754,7 +1754,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"type": "Type", "name": "start-deploy", "href": "Href", "event_listener": "EventListener", "id": "ID", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path", "href": "Href"}], "tags": ["Tags"], "worker": {"name": "Name", "type": "private", "id": "ID"}, "max_concurrent_runs": 4, "disabled": true}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
 				}))
 			})
 			It(`Invoke GetTektonPipelineRun successfully with retries`, func() {
@@ -1811,7 +1811,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"type": "Type", "name": "start-deploy", "href": "Href", "event_listener": "EventListener", "id": "ID", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path", "href": "Href"}], "tags": ["Tags"], "worker": {"name": "Name", "type": "private", "id": "ID"}, "max_concurrent_runs": 4, "disabled": true}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
 				}))
 			})
 			It(`Invoke GetTektonPipelineRun successfully`, func() {
@@ -2063,7 +2063,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"type": "Type", "name": "start-deploy", "href": "Href", "event_listener": "EventListener", "id": "ID", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path", "href": "Href"}], "tags": ["Tags"], "worker": {"name": "Name", "type": "private", "id": "ID"}, "max_concurrent_runs": 4, "disabled": true}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
 				}))
 			})
 			It(`Invoke CancelTektonPipelineRun successfully with retries`, func() {
@@ -2135,7 +2135,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"type": "Type", "name": "start-deploy", "href": "Href", "event_listener": "EventListener", "id": "ID", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path", "href": "Href"}], "tags": ["Tags"], "worker": {"name": "Name", "type": "private", "id": "ID"}, "max_concurrent_runs": 4, "disabled": true}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
 				}))
 			})
 			It(`Invoke CancelTektonPipelineRun successfully`, func() {
@@ -2300,7 +2300,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"type": "Type", "name": "start-deploy", "href": "Href", "event_listener": "EventListener", "id": "ID", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path", "href": "Href"}], "tags": ["Tags"], "worker": {"name": "Name", "type": "private", "id": "ID"}, "max_concurrent_runs": 4, "disabled": true}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
 				}))
 			})
 			It(`Invoke RerunTektonPipelineRun successfully with retries`, func() {
@@ -2355,7 +2355,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"type": "Type", "name": "start-deploy", "href": "Href", "event_listener": "EventListener", "id": "ID", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path", "href": "Href"}], "tags": ["Tags"], "worker": {"name": "Name", "type": "private", "id": "ID"}, "max_concurrent_runs": 4, "disabled": true}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL"}`)
 				}))
 			})
 			It(`Invoke RerunTektonPipelineRun successfully`, func() {
@@ -5131,7 +5131,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}]}`)
+					fmt.Fprintf(res, "%s", `{"triggers": [{"type": "Type", "name": "start-deploy", "href": "Href", "event_listener": "EventListener", "id": "ID", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path", "href": "Href"}], "tags": ["Tags"], "worker": {"name": "Name", "type": "private", "id": "ID"}, "max_concurrent_runs": 4, "disabled": true}]}`)
 				}))
 			})
 			It(`Invoke ListTektonPipelineTriggers successfully with retries`, func() {
@@ -5199,7 +5199,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}]}`)
+					fmt.Fprintf(res, "%s", `{"triggers": [{"type": "Type", "name": "start-deploy", "href": "Href", "event_listener": "EventListener", "id": "ID", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path", "href": "Href"}], "tags": ["Tags"], "worker": {"name": "Name", "type": "private", "id": "ID"}, "max_concurrent_runs": 4, "disabled": true}]}`)
 				}))
 			})
 			It(`Invoke ListTektonPipelineTriggers successfully`, func() {
@@ -5339,10 +5339,42 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(serviceErr).To(BeNil())
 				Expect(cdTektonPipelineService).ToNot(BeNil())
 
-				// Construct an instance of the TriggerDuplicateTrigger model
-				triggerModel := new(cdtektonpipelinev2.TriggerDuplicateTrigger)
-				triggerModel.SourceTriggerID = core.StringPtr("b3a8228f-1c82-409b-b249-7639166a0300")
-				triggerModel.Name = core.StringPtr("Trigger Name")
+				// Construct an instance of the TriggerGenericTriggerPropertiesItem model
+				triggerGenericTriggerPropertiesItemModel := new(cdtektonpipelinev2.TriggerGenericTriggerPropertiesItem)
+				triggerGenericTriggerPropertiesItemModel.Name = core.StringPtr("testString")
+				triggerGenericTriggerPropertiesItemModel.Value = core.StringPtr("testString")
+				triggerGenericTriggerPropertiesItemModel.Enum = []string{"testString"}
+				triggerGenericTriggerPropertiesItemModel.Type = core.StringPtr("secure")
+				triggerGenericTriggerPropertiesItemModel.Path = core.StringPtr("testString")
+				triggerGenericTriggerPropertiesItemModel.Href = core.StringPtr("testString")
+
+				// Construct an instance of the Worker model
+				workerModel := new(cdtektonpipelinev2.Worker)
+				workerModel.Name = core.StringPtr("testString")
+				workerModel.Type = core.StringPtr("private")
+				workerModel.ID = core.StringPtr("5df804a4-9d7b-44e1-874f-3810866fb80b")
+
+				// Construct an instance of the GenericSecret model
+				genericSecretModel := new(cdtektonpipelinev2.GenericSecret)
+				genericSecretModel.Type = core.StringPtr("token_matches")
+				genericSecretModel.Value = core.StringPtr("secret")
+				genericSecretModel.Source = core.StringPtr("query")
+				genericSecretModel.KeyName = core.StringPtr("auth")
+				genericSecretModel.Algorithm = core.StringPtr("md4")
+
+				// Construct an instance of the TriggerGenericTrigger model
+				triggerModel := new(cdtektonpipelinev2.TriggerGenericTrigger)
+				triggerModel.Type = core.StringPtr("generic")
+				triggerModel.Name = core.StringPtr("Generic Webhook Trigger")
+				triggerModel.Href = core.StringPtr("testString")
+				triggerModel.EventListener = core.StringPtr("pr-listener")
+				triggerModel.ID = core.StringPtr("testString")
+				triggerModel.Properties = []cdtektonpipelinev2.TriggerGenericTriggerPropertiesItem{*triggerGenericTriggerPropertiesItemModel}
+				triggerModel.Tags = []string{"prod", "dev"}
+				triggerModel.Worker = workerModel
+				triggerModel.MaxConcurrentRuns = core.Int64Ptr(int64(4))
+				triggerModel.Disabled = core.BoolPtr(false)
+				triggerModel.Secret = genericSecretModel
 
 				// Construct an instance of the CreateTektonPipelineTriggerOptions model
 				createTektonPipelineTriggerOptionsModel := new(cdtektonpipelinev2.CreateTektonPipelineTriggerOptions)
@@ -5400,7 +5432,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}`)
+					fmt.Fprintf(res, "%s", `{"type": "Type", "name": "start-deploy", "href": "Href", "event_listener": "EventListener", "id": "ID", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path", "href": "Href"}], "tags": ["Tags"], "worker": {"name": "Name", "type": "private", "id": "ID"}, "max_concurrent_runs": 4, "disabled": true}`)
 				}))
 			})
 			It(`Invoke CreateTektonPipelineTrigger successfully with retries`, func() {
@@ -5412,10 +5444,42 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(cdTektonPipelineService).ToNot(BeNil())
 				cdTektonPipelineService.EnableRetries(0, 0)
 
-				// Construct an instance of the TriggerDuplicateTrigger model
-				triggerModel := new(cdtektonpipelinev2.TriggerDuplicateTrigger)
-				triggerModel.SourceTriggerID = core.StringPtr("b3a8228f-1c82-409b-b249-7639166a0300")
-				triggerModel.Name = core.StringPtr("Trigger Name")
+				// Construct an instance of the TriggerGenericTriggerPropertiesItem model
+				triggerGenericTriggerPropertiesItemModel := new(cdtektonpipelinev2.TriggerGenericTriggerPropertiesItem)
+				triggerGenericTriggerPropertiesItemModel.Name = core.StringPtr("testString")
+				triggerGenericTriggerPropertiesItemModel.Value = core.StringPtr("testString")
+				triggerGenericTriggerPropertiesItemModel.Enum = []string{"testString"}
+				triggerGenericTriggerPropertiesItemModel.Type = core.StringPtr("secure")
+				triggerGenericTriggerPropertiesItemModel.Path = core.StringPtr("testString")
+				triggerGenericTriggerPropertiesItemModel.Href = core.StringPtr("testString")
+
+				// Construct an instance of the Worker model
+				workerModel := new(cdtektonpipelinev2.Worker)
+				workerModel.Name = core.StringPtr("testString")
+				workerModel.Type = core.StringPtr("private")
+				workerModel.ID = core.StringPtr("5df804a4-9d7b-44e1-874f-3810866fb80b")
+
+				// Construct an instance of the GenericSecret model
+				genericSecretModel := new(cdtektonpipelinev2.GenericSecret)
+				genericSecretModel.Type = core.StringPtr("token_matches")
+				genericSecretModel.Value = core.StringPtr("secret")
+				genericSecretModel.Source = core.StringPtr("query")
+				genericSecretModel.KeyName = core.StringPtr("auth")
+				genericSecretModel.Algorithm = core.StringPtr("md4")
+
+				// Construct an instance of the TriggerGenericTrigger model
+				triggerModel := new(cdtektonpipelinev2.TriggerGenericTrigger)
+				triggerModel.Type = core.StringPtr("generic")
+				triggerModel.Name = core.StringPtr("Generic Webhook Trigger")
+				triggerModel.Href = core.StringPtr("testString")
+				triggerModel.EventListener = core.StringPtr("pr-listener")
+				triggerModel.ID = core.StringPtr("testString")
+				triggerModel.Properties = []cdtektonpipelinev2.TriggerGenericTriggerPropertiesItem{*triggerGenericTriggerPropertiesItemModel}
+				triggerModel.Tags = []string{"prod", "dev"}
+				triggerModel.Worker = workerModel
+				triggerModel.MaxConcurrentRuns = core.Int64Ptr(int64(4))
+				triggerModel.Disabled = core.BoolPtr(false)
+				triggerModel.Secret = genericSecretModel
 
 				// Construct an instance of the CreateTektonPipelineTriggerOptions model
 				createTektonPipelineTriggerOptionsModel := new(cdtektonpipelinev2.CreateTektonPipelineTriggerOptions)
@@ -5476,7 +5540,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}`)
+					fmt.Fprintf(res, "%s", `{"type": "Type", "name": "start-deploy", "href": "Href", "event_listener": "EventListener", "id": "ID", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path", "href": "Href"}], "tags": ["Tags"], "worker": {"name": "Name", "type": "private", "id": "ID"}, "max_concurrent_runs": 4, "disabled": true}`)
 				}))
 			})
 			It(`Invoke CreateTektonPipelineTrigger successfully`, func() {
@@ -5493,10 +5557,42 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(response).To(BeNil())
 				Expect(result).To(BeNil())
 
-				// Construct an instance of the TriggerDuplicateTrigger model
-				triggerModel := new(cdtektonpipelinev2.TriggerDuplicateTrigger)
-				triggerModel.SourceTriggerID = core.StringPtr("b3a8228f-1c82-409b-b249-7639166a0300")
-				triggerModel.Name = core.StringPtr("Trigger Name")
+				// Construct an instance of the TriggerGenericTriggerPropertiesItem model
+				triggerGenericTriggerPropertiesItemModel := new(cdtektonpipelinev2.TriggerGenericTriggerPropertiesItem)
+				triggerGenericTriggerPropertiesItemModel.Name = core.StringPtr("testString")
+				triggerGenericTriggerPropertiesItemModel.Value = core.StringPtr("testString")
+				triggerGenericTriggerPropertiesItemModel.Enum = []string{"testString"}
+				triggerGenericTriggerPropertiesItemModel.Type = core.StringPtr("secure")
+				triggerGenericTriggerPropertiesItemModel.Path = core.StringPtr("testString")
+				triggerGenericTriggerPropertiesItemModel.Href = core.StringPtr("testString")
+
+				// Construct an instance of the Worker model
+				workerModel := new(cdtektonpipelinev2.Worker)
+				workerModel.Name = core.StringPtr("testString")
+				workerModel.Type = core.StringPtr("private")
+				workerModel.ID = core.StringPtr("5df804a4-9d7b-44e1-874f-3810866fb80b")
+
+				// Construct an instance of the GenericSecret model
+				genericSecretModel := new(cdtektonpipelinev2.GenericSecret)
+				genericSecretModel.Type = core.StringPtr("token_matches")
+				genericSecretModel.Value = core.StringPtr("secret")
+				genericSecretModel.Source = core.StringPtr("query")
+				genericSecretModel.KeyName = core.StringPtr("auth")
+				genericSecretModel.Algorithm = core.StringPtr("md4")
+
+				// Construct an instance of the TriggerGenericTrigger model
+				triggerModel := new(cdtektonpipelinev2.TriggerGenericTrigger)
+				triggerModel.Type = core.StringPtr("generic")
+				triggerModel.Name = core.StringPtr("Generic Webhook Trigger")
+				triggerModel.Href = core.StringPtr("testString")
+				triggerModel.EventListener = core.StringPtr("pr-listener")
+				triggerModel.ID = core.StringPtr("testString")
+				triggerModel.Properties = []cdtektonpipelinev2.TriggerGenericTriggerPropertiesItem{*triggerGenericTriggerPropertiesItemModel}
+				triggerModel.Tags = []string{"prod", "dev"}
+				triggerModel.Worker = workerModel
+				triggerModel.MaxConcurrentRuns = core.Int64Ptr(int64(4))
+				triggerModel.Disabled = core.BoolPtr(false)
+				triggerModel.Secret = genericSecretModel
 
 				// Construct an instance of the CreateTektonPipelineTriggerOptions model
 				createTektonPipelineTriggerOptionsModel := new(cdtektonpipelinev2.CreateTektonPipelineTriggerOptions)
@@ -5519,10 +5615,42 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(serviceErr).To(BeNil())
 				Expect(cdTektonPipelineService).ToNot(BeNil())
 
-				// Construct an instance of the TriggerDuplicateTrigger model
-				triggerModel := new(cdtektonpipelinev2.TriggerDuplicateTrigger)
-				triggerModel.SourceTriggerID = core.StringPtr("b3a8228f-1c82-409b-b249-7639166a0300")
-				triggerModel.Name = core.StringPtr("Trigger Name")
+				// Construct an instance of the TriggerGenericTriggerPropertiesItem model
+				triggerGenericTriggerPropertiesItemModel := new(cdtektonpipelinev2.TriggerGenericTriggerPropertiesItem)
+				triggerGenericTriggerPropertiesItemModel.Name = core.StringPtr("testString")
+				triggerGenericTriggerPropertiesItemModel.Value = core.StringPtr("testString")
+				triggerGenericTriggerPropertiesItemModel.Enum = []string{"testString"}
+				triggerGenericTriggerPropertiesItemModel.Type = core.StringPtr("secure")
+				triggerGenericTriggerPropertiesItemModel.Path = core.StringPtr("testString")
+				triggerGenericTriggerPropertiesItemModel.Href = core.StringPtr("testString")
+
+				// Construct an instance of the Worker model
+				workerModel := new(cdtektonpipelinev2.Worker)
+				workerModel.Name = core.StringPtr("testString")
+				workerModel.Type = core.StringPtr("private")
+				workerModel.ID = core.StringPtr("5df804a4-9d7b-44e1-874f-3810866fb80b")
+
+				// Construct an instance of the GenericSecret model
+				genericSecretModel := new(cdtektonpipelinev2.GenericSecret)
+				genericSecretModel.Type = core.StringPtr("token_matches")
+				genericSecretModel.Value = core.StringPtr("secret")
+				genericSecretModel.Source = core.StringPtr("query")
+				genericSecretModel.KeyName = core.StringPtr("auth")
+				genericSecretModel.Algorithm = core.StringPtr("md4")
+
+				// Construct an instance of the TriggerGenericTrigger model
+				triggerModel := new(cdtektonpipelinev2.TriggerGenericTrigger)
+				triggerModel.Type = core.StringPtr("generic")
+				triggerModel.Name = core.StringPtr("Generic Webhook Trigger")
+				triggerModel.Href = core.StringPtr("testString")
+				triggerModel.EventListener = core.StringPtr("pr-listener")
+				triggerModel.ID = core.StringPtr("testString")
+				triggerModel.Properties = []cdtektonpipelinev2.TriggerGenericTriggerPropertiesItem{*triggerGenericTriggerPropertiesItemModel}
+				triggerModel.Tags = []string{"prod", "dev"}
+				triggerModel.Worker = workerModel
+				triggerModel.MaxConcurrentRuns = core.Int64Ptr(int64(4))
+				triggerModel.Disabled = core.BoolPtr(false)
+				triggerModel.Secret = genericSecretModel
 
 				// Construct an instance of the CreateTektonPipelineTriggerOptions model
 				createTektonPipelineTriggerOptionsModel := new(cdtektonpipelinev2.CreateTektonPipelineTriggerOptions)
@@ -5566,10 +5694,42 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(serviceErr).To(BeNil())
 				Expect(cdTektonPipelineService).ToNot(BeNil())
 
-				// Construct an instance of the TriggerDuplicateTrigger model
-				triggerModel := new(cdtektonpipelinev2.TriggerDuplicateTrigger)
-				triggerModel.SourceTriggerID = core.StringPtr("b3a8228f-1c82-409b-b249-7639166a0300")
-				triggerModel.Name = core.StringPtr("Trigger Name")
+				// Construct an instance of the TriggerGenericTriggerPropertiesItem model
+				triggerGenericTriggerPropertiesItemModel := new(cdtektonpipelinev2.TriggerGenericTriggerPropertiesItem)
+				triggerGenericTriggerPropertiesItemModel.Name = core.StringPtr("testString")
+				triggerGenericTriggerPropertiesItemModel.Value = core.StringPtr("testString")
+				triggerGenericTriggerPropertiesItemModel.Enum = []string{"testString"}
+				triggerGenericTriggerPropertiesItemModel.Type = core.StringPtr("secure")
+				triggerGenericTriggerPropertiesItemModel.Path = core.StringPtr("testString")
+				triggerGenericTriggerPropertiesItemModel.Href = core.StringPtr("testString")
+
+				// Construct an instance of the Worker model
+				workerModel := new(cdtektonpipelinev2.Worker)
+				workerModel.Name = core.StringPtr("testString")
+				workerModel.Type = core.StringPtr("private")
+				workerModel.ID = core.StringPtr("5df804a4-9d7b-44e1-874f-3810866fb80b")
+
+				// Construct an instance of the GenericSecret model
+				genericSecretModel := new(cdtektonpipelinev2.GenericSecret)
+				genericSecretModel.Type = core.StringPtr("token_matches")
+				genericSecretModel.Value = core.StringPtr("secret")
+				genericSecretModel.Source = core.StringPtr("query")
+				genericSecretModel.KeyName = core.StringPtr("auth")
+				genericSecretModel.Algorithm = core.StringPtr("md4")
+
+				// Construct an instance of the TriggerGenericTrigger model
+				triggerModel := new(cdtektonpipelinev2.TriggerGenericTrigger)
+				triggerModel.Type = core.StringPtr("generic")
+				triggerModel.Name = core.StringPtr("Generic Webhook Trigger")
+				triggerModel.Href = core.StringPtr("testString")
+				triggerModel.EventListener = core.StringPtr("pr-listener")
+				triggerModel.ID = core.StringPtr("testString")
+				triggerModel.Properties = []cdtektonpipelinev2.TriggerGenericTriggerPropertiesItem{*triggerGenericTriggerPropertiesItemModel}
+				triggerModel.Tags = []string{"prod", "dev"}
+				triggerModel.Worker = workerModel
+				triggerModel.MaxConcurrentRuns = core.Int64Ptr(int64(4))
+				triggerModel.Disabled = core.BoolPtr(false)
+				triggerModel.Secret = genericSecretModel
 
 				// Construct an instance of the CreateTektonPipelineTriggerOptions model
 				createTektonPipelineTriggerOptionsModel := new(cdtektonpipelinev2.CreateTektonPipelineTriggerOptions)
@@ -5653,7 +5813,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}`)
+					fmt.Fprintf(res, "%s", `{"type": "Type", "name": "start-deploy", "href": "Href", "event_listener": "EventListener", "id": "ID", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path", "href": "Href"}], "tags": ["Tags"], "worker": {"name": "Name", "type": "private", "id": "ID"}, "max_concurrent_runs": 4, "disabled": true}`)
 				}))
 			})
 			It(`Invoke GetTektonPipelineTrigger successfully with retries`, func() {
@@ -5708,7 +5868,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}`)
+					fmt.Fprintf(res, "%s", `{"type": "Type", "name": "start-deploy", "href": "Href", "event_listener": "EventListener", "id": "ID", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path", "href": "Href"}], "tags": ["Tags"], "worker": {"name": "Name", "type": "private", "id": "ID"}, "max_concurrent_runs": 4, "disabled": true}`)
 				}))
 			})
 			It(`Invoke GetTektonPipelineTrigger successfully`, func() {
@@ -5933,7 +6093,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}`)
+					fmt.Fprintf(res, "%s", `{"type": "Type", "name": "start-deploy", "href": "Href", "event_listener": "EventListener", "id": "ID", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path", "href": "Href"}], "tags": ["Tags"], "worker": {"name": "Name", "type": "private", "id": "ID"}, "max_concurrent_runs": 4, "disabled": true}`)
 				}))
 			})
 			It(`Invoke UpdateTektonPipelineTrigger successfully with retries`, func() {
@@ -6051,7 +6211,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}`)
+					fmt.Fprintf(res, "%s", `{"type": "Type", "name": "start-deploy", "href": "Href", "event_listener": "EventListener", "id": "ID", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path", "href": "Href"}], "tags": ["Tags"], "worker": {"name": "Name", "type": "private", "id": "ID"}, "max_concurrent_runs": 4, "disabled": true}`)
 				}))
 			})
 			It(`Invoke UpdateTektonPipelineTrigger successfully`, func() {
@@ -6355,6 +6515,260 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				response, operationErr = cdTektonPipelineService.DeleteTektonPipelineTrigger(deleteTektonPipelineTriggerOptionsModelNew)
 				Expect(operationErr).ToNot(BeNil())
 				Expect(response).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`DuplicateTektonPipelineTrigger(duplicateTektonPipelineTriggerOptions *DuplicateTektonPipelineTriggerOptions) - Operation response error`, func() {
+		duplicateTektonPipelineTriggerPath := "/tekton_pipelines/94619026-912b-4d92-8f51-6c74f0692d90/triggers/1bb892a1-2e04-4768-a369-b1159eace147/duplicate"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(duplicateTektonPipelineTriggerPath))
+					Expect(req.Method).To(Equal("POST"))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(201)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke DuplicateTektonPipelineTrigger with error: Operation response processing error`, func() {
+				cdTektonPipelineService, serviceErr := cdtektonpipelinev2.NewCdTektonPipelineV2(&cdtektonpipelinev2.CdTektonPipelineV2Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(cdTektonPipelineService).ToNot(BeNil())
+
+				// Construct an instance of the DuplicateTektonPipelineTriggerOptions model
+				duplicateTektonPipelineTriggerOptionsModel := new(cdtektonpipelinev2.DuplicateTektonPipelineTriggerOptions)
+				duplicateTektonPipelineTriggerOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
+				duplicateTektonPipelineTriggerOptionsModel.SourceTriggerID = core.StringPtr("1bb892a1-2e04-4768-a369-b1159eace147")
+				duplicateTektonPipelineTriggerOptionsModel.Name = core.StringPtr("triggerName")
+				duplicateTektonPipelineTriggerOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := cdTektonPipelineService.DuplicateTektonPipelineTrigger(duplicateTektonPipelineTriggerOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				cdTektonPipelineService.EnableRetries(0, 0)
+				result, response, operationErr = cdTektonPipelineService.DuplicateTektonPipelineTrigger(duplicateTektonPipelineTriggerOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`DuplicateTektonPipelineTrigger(duplicateTektonPipelineTriggerOptions *DuplicateTektonPipelineTriggerOptions)`, func() {
+		duplicateTektonPipelineTriggerPath := "/tekton_pipelines/94619026-912b-4d92-8f51-6c74f0692d90/triggers/1bb892a1-2e04-4768-a369-b1159eace147/duplicate"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(duplicateTektonPipelineTriggerPath))
+					Expect(req.Method).To(Equal("POST"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(201)
+					fmt.Fprintf(res, "%s", `{"type": "Type", "name": "start-deploy", "href": "Href", "event_listener": "EventListener", "id": "ID", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path", "href": "Href"}], "tags": ["Tags"], "worker": {"name": "Name", "type": "private", "id": "ID"}, "max_concurrent_runs": 4, "disabled": true}`)
+				}))
+			})
+			It(`Invoke DuplicateTektonPipelineTrigger successfully with retries`, func() {
+				cdTektonPipelineService, serviceErr := cdtektonpipelinev2.NewCdTektonPipelineV2(&cdtektonpipelinev2.CdTektonPipelineV2Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(cdTektonPipelineService).ToNot(BeNil())
+				cdTektonPipelineService.EnableRetries(0, 0)
+
+				// Construct an instance of the DuplicateTektonPipelineTriggerOptions model
+				duplicateTektonPipelineTriggerOptionsModel := new(cdtektonpipelinev2.DuplicateTektonPipelineTriggerOptions)
+				duplicateTektonPipelineTriggerOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
+				duplicateTektonPipelineTriggerOptionsModel.SourceTriggerID = core.StringPtr("1bb892a1-2e04-4768-a369-b1159eace147")
+				duplicateTektonPipelineTriggerOptionsModel.Name = core.StringPtr("triggerName")
+				duplicateTektonPipelineTriggerOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := cdTektonPipelineService.DuplicateTektonPipelineTriggerWithContext(ctx, duplicateTektonPipelineTriggerOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				cdTektonPipelineService.DisableRetries()
+				result, response, operationErr := cdTektonPipelineService.DuplicateTektonPipelineTrigger(duplicateTektonPipelineTriggerOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = cdTektonPipelineService.DuplicateTektonPipelineTriggerWithContext(ctx, duplicateTektonPipelineTriggerOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(duplicateTektonPipelineTriggerPath))
+					Expect(req.Method).To(Equal("POST"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(201)
+					fmt.Fprintf(res, "%s", `{"type": "Type", "name": "start-deploy", "href": "Href", "event_listener": "EventListener", "id": "ID", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path", "href": "Href"}], "tags": ["Tags"], "worker": {"name": "Name", "type": "private", "id": "ID"}, "max_concurrent_runs": 4, "disabled": true}`)
+				}))
+			})
+			It(`Invoke DuplicateTektonPipelineTrigger successfully`, func() {
+				cdTektonPipelineService, serviceErr := cdtektonpipelinev2.NewCdTektonPipelineV2(&cdtektonpipelinev2.CdTektonPipelineV2Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(cdTektonPipelineService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := cdTektonPipelineService.DuplicateTektonPipelineTrigger(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the DuplicateTektonPipelineTriggerOptions model
+				duplicateTektonPipelineTriggerOptionsModel := new(cdtektonpipelinev2.DuplicateTektonPipelineTriggerOptions)
+				duplicateTektonPipelineTriggerOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
+				duplicateTektonPipelineTriggerOptionsModel.SourceTriggerID = core.StringPtr("1bb892a1-2e04-4768-a369-b1159eace147")
+				duplicateTektonPipelineTriggerOptionsModel.Name = core.StringPtr("triggerName")
+				duplicateTektonPipelineTriggerOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = cdTektonPipelineService.DuplicateTektonPipelineTrigger(duplicateTektonPipelineTriggerOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke DuplicateTektonPipelineTrigger with error: Operation validation and request error`, func() {
+				cdTektonPipelineService, serviceErr := cdtektonpipelinev2.NewCdTektonPipelineV2(&cdtektonpipelinev2.CdTektonPipelineV2Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(cdTektonPipelineService).ToNot(BeNil())
+
+				// Construct an instance of the DuplicateTektonPipelineTriggerOptions model
+				duplicateTektonPipelineTriggerOptionsModel := new(cdtektonpipelinev2.DuplicateTektonPipelineTriggerOptions)
+				duplicateTektonPipelineTriggerOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
+				duplicateTektonPipelineTriggerOptionsModel.SourceTriggerID = core.StringPtr("1bb892a1-2e04-4768-a369-b1159eace147")
+				duplicateTektonPipelineTriggerOptionsModel.Name = core.StringPtr("triggerName")
+				duplicateTektonPipelineTriggerOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := cdTektonPipelineService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := cdTektonPipelineService.DuplicateTektonPipelineTrigger(duplicateTektonPipelineTriggerOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+				// Construct a second instance of the DuplicateTektonPipelineTriggerOptions model with no property values
+				duplicateTektonPipelineTriggerOptionsModelNew := new(cdtektonpipelinev2.DuplicateTektonPipelineTriggerOptions)
+				// Invoke operation with invalid model (negative test)
+				result, response, operationErr = cdTektonPipelineService.DuplicateTektonPipelineTrigger(duplicateTektonPipelineTriggerOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(201)
+				}))
+			})
+			It(`Invoke DuplicateTektonPipelineTrigger successfully`, func() {
+				cdTektonPipelineService, serviceErr := cdtektonpipelinev2.NewCdTektonPipelineV2(&cdtektonpipelinev2.CdTektonPipelineV2Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(cdTektonPipelineService).ToNot(BeNil())
+
+				// Construct an instance of the DuplicateTektonPipelineTriggerOptions model
+				duplicateTektonPipelineTriggerOptionsModel := new(cdtektonpipelinev2.DuplicateTektonPipelineTriggerOptions)
+				duplicateTektonPipelineTriggerOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
+				duplicateTektonPipelineTriggerOptionsModel.SourceTriggerID = core.StringPtr("1bb892a1-2e04-4768-a369-b1159eace147")
+				duplicateTektonPipelineTriggerOptionsModel.Name = core.StringPtr("triggerName")
+				duplicateTektonPipelineTriggerOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := cdTektonPipelineService.DuplicateTektonPipelineTrigger(duplicateTektonPipelineTriggerOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
 			})
 			AfterEach(func() {
 				testServer.Close()
@@ -7560,13 +7974,55 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(createTektonPipelineRunOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewCreateTektonPipelineTriggerOptions successfully`, func() {
-				// Construct an instance of the TriggerDuplicateTrigger model
-				triggerModel := new(cdtektonpipelinev2.TriggerDuplicateTrigger)
+				// Construct an instance of the TriggerManualTriggerPropertiesItem model
+				triggerManualTriggerPropertiesItemModel := new(cdtektonpipelinev2.TriggerManualTriggerPropertiesItem)
+				Expect(triggerManualTriggerPropertiesItemModel).ToNot(BeNil())
+				triggerManualTriggerPropertiesItemModel.Name = core.StringPtr("testString")
+				triggerManualTriggerPropertiesItemModel.Value = core.StringPtr("testString")
+				triggerManualTriggerPropertiesItemModel.Enum = []string{"testString"}
+				triggerManualTriggerPropertiesItemModel.Type = core.StringPtr("secure")
+				triggerManualTriggerPropertiesItemModel.Path = core.StringPtr("testString")
+				triggerManualTriggerPropertiesItemModel.Href = core.StringPtr("testString")
+				Expect(triggerManualTriggerPropertiesItemModel.Name).To(Equal(core.StringPtr("testString")))
+				Expect(triggerManualTriggerPropertiesItemModel.Value).To(Equal(core.StringPtr("testString")))
+				Expect(triggerManualTriggerPropertiesItemModel.Enum).To(Equal([]string{"testString"}))
+				Expect(triggerManualTriggerPropertiesItemModel.Type).To(Equal(core.StringPtr("secure")))
+				Expect(triggerManualTriggerPropertiesItemModel.Path).To(Equal(core.StringPtr("testString")))
+				Expect(triggerManualTriggerPropertiesItemModel.Href).To(Equal(core.StringPtr("testString")))
+
+				// Construct an instance of the Worker model
+				workerModel := new(cdtektonpipelinev2.Worker)
+				Expect(workerModel).ToNot(BeNil())
+				workerModel.Name = core.StringPtr("testString")
+				workerModel.Type = core.StringPtr("private")
+				workerModel.ID = core.StringPtr("testString")
+				Expect(workerModel.Name).To(Equal(core.StringPtr("testString")))
+				Expect(workerModel.Type).To(Equal(core.StringPtr("private")))
+				Expect(workerModel.ID).To(Equal(core.StringPtr("testString")))
+
+				// Construct an instance of the TriggerManualTrigger model
+				triggerModel := new(cdtektonpipelinev2.TriggerManualTrigger)
 				Expect(triggerModel).ToNot(BeNil())
-				triggerModel.SourceTriggerID = core.StringPtr("testString")
+				triggerModel.Type = core.StringPtr("testString")
 				triggerModel.Name = core.StringPtr("start-deploy")
-				Expect(triggerModel.SourceTriggerID).To(Equal(core.StringPtr("testString")))
+				triggerModel.Href = core.StringPtr("testString")
+				triggerModel.EventListener = core.StringPtr("testString")
+				triggerModel.ID = core.StringPtr("testString")
+				triggerModel.Properties = []cdtektonpipelinev2.TriggerManualTriggerPropertiesItem{*triggerManualTriggerPropertiesItemModel}
+				triggerModel.Tags = []string{"testString"}
+				triggerModel.Worker = workerModel
+				triggerModel.MaxConcurrentRuns = core.Int64Ptr(int64(4))
+				triggerModel.Disabled = core.BoolPtr(true)
+				Expect(triggerModel.Type).To(Equal(core.StringPtr("testString")))
 				Expect(triggerModel.Name).To(Equal(core.StringPtr("start-deploy")))
+				Expect(triggerModel.Href).To(Equal(core.StringPtr("testString")))
+				Expect(triggerModel.EventListener).To(Equal(core.StringPtr("testString")))
+				Expect(triggerModel.ID).To(Equal(core.StringPtr("testString")))
+				Expect(triggerModel.Properties).To(Equal([]cdtektonpipelinev2.TriggerManualTriggerPropertiesItem{*triggerManualTriggerPropertiesItemModel}))
+				Expect(triggerModel.Tags).To(Equal([]string{"testString"}))
+				Expect(triggerModel.Worker).To(Equal(workerModel))
+				Expect(triggerModel.MaxConcurrentRuns).To(Equal(core.Int64Ptr(int64(4))))
+				Expect(triggerModel.Disabled).To(Equal(core.BoolPtr(true)))
 
 				// Construct an instance of the CreateTektonPipelineTriggerOptions model
 				pipelineID := "94619026-912b-4d92-8f51-6c74f0692d90"
@@ -7686,6 +8142,21 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(deleteTektonPipelineTriggerPropertyOptionsModel.TriggerID).To(Equal(core.StringPtr("1bb892a1-2e04-4768-a369-b1159eace147")))
 				Expect(deleteTektonPipelineTriggerPropertyOptionsModel.PropertyName).To(Equal(core.StringPtr("debug-pipeline")))
 				Expect(deleteTektonPipelineTriggerPropertyOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
+			It(`Invoke NewDuplicateTektonPipelineTriggerOptions successfully`, func() {
+				// Construct an instance of the DuplicateTektonPipelineTriggerOptions model
+				pipelineID := "94619026-912b-4d92-8f51-6c74f0692d90"
+				sourceTriggerID := "1bb892a1-2e04-4768-a369-b1159eace147"
+				duplicateTektonPipelineTriggerOptionsModel := cdTektonPipelineService.NewDuplicateTektonPipelineTriggerOptions(pipelineID, sourceTriggerID)
+				duplicateTektonPipelineTriggerOptionsModel.SetPipelineID("94619026-912b-4d92-8f51-6c74f0692d90")
+				duplicateTektonPipelineTriggerOptionsModel.SetSourceTriggerID("1bb892a1-2e04-4768-a369-b1159eace147")
+				duplicateTektonPipelineTriggerOptionsModel.SetName("triggerName")
+				duplicateTektonPipelineTriggerOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(duplicateTektonPipelineTriggerOptionsModel).ToNot(BeNil())
+				Expect(duplicateTektonPipelineTriggerOptionsModel.PipelineID).To(Equal(core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")))
+				Expect(duplicateTektonPipelineTriggerOptionsModel.SourceTriggerID).To(Equal(core.StringPtr("1bb892a1-2e04-4768-a369-b1159eace147")))
+				Expect(duplicateTektonPipelineTriggerOptionsModel.Name).To(Equal(core.StringPtr("triggerName")))
+				Expect(duplicateTektonPipelineTriggerOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewGetTektonPipelineDefinitionOptions successfully`, func() {
 				// Construct an instance of the GetTektonPipelineDefinitionOptions model
@@ -8058,13 +8529,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 			It(`Invoke NewWorkerWithID successfully`, func() {
 				id := "testString"
 				_model, err := cdTektonPipelineService.NewWorkerWithID(id)
-				Expect(_model).ToNot(BeNil())
-				Expect(err).To(BeNil())
-			})
-			It(`Invoke NewTriggerDuplicateTrigger successfully`, func() {
-				sourceTriggerID := "testString"
-				name := "start-deploy"
-				_model, err := cdTektonPipelineService.NewTriggerDuplicateTrigger(sourceTriggerID, name)
 				Expect(_model).ToNot(BeNil())
 				Expect(err).To(BeNil())
 			})

--- a/cdtektonpipelinev2/cd_tekton_pipeline_v2_test.go
+++ b/cdtektonpipelinev2/cd_tekton_pipeline_v2_test.go
@@ -1070,6 +1070,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Verify the contents of the request
 					Expect(req.URL.EscapedPath()).To(Equal(listTektonPipelineRunsPath))
 					Expect(req.Method).To(Equal("GET"))
+					Expect(req.URL.Query()["start"]).To(Equal([]string{"testString"}))
 					Expect(req.URL.Query()["limit"]).To(Equal([]string{fmt.Sprint(int64(10))}))
 					Expect(req.URL.Query()["offset"]).To(Equal([]string{fmt.Sprint(int64(38))}))
 					Expect(req.URL.Query()["status"]).To(Equal([]string{"succeeded"}))
@@ -1090,6 +1091,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				// Construct an instance of the ListTektonPipelineRunsOptions model
 				listTektonPipelineRunsOptionsModel := new(cdtektonpipelinev2.ListTektonPipelineRunsOptions)
 				listTektonPipelineRunsOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
+				listTektonPipelineRunsOptionsModel.Start = core.StringPtr("testString")
 				listTektonPipelineRunsOptionsModel.Limit = core.Int64Ptr(int64(10))
 				listTektonPipelineRunsOptionsModel.Offset = core.Int64Ptr(int64(38))
 				listTektonPipelineRunsOptionsModel.Status = core.StringPtr("succeeded")
@@ -1124,6 +1126,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					Expect(req.URL.EscapedPath()).To(Equal(listTektonPipelineRunsPath))
 					Expect(req.Method).To(Equal("GET"))
 
+					Expect(req.URL.Query()["start"]).To(Equal([]string{"testString"}))
 					Expect(req.URL.Query()["limit"]).To(Equal([]string{fmt.Sprint(int64(10))}))
 					Expect(req.URL.Query()["offset"]).To(Equal([]string{fmt.Sprint(int64(38))}))
 					Expect(req.URL.Query()["status"]).To(Equal([]string{"succeeded"}))
@@ -1134,7 +1137,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"pipeline_runs": [{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL", "href": "Href"}], "offset": 20, "limit": 20, "first": {"href": "Href"}, "next": {"href": "Href"}}`)
+					fmt.Fprintf(res, "%s", `{"pipeline_runs": [{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL", "href": "Href"}], "offset": 20, "limit": 20, "first": {"href": "Href"}, "next": {"href": "Href"}, "last": {"href": "Href"}}`)
 				}))
 			})
 			It(`Invoke ListTektonPipelineRuns successfully with retries`, func() {
@@ -1149,6 +1152,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				// Construct an instance of the ListTektonPipelineRunsOptions model
 				listTektonPipelineRunsOptionsModel := new(cdtektonpipelinev2.ListTektonPipelineRunsOptions)
 				listTektonPipelineRunsOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
+				listTektonPipelineRunsOptionsModel.Start = core.StringPtr("testString")
 				listTektonPipelineRunsOptionsModel.Limit = core.Int64Ptr(int64(10))
 				listTektonPipelineRunsOptionsModel.Offset = core.Int64Ptr(int64(38))
 				listTektonPipelineRunsOptionsModel.Status = core.StringPtr("succeeded")
@@ -1189,6 +1193,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					Expect(req.URL.EscapedPath()).To(Equal(listTektonPipelineRunsPath))
 					Expect(req.Method).To(Equal("GET"))
 
+					Expect(req.URL.Query()["start"]).To(Equal([]string{"testString"}))
 					Expect(req.URL.Query()["limit"]).To(Equal([]string{fmt.Sprint(int64(10))}))
 					Expect(req.URL.Query()["offset"]).To(Equal([]string{fmt.Sprint(int64(38))}))
 					Expect(req.URL.Query()["status"]).To(Equal([]string{"succeeded"}))
@@ -1196,7 +1201,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"pipeline_runs": [{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL", "href": "Href"}], "offset": 20, "limit": 20, "first": {"href": "Href"}, "next": {"href": "Href"}}`)
+					fmt.Fprintf(res, "%s", `{"pipeline_runs": [{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "type": "secure", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "run_url": "RunURL", "href": "Href"}], "offset": 20, "limit": 20, "first": {"href": "Href"}, "next": {"href": "Href"}, "last": {"href": "Href"}}`)
 				}))
 			})
 			It(`Invoke ListTektonPipelineRuns successfully`, func() {
@@ -1216,6 +1221,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				// Construct an instance of the ListTektonPipelineRunsOptions model
 				listTektonPipelineRunsOptionsModel := new(cdtektonpipelinev2.ListTektonPipelineRunsOptions)
 				listTektonPipelineRunsOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
+				listTektonPipelineRunsOptionsModel.Start = core.StringPtr("testString")
 				listTektonPipelineRunsOptionsModel.Limit = core.Int64Ptr(int64(10))
 				listTektonPipelineRunsOptionsModel.Offset = core.Int64Ptr(int64(38))
 				listTektonPipelineRunsOptionsModel.Status = core.StringPtr("succeeded")
@@ -1240,6 +1246,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				// Construct an instance of the ListTektonPipelineRunsOptions model
 				listTektonPipelineRunsOptionsModel := new(cdtektonpipelinev2.ListTektonPipelineRunsOptions)
 				listTektonPipelineRunsOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
+				listTektonPipelineRunsOptionsModel.Start = core.StringPtr("testString")
 				listTektonPipelineRunsOptionsModel.Limit = core.Int64Ptr(int64(10))
 				listTektonPipelineRunsOptionsModel.Offset = core.Int64Ptr(int64(38))
 				listTektonPipelineRunsOptionsModel.Status = core.StringPtr("succeeded")
@@ -1285,6 +1292,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				// Construct an instance of the ListTektonPipelineRunsOptions model
 				listTektonPipelineRunsOptionsModel := new(cdtektonpipelinev2.ListTektonPipelineRunsOptions)
 				listTektonPipelineRunsOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
+				listTektonPipelineRunsOptionsModel.Start = core.StringPtr("testString")
 				listTektonPipelineRunsOptionsModel.Limit = core.Int64Ptr(int64(10))
 				listTektonPipelineRunsOptionsModel.Offset = core.Int64Ptr(int64(38))
 				listTektonPipelineRunsOptionsModel.Status = core.StringPtr("succeeded")
@@ -1304,41 +1312,31 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 			})
 		})
 		Context(`Test pagination helper method on response`, func() {
-			It(`Invoke GetNextOffset successfully`, func() {
+			It(`Invoke GetNextStart successfully`, func() {
 				responseObject := new(cdtektonpipelinev2.PipelineRunsCollection)
 				nextObject := new(cdtektonpipelinev2.PipelineRunsCollectionNext)
-				nextObject.Href = core.StringPtr("ibm.com?offset=135")
+				nextObject.Href = core.StringPtr("ibm.com?start=abc-123")
 				responseObject.Next = nextObject
 	
-				value, err := responseObject.GetNextOffset()
+				value, err := responseObject.GetNextStart()
 				Expect(err).To(BeNil())
-				Expect(value).To(Equal(core.Int64Ptr(int64(135))))
+				Expect(value).To(Equal(core.StringPtr("abc-123")))
 			})
-			It(`Invoke GetNextOffset without a "Next" property in the response`, func() {
+			It(`Invoke GetNextStart without a "Next" property in the response`, func() {
 				responseObject := new(cdtektonpipelinev2.PipelineRunsCollection)
 	
-				value, err := responseObject.GetNextOffset()
+				value, err := responseObject.GetNextStart()
 				Expect(err).To(BeNil())
 				Expect(value).To(BeNil())
 			})
-			It(`Invoke GetNextOffset without any query params in the "Next" URL`, func() {
+			It(`Invoke GetNextStart without any query params in the "Next" URL`, func() {
 				responseObject := new(cdtektonpipelinev2.PipelineRunsCollection)
 				nextObject := new(cdtektonpipelinev2.PipelineRunsCollectionNext)
 				nextObject.Href = core.StringPtr("ibm.com")
 				responseObject.Next = nextObject
 	
-				value, err := responseObject.GetNextOffset()
+				value, err := responseObject.GetNextStart()
 				Expect(err).To(BeNil())
-				Expect(value).To(BeNil())
-			})
-			It(`Invoke GetNextOffset with a non-integer query param in the "Next" URL`, func() {
-				responseObject := new(cdtektonpipelinev2.PipelineRunsCollection)
-				nextObject := new(cdtektonpipelinev2.PipelineRunsCollectionNext)
-				nextObject.Href = core.StringPtr("ibm.com?offset=tiger")
-				responseObject.Next = nextObject
-	
-				value, err := responseObject.GetNextOffset()
-				Expect(err).NotTo(BeNil())
 				Expect(value).To(BeNil())
 			})
 		})
@@ -1357,7 +1355,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					res.WriteHeader(200)
 					requestNumber++
 					if requestNumber == 1 {
-						fmt.Fprintf(res, "%s", `{"next":{"href":"https://myhost.com/somePath?offset=1"},"total_count":2,"limit":1,"pipeline_runs":[{"id":"ID","user_info":{"iam_id":"IamID","sub":"Sub"},"status":"pending","definition_id":"DefinitionID","worker":{"name":"Name","agent":"Agent","service_id":"ServiceID","id":"ID"},"pipeline_id":"PipelineID","listener_name":"ListenerName","trigger":{"source_trigger_id":"SourceTriggerID","name":"start-deploy"},"event_params_blob":"EventParamsBlob","event_header_params_blob":"EventHeaderParamsBlob","properties":[{"name":"Name","value":"Value","enum":["Enum"],"type":"secure","path":"Path"}],"created_at":"2019-01-01T12:00:00.000Z","updated_at":"2019-01-01T12:00:00.000Z","run_url":"RunURL","href":"Href"}]}`)
+						fmt.Fprintf(res, "%s", `{"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1,"pipeline_runs":[{"id":"ID","user_info":{"iam_id":"IamID","sub":"Sub"},"status":"pending","definition_id":"DefinitionID","worker":{"name":"Name","agent":"Agent","service_id":"ServiceID","id":"ID"},"pipeline_id":"PipelineID","listener_name":"ListenerName","trigger":{"source_trigger_id":"SourceTriggerID","name":"start-deploy"},"event_params_blob":"EventParamsBlob","event_header_params_blob":"EventHeaderParamsBlob","properties":[{"name":"Name","value":"Value","enum":["Enum"],"type":"secure","path":"Path"}],"created_at":"2019-01-01T12:00:00.000Z","updated_at":"2019-01-01T12:00:00.000Z","run_url":"RunURL","href":"Href"}]}`)
 					} else if requestNumber == 2 {
 						fmt.Fprintf(res, "%s", `{"total_count":2,"limit":1,"pipeline_runs":[{"id":"ID","user_info":{"iam_id":"IamID","sub":"Sub"},"status":"pending","definition_id":"DefinitionID","worker":{"name":"Name","agent":"Agent","service_id":"ServiceID","id":"ID"},"pipeline_id":"PipelineID","listener_name":"ListenerName","trigger":{"source_trigger_id":"SourceTriggerID","name":"start-deploy"},"event_params_blob":"EventParamsBlob","event_header_params_blob":"EventHeaderParamsBlob","properties":[{"name":"Name","value":"Value","enum":["Enum"],"type":"secure","path":"Path"}],"created_at":"2019-01-01T12:00:00.000Z","updated_at":"2019-01-01T12:00:00.000Z","run_url":"RunURL","href":"Href"}]}`)
 					} else {
@@ -1376,6 +1374,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				listTektonPipelineRunsOptionsModel := &cdtektonpipelinev2.ListTektonPipelineRunsOptions{
 					PipelineID: core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90"),
 					Limit: core.Int64Ptr(int64(10)),
+					Offset: core.Int64Ptr(int64(38)),
 					Status: core.StringPtr("succeeded"),
 					TriggerName: core.StringPtr("manual-trigger"),
 				}
@@ -1404,6 +1403,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				listTektonPipelineRunsOptionsModel := &cdtektonpipelinev2.ListTektonPipelineRunsOptions{
 					PipelineID: core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90"),
 					Limit: core.Int64Ptr(int64(10)),
+					Offset: core.Int64Ptr(int64(38)),
 					Status: core.StringPtr("succeeded"),
 					TriggerName: core.StringPtr("manual-trigger"),
 				}
@@ -7827,6 +7827,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				pipelineID := "94619026-912b-4d92-8f51-6c74f0692d90"
 				listTektonPipelineRunsOptionsModel := cdTektonPipelineService.NewListTektonPipelineRunsOptions(pipelineID)
 				listTektonPipelineRunsOptionsModel.SetPipelineID("94619026-912b-4d92-8f51-6c74f0692d90")
+				listTektonPipelineRunsOptionsModel.SetStart("testString")
 				listTektonPipelineRunsOptionsModel.SetLimit(int64(10))
 				listTektonPipelineRunsOptionsModel.SetOffset(int64(38))
 				listTektonPipelineRunsOptionsModel.SetStatus("succeeded")
@@ -7834,6 +7835,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				listTektonPipelineRunsOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(listTektonPipelineRunsOptionsModel).ToNot(BeNil())
 				Expect(listTektonPipelineRunsOptionsModel.PipelineID).To(Equal(core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")))
+				Expect(listTektonPipelineRunsOptionsModel.Start).To(Equal(core.StringPtr("testString")))
 				Expect(listTektonPipelineRunsOptionsModel.Limit).To(Equal(core.Int64Ptr(int64(10))))
 				Expect(listTektonPipelineRunsOptionsModel.Offset).To(Equal(core.Int64Ptr(int64(38))))
 				Expect(listTektonPipelineRunsOptionsModel.Status).To(Equal(core.StringPtr("succeeded")))

--- a/cdtektonpipelinev2/cd_tekton_pipeline_v2_test.go
+++ b/cdtektonpipelinev2/cd_tekton_pipeline_v2_test.go
@@ -283,7 +283,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path"}, "service_instance_id": "ServiceInstanceID", "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "html_url": "HTMLURL", "build_number": 1, "enabled": false}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path"}, "service_instance_id": "ServiceInstanceID", "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "html_url": "HTMLURL", "build_number": 1, "enabled": false}`)
 				}))
 			})
 			It(`Invoke CreateTektonPipeline successfully with retries`, func() {
@@ -358,7 +358,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path"}, "service_instance_id": "ServiceInstanceID", "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "html_url": "HTMLURL", "build_number": 1, "enabled": false}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path"}, "service_instance_id": "ServiceInstanceID", "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "html_url": "HTMLURL", "build_number": 1, "enabled": false}`)
 				}))
 			})
 			It(`Invoke CreateTektonPipeline successfully`, func() {
@@ -524,7 +524,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path"}, "service_instance_id": "ServiceInstanceID", "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "html_url": "HTMLURL", "build_number": 1, "enabled": false}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path"}, "service_instance_id": "ServiceInstanceID", "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "html_url": "HTMLURL", "build_number": 1, "enabled": false}`)
 				}))
 			})
 			It(`Invoke GetTektonPipeline successfully with retries`, func() {
@@ -578,7 +578,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path"}, "service_instance_id": "ServiceInstanceID", "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "html_url": "HTMLURL", "build_number": 1, "enabled": false}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path"}, "service_instance_id": "ServiceInstanceID", "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "html_url": "HTMLURL", "build_number": 1, "enabled": false}`)
 				}))
 			})
 			It(`Invoke GetTektonPipeline successfully`, func() {
@@ -757,7 +757,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path"}, "service_instance_id": "ServiceInstanceID", "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "html_url": "HTMLURL", "build_number": 1, "enabled": false}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path"}, "service_instance_id": "ServiceInstanceID", "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "html_url": "HTMLURL", "build_number": 1, "enabled": false}`)
 				}))
 			})
 			It(`Invoke UpdateTektonPipeline successfully with retries`, func() {
@@ -832,7 +832,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path"}, "service_instance_id": "ServiceInstanceID", "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "html_url": "HTMLURL", "build_number": 1, "enabled": false}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "status": "configured", "resource_group_id": "ResourceGroupID", "toolchain": {"id": "ID", "crn": "crn:v1:staging:public:toolchain:us-south:a/0ba224679d6c697f9baee5e14ade83ac:bf5fa00f-ddef-4298-b87b-aa8b6da0e1a6::"}, "id": "ID", "definitions": [{"scm_source": {"url": "URL", "branch": "Branch", "tag": "Tag", "path": "Path"}, "service_instance_id": "ServiceInstanceID", "id": "ID"}], "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "updated_at": "2019-01-01T12:00:00.000Z", "created_at": "2019-01-01T12:00:00.000Z", "pipeline_definition": {"status": "updated", "id": "ID"}, "triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}], "worker": {"name": "Name", "type": "private", "id": "ID"}, "html_url": "HTMLURL", "build_number": 1, "enabled": false}`)
 				}))
 			})
 			It(`Invoke UpdateTektonPipeline successfully`, func() {
@@ -1085,7 +1085,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"pipeline_runs": [{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "html_url": "HTMLURL", "href": "Href"}], "offset": 20, "limit": 20, "first": {"href": "Href"}, "next": {"href": "Href"}}`)
+					fmt.Fprintf(res, "%s", `{"pipeline_runs": [{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "html_url": "HTMLURL", "href": "Href"}], "offset": 20, "limit": 20, "first": {"href": "Href"}, "next": {"href": "Href"}}`)
 				}))
 			})
 			It(`Invoke ListTektonPipelineRuns successfully with retries`, func() {
@@ -1147,7 +1147,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"pipeline_runs": [{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "html_url": "HTMLURL", "href": "Href"}], "offset": 20, "limit": 20, "first": {"href": "Href"}, "next": {"href": "Href"}}`)
+					fmt.Fprintf(res, "%s", `{"pipeline_runs": [{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "html_url": "HTMLURL", "href": "Href"}], "offset": 20, "limit": 20, "first": {"href": "Href"}, "next": {"href": "Href"}}`)
 				}))
 			})
 			It(`Invoke ListTektonPipelineRuns successfully`, func() {
@@ -1256,8 +1256,8 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 		})
 		Context(`Test pagination helper method on response`, func() {
 			It(`Invoke GetNextOffset successfully`, func() {
-				responseObject := new(cdtektonpipelinev2.PipelineRuns)
-				nextObject := new(cdtektonpipelinev2.PipelineRunsNext)
+				responseObject := new(cdtektonpipelinev2.PipelineRunsCollection)
+				nextObject := new(cdtektonpipelinev2.PipelineRunsCollectionNext)
 				nextObject.Href = core.StringPtr("ibm.com?offset=135")
 				responseObject.Next = nextObject
 	
@@ -1266,15 +1266,15 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(value).To(Equal(core.Int64Ptr(int64(135))))
 			})
 			It(`Invoke GetNextOffset without a "Next" property in the response`, func() {
-				responseObject := new(cdtektonpipelinev2.PipelineRuns)
+				responseObject := new(cdtektonpipelinev2.PipelineRunsCollection)
 	
 				value, err := responseObject.GetNextOffset()
 				Expect(err).To(BeNil())
 				Expect(value).To(BeNil())
 			})
 			It(`Invoke GetNextOffset without any query params in the "Next" URL`, func() {
-				responseObject := new(cdtektonpipelinev2.PipelineRuns)
-				nextObject := new(cdtektonpipelinev2.PipelineRunsNext)
+				responseObject := new(cdtektonpipelinev2.PipelineRunsCollection)
+				nextObject := new(cdtektonpipelinev2.PipelineRunsCollectionNext)
 				nextObject.Href = core.StringPtr("ibm.com")
 				responseObject.Next = nextObject
 	
@@ -1283,8 +1283,8 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(value).To(BeNil())
 			})
 			It(`Invoke GetNextOffset with a non-integer query param in the "Next" URL`, func() {
-				responseObject := new(cdtektonpipelinev2.PipelineRuns)
-				nextObject := new(cdtektonpipelinev2.PipelineRunsNext)
+				responseObject := new(cdtektonpipelinev2.PipelineRunsCollection)
+				nextObject := new(cdtektonpipelinev2.PipelineRunsCollectionNext)
 				nextObject.Href = core.StringPtr("ibm.com?offset=tiger")
 				responseObject.Next = nextObject
 	
@@ -1308,9 +1308,9 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					res.WriteHeader(200)
 					requestNumber++
 					if requestNumber == 1 {
-						fmt.Fprintf(res, "%s", `{"next":{"href":"https://myhost.com/somePath?offset=1"},"total_count":2,"limit":1,"pipeline_runs":[{"id":"ID","user_info":{"iam_id":"IamID","sub":"Sub"},"status":"pending","definition_id":"DefinitionID","worker":{"name":"Name","agent":"Agent","service_id":"ServiceID","id":"ID"},"pipeline_id":"PipelineID","listener_name":"ListenerName","trigger":{"source_trigger_id":"SourceTriggerID","name":"start-deploy"},"event_params_blob":"EventParamsBlob","event_header_params_blob":"EventHeaderParamsBlob","properties":[{"name":"Name","value":"Value","enum":["Enum"],"default":"Default","type":"SECURE","path":"Path"}],"created":"2019-01-01T12:00:00.000Z","updated":"2019-01-01T12:00:00.000Z","html_url":"HTMLURL","href":"Href"}]}`)
+						fmt.Fprintf(res, "%s", `{"next":{"href":"https://myhost.com/somePath?offset=1"},"total_count":2,"limit":1,"pipeline_runs":[{"id":"ID","user_info":{"iam_id":"IamID","sub":"Sub"},"status":"pending","definition_id":"DefinitionID","worker":{"name":"Name","agent":"Agent","service_id":"ServiceID","id":"ID"},"pipeline_id":"PipelineID","listener_name":"ListenerName","trigger":{"source_trigger_id":"SourceTriggerID","name":"start-deploy"},"event_params_blob":"EventParamsBlob","event_header_params_blob":"EventHeaderParamsBlob","properties":[{"name":"Name","value":"Value","enum":["Enum"],"default":"Default","type":"SECURE","path":"Path"}],"created_at":"2019-01-01T12:00:00.000Z","updated_at":"2019-01-01T12:00:00.000Z","html_url":"HTMLURL","href":"Href"}]}`)
 					} else if requestNumber == 2 {
-						fmt.Fprintf(res, "%s", `{"total_count":2,"limit":1,"pipeline_runs":[{"id":"ID","user_info":{"iam_id":"IamID","sub":"Sub"},"status":"pending","definition_id":"DefinitionID","worker":{"name":"Name","agent":"Agent","service_id":"ServiceID","id":"ID"},"pipeline_id":"PipelineID","listener_name":"ListenerName","trigger":{"source_trigger_id":"SourceTriggerID","name":"start-deploy"},"event_params_blob":"EventParamsBlob","event_header_params_blob":"EventHeaderParamsBlob","properties":[{"name":"Name","value":"Value","enum":["Enum"],"default":"Default","type":"SECURE","path":"Path"}],"created":"2019-01-01T12:00:00.000Z","updated":"2019-01-01T12:00:00.000Z","html_url":"HTMLURL","href":"Href"}]}`)
+						fmt.Fprintf(res, "%s", `{"total_count":2,"limit":1,"pipeline_runs":[{"id":"ID","user_info":{"iam_id":"IamID","sub":"Sub"},"status":"pending","definition_id":"DefinitionID","worker":{"name":"Name","agent":"Agent","service_id":"ServiceID","id":"ID"},"pipeline_id":"PipelineID","listener_name":"ListenerName","trigger":{"source_trigger_id":"SourceTriggerID","name":"start-deploy"},"event_params_blob":"EventParamsBlob","event_header_params_blob":"EventHeaderParamsBlob","properties":[{"name":"Name","value":"Value","enum":["Enum"],"default":"Default","type":"SECURE","path":"Path"}],"created_at":"2019-01-01T12:00:00.000Z","updated_at":"2019-01-01T12:00:00.000Z","html_url":"HTMLURL","href":"Href"}]}`)
 					} else {
 						res.WriteHeader(400)
 					}
@@ -1335,7 +1335,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(err).To(BeNil())
 				Expect(pager).ToNot(BeNil())
 
-				var allResults []cdtektonpipelinev2.PipelineRunsPipelineRunsItem
+				var allResults []cdtektonpipelinev2.PipelineRunsCollectionPipelineRunsItem
 				for pager.HasNext() {
 					nextPage, err := pager.GetNext()
 					Expect(err).To(BeNil())
@@ -1453,7 +1453,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "html_url": "HTMLURL"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "html_url": "HTMLURL"}`)
 				}))
 			})
 			It(`Invoke CreateTektonPipelineRun successfully with retries`, func() {
@@ -1528,7 +1528,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "html_url": "HTMLURL"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "html_url": "HTMLURL"}`)
 				}))
 			})
 			It(`Invoke CreateTektonPipelineRun successfully`, func() {
@@ -1705,7 +1705,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "html_url": "HTMLURL"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "html_url": "HTMLURL"}`)
 				}))
 			})
 			It(`Invoke GetTektonPipelineRun successfully with retries`, func() {
@@ -1762,7 +1762,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "html_url": "HTMLURL"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "html_url": "HTMLURL"}`)
 				}))
 			})
 			It(`Invoke GetTektonPipelineRun successfully`, func() {
@@ -2014,7 +2014,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "html_url": "HTMLURL"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "html_url": "HTMLURL"}`)
 				}))
 			})
 			It(`Invoke CancelTektonPipelineRun successfully with retries`, func() {
@@ -2086,7 +2086,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "html_url": "HTMLURL"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "html_url": "HTMLURL"}`)
 				}))
 			})
 			It(`Invoke CancelTektonPipelineRun successfully`, func() {
@@ -2251,7 +2251,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "html_url": "HTMLURL"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "html_url": "HTMLURL"}`)
 				}))
 			})
 			It(`Invoke RerunTektonPipelineRun successfully with retries`, func() {
@@ -2306,7 +2306,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "html_url": "HTMLURL"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "user_info": {"iam_id": "IamID", "sub": "Sub"}, "status": "pending", "definition_id": "DefinitionID", "worker": {"name": "Name", "agent": "Agent", "service_id": "ServiceID", "id": "ID"}, "pipeline_id": "PipelineID", "listener_name": "ListenerName", "trigger": {"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}, "event_params_blob": "EventParamsBlob", "event_header_params_blob": "EventHeaderParamsBlob", "properties": [{"name": "Name", "value": "Value", "enum": ["Enum"], "default": "Default", "type": "SECURE", "path": "Path"}], "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "html_url": "HTMLURL"}`)
 				}))
 			})
 			It(`Invoke RerunTektonPipelineRun successfully`, func() {
@@ -3090,6 +3090,8 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelineDefinitionOptionsModel := new(cdtektonpipelinev2.CreateTektonPipelineDefinitionOptions)
 				createTektonPipelineDefinitionOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				createTektonPipelineDefinitionOptionsModel.ScmSource = definitionScmSourceModel
+				createTektonPipelineDefinitionOptionsModel.ServiceInstanceID = core.StringPtr("testString")
+				createTektonPipelineDefinitionOptionsModel.ID = core.StringPtr("testString")
 				createTektonPipelineDefinitionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
 				result, response, operationErr := cdTektonPipelineService.CreateTektonPipelineDefinition(createTektonPipelineDefinitionOptionsModel)
@@ -3165,6 +3167,8 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelineDefinitionOptionsModel := new(cdtektonpipelinev2.CreateTektonPipelineDefinitionOptions)
 				createTektonPipelineDefinitionOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				createTektonPipelineDefinitionOptionsModel.ScmSource = definitionScmSourceModel
+				createTektonPipelineDefinitionOptionsModel.ServiceInstanceID = core.StringPtr("testString")
+				createTektonPipelineDefinitionOptionsModel.ID = core.StringPtr("testString")
 				createTektonPipelineDefinitionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with a Context to test a timeout error
@@ -3248,6 +3252,8 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelineDefinitionOptionsModel := new(cdtektonpipelinev2.CreateTektonPipelineDefinitionOptions)
 				createTektonPipelineDefinitionOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				createTektonPipelineDefinitionOptionsModel.ScmSource = definitionScmSourceModel
+				createTektonPipelineDefinitionOptionsModel.ServiceInstanceID = core.StringPtr("testString")
+				createTektonPipelineDefinitionOptionsModel.ID = core.StringPtr("testString")
 				createTektonPipelineDefinitionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with valid options model (positive test)
@@ -3276,6 +3282,8 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelineDefinitionOptionsModel := new(cdtektonpipelinev2.CreateTektonPipelineDefinitionOptions)
 				createTektonPipelineDefinitionOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				createTektonPipelineDefinitionOptionsModel.ScmSource = definitionScmSourceModel
+				createTektonPipelineDefinitionOptionsModel.ServiceInstanceID = core.StringPtr("testString")
+				createTektonPipelineDefinitionOptionsModel.ID = core.StringPtr("testString")
 				createTektonPipelineDefinitionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
 				err := cdTektonPipelineService.SetServiceURL("")
@@ -3325,6 +3333,8 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelineDefinitionOptionsModel := new(cdtektonpipelinev2.CreateTektonPipelineDefinitionOptions)
 				createTektonPipelineDefinitionOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				createTektonPipelineDefinitionOptionsModel.ScmSource = definitionScmSourceModel
+				createTektonPipelineDefinitionOptionsModel.ServiceInstanceID = core.StringPtr("testString")
+				createTektonPipelineDefinitionOptionsModel.ID = core.StringPtr("testString")
 				createTektonPipelineDefinitionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation
@@ -5082,7 +5092,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"triggers": [{"href": "Href", "source_trigger_id": "SourceTriggerID", "name": "start-deploy"}]}`)
+					fmt.Fprintf(res, "%s", `{"triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}]}`)
 				}))
 			})
 			It(`Invoke ListTektonPipelineTriggers successfully with retries`, func() {
@@ -5150,7 +5160,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"triggers": [{"href": "Href", "source_trigger_id": "SourceTriggerID", "name": "start-deploy"}]}`)
+					fmt.Fprintf(res, "%s", `{"triggers": [{"source_trigger_id": "SourceTriggerID", "name": "start-deploy"}]}`)
 				}))
 			})
 			It(`Invoke ListTektonPipelineTriggers successfully`, func() {
@@ -5293,7 +5303,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				// Construct an instance of the TriggerDuplicateTrigger model
 				triggerModel := new(cdtektonpipelinev2.TriggerDuplicateTrigger)
 				triggerModel.SourceTriggerID = core.StringPtr("b3a8228f-1c82-409b-b249-7639166a0300")
-				triggerModel.Name = core.StringPtr("Generic Trigger- duplicated")
+				triggerModel.Name = core.StringPtr("Trigger Name")
 
 				// Construct an instance of the CreateTektonPipelineTriggerOptions model
 				createTektonPipelineTriggerOptionsModel := new(cdtektonpipelinev2.CreateTektonPipelineTriggerOptions)
@@ -5366,7 +5376,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				// Construct an instance of the TriggerDuplicateTrigger model
 				triggerModel := new(cdtektonpipelinev2.TriggerDuplicateTrigger)
 				triggerModel.SourceTriggerID = core.StringPtr("b3a8228f-1c82-409b-b249-7639166a0300")
-				triggerModel.Name = core.StringPtr("Generic Trigger- duplicated")
+				triggerModel.Name = core.StringPtr("Trigger Name")
 
 				// Construct an instance of the CreateTektonPipelineTriggerOptions model
 				createTektonPipelineTriggerOptionsModel := new(cdtektonpipelinev2.CreateTektonPipelineTriggerOptions)
@@ -5447,7 +5457,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				// Construct an instance of the TriggerDuplicateTrigger model
 				triggerModel := new(cdtektonpipelinev2.TriggerDuplicateTrigger)
 				triggerModel.SourceTriggerID = core.StringPtr("b3a8228f-1c82-409b-b249-7639166a0300")
-				triggerModel.Name = core.StringPtr("Generic Trigger- duplicated")
+				triggerModel.Name = core.StringPtr("Trigger Name")
 
 				// Construct an instance of the CreateTektonPipelineTriggerOptions model
 				createTektonPipelineTriggerOptionsModel := new(cdtektonpipelinev2.CreateTektonPipelineTriggerOptions)
@@ -5473,7 +5483,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				// Construct an instance of the TriggerDuplicateTrigger model
 				triggerModel := new(cdtektonpipelinev2.TriggerDuplicateTrigger)
 				triggerModel.SourceTriggerID = core.StringPtr("b3a8228f-1c82-409b-b249-7639166a0300")
-				triggerModel.Name = core.StringPtr("Generic Trigger- duplicated")
+				triggerModel.Name = core.StringPtr("Trigger Name")
 
 				// Construct an instance of the CreateTektonPipelineTriggerOptions model
 				createTektonPipelineTriggerOptionsModel := new(cdtektonpipelinev2.CreateTektonPipelineTriggerOptions)
@@ -5520,7 +5530,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				// Construct an instance of the TriggerDuplicateTrigger model
 				triggerModel := new(cdtektonpipelinev2.TriggerDuplicateTrigger)
 				triggerModel.SourceTriggerID = core.StringPtr("b3a8228f-1c82-409b-b249-7639166a0300")
-				triggerModel.Name = core.StringPtr("Generic Trigger- duplicated")
+				triggerModel.Name = core.StringPtr("Trigger Name")
 
 				// Construct an instance of the CreateTektonPipelineTriggerOptions model
 				createTektonPipelineTriggerOptionsModel := new(cdtektonpipelinev2.CreateTektonPipelineTriggerOptions)
@@ -5787,10 +5797,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				workerModel.Type = core.StringPtr("private")
 				workerModel.ID = core.StringPtr("testString")
 
-				// Construct an instance of the Concurrency model
-				concurrencyModel := new(cdtektonpipelinev2.Concurrency)
-				concurrencyModel.MaxConcurrentRuns = core.Int64Ptr(int64(20))
-
 				// Construct an instance of the GenericSecret model
 				genericSecretModel := new(cdtektonpipelinev2.GenericSecret)
 				genericSecretModel.Type = core.StringPtr("tokenMatches")
@@ -5822,7 +5828,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				updateTektonPipelineTriggerOptionsModel.EventListener = core.StringPtr("testString")
 				updateTektonPipelineTriggerOptionsModel.Tags = []string{"testString"}
 				updateTektonPipelineTriggerOptionsModel.Worker = workerModel
-				updateTektonPipelineTriggerOptionsModel.Concurrency = concurrencyModel
+				updateTektonPipelineTriggerOptionsModel.MaxConcurrentRuns = core.Int64Ptr(int64(38))
 				updateTektonPipelineTriggerOptionsModel.Disabled = core.BoolPtr(true)
 				updateTektonPipelineTriggerOptionsModel.Secret = genericSecretModel
 				updateTektonPipelineTriggerOptionsModel.Cron = core.StringPtr("testString")
@@ -5899,10 +5905,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				workerModel.Type = core.StringPtr("private")
 				workerModel.ID = core.StringPtr("testString")
 
-				// Construct an instance of the Concurrency model
-				concurrencyModel := new(cdtektonpipelinev2.Concurrency)
-				concurrencyModel.MaxConcurrentRuns = core.Int64Ptr(int64(20))
-
 				// Construct an instance of the GenericSecret model
 				genericSecretModel := new(cdtektonpipelinev2.GenericSecret)
 				genericSecretModel.Type = core.StringPtr("tokenMatches")
@@ -5934,7 +5936,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				updateTektonPipelineTriggerOptionsModel.EventListener = core.StringPtr("testString")
 				updateTektonPipelineTriggerOptionsModel.Tags = []string{"testString"}
 				updateTektonPipelineTriggerOptionsModel.Worker = workerModel
-				updateTektonPipelineTriggerOptionsModel.Concurrency = concurrencyModel
+				updateTektonPipelineTriggerOptionsModel.MaxConcurrentRuns = core.Int64Ptr(int64(38))
 				updateTektonPipelineTriggerOptionsModel.Disabled = core.BoolPtr(true)
 				updateTektonPipelineTriggerOptionsModel.Secret = genericSecretModel
 				updateTektonPipelineTriggerOptionsModel.Cron = core.StringPtr("testString")
@@ -6019,10 +6021,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				workerModel.Type = core.StringPtr("private")
 				workerModel.ID = core.StringPtr("testString")
 
-				// Construct an instance of the Concurrency model
-				concurrencyModel := new(cdtektonpipelinev2.Concurrency)
-				concurrencyModel.MaxConcurrentRuns = core.Int64Ptr(int64(20))
-
 				// Construct an instance of the GenericSecret model
 				genericSecretModel := new(cdtektonpipelinev2.GenericSecret)
 				genericSecretModel.Type = core.StringPtr("tokenMatches")
@@ -6054,7 +6052,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				updateTektonPipelineTriggerOptionsModel.EventListener = core.StringPtr("testString")
 				updateTektonPipelineTriggerOptionsModel.Tags = []string{"testString"}
 				updateTektonPipelineTriggerOptionsModel.Worker = workerModel
-				updateTektonPipelineTriggerOptionsModel.Concurrency = concurrencyModel
+				updateTektonPipelineTriggerOptionsModel.MaxConcurrentRuns = core.Int64Ptr(int64(38))
 				updateTektonPipelineTriggerOptionsModel.Disabled = core.BoolPtr(true)
 				updateTektonPipelineTriggerOptionsModel.Secret = genericSecretModel
 				updateTektonPipelineTriggerOptionsModel.Cron = core.StringPtr("testString")
@@ -6084,10 +6082,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				workerModel.Type = core.StringPtr("private")
 				workerModel.ID = core.StringPtr("testString")
 
-				// Construct an instance of the Concurrency model
-				concurrencyModel := new(cdtektonpipelinev2.Concurrency)
-				concurrencyModel.MaxConcurrentRuns = core.Int64Ptr(int64(20))
-
 				// Construct an instance of the GenericSecret model
 				genericSecretModel := new(cdtektonpipelinev2.GenericSecret)
 				genericSecretModel.Type = core.StringPtr("tokenMatches")
@@ -6119,7 +6113,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				updateTektonPipelineTriggerOptionsModel.EventListener = core.StringPtr("testString")
 				updateTektonPipelineTriggerOptionsModel.Tags = []string{"testString"}
 				updateTektonPipelineTriggerOptionsModel.Worker = workerModel
-				updateTektonPipelineTriggerOptionsModel.Concurrency = concurrencyModel
+				updateTektonPipelineTriggerOptionsModel.MaxConcurrentRuns = core.Int64Ptr(int64(38))
 				updateTektonPipelineTriggerOptionsModel.Disabled = core.BoolPtr(true)
 				updateTektonPipelineTriggerOptionsModel.Secret = genericSecretModel
 				updateTektonPipelineTriggerOptionsModel.Cron = core.StringPtr("testString")
@@ -6170,10 +6164,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				workerModel.Type = core.StringPtr("private")
 				workerModel.ID = core.StringPtr("testString")
 
-				// Construct an instance of the Concurrency model
-				concurrencyModel := new(cdtektonpipelinev2.Concurrency)
-				concurrencyModel.MaxConcurrentRuns = core.Int64Ptr(int64(20))
-
 				// Construct an instance of the GenericSecret model
 				genericSecretModel := new(cdtektonpipelinev2.GenericSecret)
 				genericSecretModel.Type = core.StringPtr("tokenMatches")
@@ -6205,7 +6195,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				updateTektonPipelineTriggerOptionsModel.EventListener = core.StringPtr("testString")
 				updateTektonPipelineTriggerOptionsModel.Tags = []string{"testString"}
 				updateTektonPipelineTriggerOptionsModel.Worker = workerModel
-				updateTektonPipelineTriggerOptionsModel.Concurrency = concurrencyModel
+				updateTektonPipelineTriggerOptionsModel.MaxConcurrentRuns = core.Int64Ptr(int64(38))
 				updateTektonPipelineTriggerOptionsModel.Disabled = core.BoolPtr(true)
 				updateTektonPipelineTriggerOptionsModel.Secret = genericSecretModel
 				updateTektonPipelineTriggerOptionsModel.Cron = core.StringPtr("testString")
@@ -7434,10 +7424,14 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelineDefinitionOptionsModel := cdTektonPipelineService.NewCreateTektonPipelineDefinitionOptions(pipelineID)
 				createTektonPipelineDefinitionOptionsModel.SetPipelineID("94619026-912b-4d92-8f51-6c74f0692d90")
 				createTektonPipelineDefinitionOptionsModel.SetScmSource(definitionScmSourceModel)
+				createTektonPipelineDefinitionOptionsModel.SetServiceInstanceID("testString")
+				createTektonPipelineDefinitionOptionsModel.SetID("testString")
 				createTektonPipelineDefinitionOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(createTektonPipelineDefinitionOptionsModel).ToNot(BeNil())
 				Expect(createTektonPipelineDefinitionOptionsModel.PipelineID).To(Equal(core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")))
 				Expect(createTektonPipelineDefinitionOptionsModel.ScmSource).To(Equal(definitionScmSourceModel))
+				Expect(createTektonPipelineDefinitionOptionsModel.ServiceInstanceID).To(Equal(core.StringPtr("testString")))
+				Expect(createTektonPipelineDefinitionOptionsModel.ID).To(Equal(core.StringPtr("testString")))
 				Expect(createTektonPipelineDefinitionOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewCreateTektonPipelineOptions successfully`, func() {
@@ -7543,12 +7537,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(createTektonPipelineTriggerPropertiesOptionsModel.Type).To(Equal(core.StringPtr("TEXT")))
 				Expect(createTektonPipelineTriggerPropertiesOptionsModel.Path).To(Equal(core.StringPtr("testString")))
 				Expect(createTektonPipelineTriggerPropertiesOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
-			})
-			It(`Invoke NewDefinition successfully`, func() {
-				var scmSource *cdtektonpipelinev2.DefinitionScmSource = nil
-				serviceInstanceID := "testString"
-				_, err := cdTektonPipelineService.NewDefinition(scmSource, serviceInstanceID)
-				Expect(err).ToNot(BeNil())
 			})
 			It(`Invoke NewDefinitionScmSource successfully`, func() {
 				url := "testString"
@@ -7834,13 +7822,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(listTektonPipelineTriggersOptionsModel.Tags).To(Equal(core.StringPtr("tag1,tag2")))
 				Expect(listTektonPipelineTriggersOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
-			It(`Invoke NewProperty successfully`, func() {
-				name := "testString"
-				typeVar := "SECURE"
-				_model, err := cdTektonPipelineService.NewProperty(name, typeVar)
-				Expect(_model).ToNot(BeNil())
-				Expect(err).To(BeNil())
-			})
 			It(`Invoke NewReplaceTektonPipelineDefinitionOptions successfully`, func() {
 				// Construct an instance of the DefinitionScmSource model
 				definitionScmSourceModel := new(cdtektonpipelinev2.DefinitionScmSource)
@@ -7959,13 +7940,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(_model).ToNot(BeNil())
 				Expect(err).To(BeNil())
 			})
-			It(`Invoke NewTriggerProperty successfully`, func() {
-				name := "testString"
-				typeVar := "SECURE"
-				_model, err := cdTektonPipelineService.NewTriggerProperty(name, typeVar)
-				Expect(_model).ToNot(BeNil())
-				Expect(err).To(BeNil())
-			})
 			It(`Invoke NewTriggerScmSource successfully`, func() {
 				url := "testString"
 				_model, err := cdTektonPipelineService.NewTriggerScmSource(url)
@@ -8014,12 +7988,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(workerModel.Name).To(Equal(core.StringPtr("testString")))
 				Expect(workerModel.Type).To(Equal(core.StringPtr("private")))
 				Expect(workerModel.ID).To(Equal(core.StringPtr("testString")))
-
-				// Construct an instance of the Concurrency model
-				concurrencyModel := new(cdtektonpipelinev2.Concurrency)
-				Expect(concurrencyModel).ToNot(BeNil())
-				concurrencyModel.MaxConcurrentRuns = core.Int64Ptr(int64(20))
-				Expect(concurrencyModel.MaxConcurrentRuns).To(Equal(core.Int64Ptr(int64(20))))
 
 				// Construct an instance of the GenericSecret model
 				genericSecretModel := new(cdtektonpipelinev2.GenericSecret)
@@ -8070,7 +8038,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				updateTektonPipelineTriggerOptionsModel.SetEventListener("testString")
 				updateTektonPipelineTriggerOptionsModel.SetTags([]string{"testString"})
 				updateTektonPipelineTriggerOptionsModel.SetWorker(workerModel)
-				updateTektonPipelineTriggerOptionsModel.SetConcurrency(concurrencyModel)
+				updateTektonPipelineTriggerOptionsModel.SetMaxConcurrentRuns(int64(38))
 				updateTektonPipelineTriggerOptionsModel.SetDisabled(true)
 				updateTektonPipelineTriggerOptionsModel.SetSecret(genericSecretModel)
 				updateTektonPipelineTriggerOptionsModel.SetCron("testString")
@@ -8086,7 +8054,7 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(updateTektonPipelineTriggerOptionsModel.EventListener).To(Equal(core.StringPtr("testString")))
 				Expect(updateTektonPipelineTriggerOptionsModel.Tags).To(Equal([]string{"testString"}))
 				Expect(updateTektonPipelineTriggerOptionsModel.Worker).To(Equal(workerModel))
-				Expect(updateTektonPipelineTriggerOptionsModel.Concurrency).To(Equal(concurrencyModel))
+				Expect(updateTektonPipelineTriggerOptionsModel.MaxConcurrentRuns).To(Equal(core.Int64Ptr(int64(38))))
 				Expect(updateTektonPipelineTriggerOptionsModel.Disabled).To(Equal(core.BoolPtr(true)))
 				Expect(updateTektonPipelineTriggerOptionsModel.Secret).To(Equal(genericSecretModel))
 				Expect(updateTektonPipelineTriggerOptionsModel.Cron).To(Equal(core.StringPtr("testString")))

--- a/cdtektonpipelinev2/cd_tekton_pipeline_v2_test.go
+++ b/cdtektonpipelinev2/cd_tekton_pipeline_v2_test.go
@@ -5339,47 +5339,50 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(serviceErr).To(BeNil())
 				Expect(cdTektonPipelineService).ToNot(BeNil())
 
-				// Construct an instance of the TriggerGenericTriggerPropertiesItem model
-				triggerGenericTriggerPropertiesItemModel := new(cdtektonpipelinev2.TriggerGenericTriggerPropertiesItem)
-				triggerGenericTriggerPropertiesItemModel.Name = core.StringPtr("testString")
-				triggerGenericTriggerPropertiesItemModel.Value = core.StringPtr("testString")
-				triggerGenericTriggerPropertiesItemModel.Enum = []string{"testString"}
-				triggerGenericTriggerPropertiesItemModel.Type = core.StringPtr("secure")
-				triggerGenericTriggerPropertiesItemModel.Path = core.StringPtr("testString")
-				triggerGenericTriggerPropertiesItemModel.Href = core.StringPtr("testString")
-
 				// Construct an instance of the Worker model
 				workerModel := new(cdtektonpipelinev2.Worker)
 				workerModel.Name = core.StringPtr("testString")
 				workerModel.Type = core.StringPtr("private")
-				workerModel.ID = core.StringPtr("5df804a4-9d7b-44e1-874f-3810866fb80b")
+				workerModel.ID = core.StringPtr("public")
 
 				// Construct an instance of the GenericSecret model
 				genericSecretModel := new(cdtektonpipelinev2.GenericSecret)
 				genericSecretModel.Type = core.StringPtr("token_matches")
-				genericSecretModel.Value = core.StringPtr("secret")
-				genericSecretModel.Source = core.StringPtr("query")
-				genericSecretModel.KeyName = core.StringPtr("auth")
+				genericSecretModel.Value = core.StringPtr("testString")
+				genericSecretModel.Source = core.StringPtr("header")
+				genericSecretModel.KeyName = core.StringPtr("testString")
 				genericSecretModel.Algorithm = core.StringPtr("md4")
 
-				// Construct an instance of the TriggerGenericTrigger model
-				triggerModel := new(cdtektonpipelinev2.TriggerGenericTrigger)
-				triggerModel.Type = core.StringPtr("generic")
-				triggerModel.Name = core.StringPtr("Generic Webhook Trigger")
-				triggerModel.Href = core.StringPtr("testString")
-				triggerModel.EventListener = core.StringPtr("pr-listener")
-				triggerModel.ID = core.StringPtr("testString")
-				triggerModel.Properties = []cdtektonpipelinev2.TriggerGenericTriggerPropertiesItem{*triggerGenericTriggerPropertiesItemModel}
-				triggerModel.Tags = []string{"prod", "dev"}
-				triggerModel.Worker = workerModel
-				triggerModel.MaxConcurrentRuns = core.Int64Ptr(int64(4))
-				triggerModel.Disabled = core.BoolPtr(false)
-				triggerModel.Secret = genericSecretModel
+				// Construct an instance of the TriggerScmSource model
+				triggerScmSourceModel := new(cdtektonpipelinev2.TriggerScmSource)
+				triggerScmSourceModel.URL = core.StringPtr("testString")
+				triggerScmSourceModel.Branch = core.StringPtr("testString")
+				triggerScmSourceModel.Pattern = core.StringPtr("testString")
+				triggerScmSourceModel.BlindConnection = core.BoolPtr(true)
+				triggerScmSourceModel.HookID = core.StringPtr("testString")
+				triggerScmSourceModel.ServiceInstanceID = core.StringPtr("testString")
+
+				// Construct an instance of the Events model
+				eventsModel := new(cdtektonpipelinev2.Events)
+				eventsModel.Push = core.BoolPtr(true)
+				eventsModel.PullRequestClosed = core.BoolPtr(true)
+				eventsModel.PullRequest = core.BoolPtr(true)
 
 				// Construct an instance of the CreateTektonPipelineTriggerOptions model
 				createTektonPipelineTriggerOptionsModel := new(cdtektonpipelinev2.CreateTektonPipelineTriggerOptions)
 				createTektonPipelineTriggerOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
-				createTektonPipelineTriggerOptionsModel.Trigger = triggerModel
+				createTektonPipelineTriggerOptionsModel.Type = core.StringPtr("manual")
+				createTektonPipelineTriggerOptionsModel.Name = core.StringPtr("Manual Trigger")
+				createTektonPipelineTriggerOptionsModel.EventListener = core.StringPtr("pr-listener")
+				createTektonPipelineTriggerOptionsModel.Tags = []string{"testString"}
+				createTektonPipelineTriggerOptionsModel.Worker = workerModel
+				createTektonPipelineTriggerOptionsModel.MaxConcurrentRuns = core.Int64Ptr(int64(3))
+				createTektonPipelineTriggerOptionsModel.Disabled = core.BoolPtr(false)
+				createTektonPipelineTriggerOptionsModel.Secret = genericSecretModel
+				createTektonPipelineTriggerOptionsModel.Cron = core.StringPtr("testString")
+				createTektonPipelineTriggerOptionsModel.Timezone = core.StringPtr("testString")
+				createTektonPipelineTriggerOptionsModel.ScmSource = triggerScmSourceModel
+				createTektonPipelineTriggerOptionsModel.Events = eventsModel
 				createTektonPipelineTriggerOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
 				result, response, operationErr := cdTektonPipelineService.CreateTektonPipelineTrigger(createTektonPipelineTriggerOptionsModel)
@@ -5444,47 +5447,50 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(cdTektonPipelineService).ToNot(BeNil())
 				cdTektonPipelineService.EnableRetries(0, 0)
 
-				// Construct an instance of the TriggerGenericTriggerPropertiesItem model
-				triggerGenericTriggerPropertiesItemModel := new(cdtektonpipelinev2.TriggerGenericTriggerPropertiesItem)
-				triggerGenericTriggerPropertiesItemModel.Name = core.StringPtr("testString")
-				triggerGenericTriggerPropertiesItemModel.Value = core.StringPtr("testString")
-				triggerGenericTriggerPropertiesItemModel.Enum = []string{"testString"}
-				triggerGenericTriggerPropertiesItemModel.Type = core.StringPtr("secure")
-				triggerGenericTriggerPropertiesItemModel.Path = core.StringPtr("testString")
-				triggerGenericTriggerPropertiesItemModel.Href = core.StringPtr("testString")
-
 				// Construct an instance of the Worker model
 				workerModel := new(cdtektonpipelinev2.Worker)
 				workerModel.Name = core.StringPtr("testString")
 				workerModel.Type = core.StringPtr("private")
-				workerModel.ID = core.StringPtr("5df804a4-9d7b-44e1-874f-3810866fb80b")
+				workerModel.ID = core.StringPtr("public")
 
 				// Construct an instance of the GenericSecret model
 				genericSecretModel := new(cdtektonpipelinev2.GenericSecret)
 				genericSecretModel.Type = core.StringPtr("token_matches")
-				genericSecretModel.Value = core.StringPtr("secret")
-				genericSecretModel.Source = core.StringPtr("query")
-				genericSecretModel.KeyName = core.StringPtr("auth")
+				genericSecretModel.Value = core.StringPtr("testString")
+				genericSecretModel.Source = core.StringPtr("header")
+				genericSecretModel.KeyName = core.StringPtr("testString")
 				genericSecretModel.Algorithm = core.StringPtr("md4")
 
-				// Construct an instance of the TriggerGenericTrigger model
-				triggerModel := new(cdtektonpipelinev2.TriggerGenericTrigger)
-				triggerModel.Type = core.StringPtr("generic")
-				triggerModel.Name = core.StringPtr("Generic Webhook Trigger")
-				triggerModel.Href = core.StringPtr("testString")
-				triggerModel.EventListener = core.StringPtr("pr-listener")
-				triggerModel.ID = core.StringPtr("testString")
-				triggerModel.Properties = []cdtektonpipelinev2.TriggerGenericTriggerPropertiesItem{*triggerGenericTriggerPropertiesItemModel}
-				triggerModel.Tags = []string{"prod", "dev"}
-				triggerModel.Worker = workerModel
-				triggerModel.MaxConcurrentRuns = core.Int64Ptr(int64(4))
-				triggerModel.Disabled = core.BoolPtr(false)
-				triggerModel.Secret = genericSecretModel
+				// Construct an instance of the TriggerScmSource model
+				triggerScmSourceModel := new(cdtektonpipelinev2.TriggerScmSource)
+				triggerScmSourceModel.URL = core.StringPtr("testString")
+				triggerScmSourceModel.Branch = core.StringPtr("testString")
+				triggerScmSourceModel.Pattern = core.StringPtr("testString")
+				triggerScmSourceModel.BlindConnection = core.BoolPtr(true)
+				triggerScmSourceModel.HookID = core.StringPtr("testString")
+				triggerScmSourceModel.ServiceInstanceID = core.StringPtr("testString")
+
+				// Construct an instance of the Events model
+				eventsModel := new(cdtektonpipelinev2.Events)
+				eventsModel.Push = core.BoolPtr(true)
+				eventsModel.PullRequestClosed = core.BoolPtr(true)
+				eventsModel.PullRequest = core.BoolPtr(true)
 
 				// Construct an instance of the CreateTektonPipelineTriggerOptions model
 				createTektonPipelineTriggerOptionsModel := new(cdtektonpipelinev2.CreateTektonPipelineTriggerOptions)
 				createTektonPipelineTriggerOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
-				createTektonPipelineTriggerOptionsModel.Trigger = triggerModel
+				createTektonPipelineTriggerOptionsModel.Type = core.StringPtr("manual")
+				createTektonPipelineTriggerOptionsModel.Name = core.StringPtr("Manual Trigger")
+				createTektonPipelineTriggerOptionsModel.EventListener = core.StringPtr("pr-listener")
+				createTektonPipelineTriggerOptionsModel.Tags = []string{"testString"}
+				createTektonPipelineTriggerOptionsModel.Worker = workerModel
+				createTektonPipelineTriggerOptionsModel.MaxConcurrentRuns = core.Int64Ptr(int64(3))
+				createTektonPipelineTriggerOptionsModel.Disabled = core.BoolPtr(false)
+				createTektonPipelineTriggerOptionsModel.Secret = genericSecretModel
+				createTektonPipelineTriggerOptionsModel.Cron = core.StringPtr("testString")
+				createTektonPipelineTriggerOptionsModel.Timezone = core.StringPtr("testString")
+				createTektonPipelineTriggerOptionsModel.ScmSource = triggerScmSourceModel
+				createTektonPipelineTriggerOptionsModel.Events = eventsModel
 				createTektonPipelineTriggerOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with a Context to test a timeout error
@@ -5557,47 +5563,50 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(response).To(BeNil())
 				Expect(result).To(BeNil())
 
-				// Construct an instance of the TriggerGenericTriggerPropertiesItem model
-				triggerGenericTriggerPropertiesItemModel := new(cdtektonpipelinev2.TriggerGenericTriggerPropertiesItem)
-				triggerGenericTriggerPropertiesItemModel.Name = core.StringPtr("testString")
-				triggerGenericTriggerPropertiesItemModel.Value = core.StringPtr("testString")
-				triggerGenericTriggerPropertiesItemModel.Enum = []string{"testString"}
-				triggerGenericTriggerPropertiesItemModel.Type = core.StringPtr("secure")
-				triggerGenericTriggerPropertiesItemModel.Path = core.StringPtr("testString")
-				triggerGenericTriggerPropertiesItemModel.Href = core.StringPtr("testString")
-
 				// Construct an instance of the Worker model
 				workerModel := new(cdtektonpipelinev2.Worker)
 				workerModel.Name = core.StringPtr("testString")
 				workerModel.Type = core.StringPtr("private")
-				workerModel.ID = core.StringPtr("5df804a4-9d7b-44e1-874f-3810866fb80b")
+				workerModel.ID = core.StringPtr("public")
 
 				// Construct an instance of the GenericSecret model
 				genericSecretModel := new(cdtektonpipelinev2.GenericSecret)
 				genericSecretModel.Type = core.StringPtr("token_matches")
-				genericSecretModel.Value = core.StringPtr("secret")
-				genericSecretModel.Source = core.StringPtr("query")
-				genericSecretModel.KeyName = core.StringPtr("auth")
+				genericSecretModel.Value = core.StringPtr("testString")
+				genericSecretModel.Source = core.StringPtr("header")
+				genericSecretModel.KeyName = core.StringPtr("testString")
 				genericSecretModel.Algorithm = core.StringPtr("md4")
 
-				// Construct an instance of the TriggerGenericTrigger model
-				triggerModel := new(cdtektonpipelinev2.TriggerGenericTrigger)
-				triggerModel.Type = core.StringPtr("generic")
-				triggerModel.Name = core.StringPtr("Generic Webhook Trigger")
-				triggerModel.Href = core.StringPtr("testString")
-				triggerModel.EventListener = core.StringPtr("pr-listener")
-				triggerModel.ID = core.StringPtr("testString")
-				triggerModel.Properties = []cdtektonpipelinev2.TriggerGenericTriggerPropertiesItem{*triggerGenericTriggerPropertiesItemModel}
-				triggerModel.Tags = []string{"prod", "dev"}
-				triggerModel.Worker = workerModel
-				triggerModel.MaxConcurrentRuns = core.Int64Ptr(int64(4))
-				triggerModel.Disabled = core.BoolPtr(false)
-				triggerModel.Secret = genericSecretModel
+				// Construct an instance of the TriggerScmSource model
+				triggerScmSourceModel := new(cdtektonpipelinev2.TriggerScmSource)
+				triggerScmSourceModel.URL = core.StringPtr("testString")
+				triggerScmSourceModel.Branch = core.StringPtr("testString")
+				triggerScmSourceModel.Pattern = core.StringPtr("testString")
+				triggerScmSourceModel.BlindConnection = core.BoolPtr(true)
+				triggerScmSourceModel.HookID = core.StringPtr("testString")
+				triggerScmSourceModel.ServiceInstanceID = core.StringPtr("testString")
+
+				// Construct an instance of the Events model
+				eventsModel := new(cdtektonpipelinev2.Events)
+				eventsModel.Push = core.BoolPtr(true)
+				eventsModel.PullRequestClosed = core.BoolPtr(true)
+				eventsModel.PullRequest = core.BoolPtr(true)
 
 				// Construct an instance of the CreateTektonPipelineTriggerOptions model
 				createTektonPipelineTriggerOptionsModel := new(cdtektonpipelinev2.CreateTektonPipelineTriggerOptions)
 				createTektonPipelineTriggerOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
-				createTektonPipelineTriggerOptionsModel.Trigger = triggerModel
+				createTektonPipelineTriggerOptionsModel.Type = core.StringPtr("manual")
+				createTektonPipelineTriggerOptionsModel.Name = core.StringPtr("Manual Trigger")
+				createTektonPipelineTriggerOptionsModel.EventListener = core.StringPtr("pr-listener")
+				createTektonPipelineTriggerOptionsModel.Tags = []string{"testString"}
+				createTektonPipelineTriggerOptionsModel.Worker = workerModel
+				createTektonPipelineTriggerOptionsModel.MaxConcurrentRuns = core.Int64Ptr(int64(3))
+				createTektonPipelineTriggerOptionsModel.Disabled = core.BoolPtr(false)
+				createTektonPipelineTriggerOptionsModel.Secret = genericSecretModel
+				createTektonPipelineTriggerOptionsModel.Cron = core.StringPtr("testString")
+				createTektonPipelineTriggerOptionsModel.Timezone = core.StringPtr("testString")
+				createTektonPipelineTriggerOptionsModel.ScmSource = triggerScmSourceModel
+				createTektonPipelineTriggerOptionsModel.Events = eventsModel
 				createTektonPipelineTriggerOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with valid options model (positive test)
@@ -5615,47 +5624,50 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(serviceErr).To(BeNil())
 				Expect(cdTektonPipelineService).ToNot(BeNil())
 
-				// Construct an instance of the TriggerGenericTriggerPropertiesItem model
-				triggerGenericTriggerPropertiesItemModel := new(cdtektonpipelinev2.TriggerGenericTriggerPropertiesItem)
-				triggerGenericTriggerPropertiesItemModel.Name = core.StringPtr("testString")
-				triggerGenericTriggerPropertiesItemModel.Value = core.StringPtr("testString")
-				triggerGenericTriggerPropertiesItemModel.Enum = []string{"testString"}
-				triggerGenericTriggerPropertiesItemModel.Type = core.StringPtr("secure")
-				triggerGenericTriggerPropertiesItemModel.Path = core.StringPtr("testString")
-				triggerGenericTriggerPropertiesItemModel.Href = core.StringPtr("testString")
-
 				// Construct an instance of the Worker model
 				workerModel := new(cdtektonpipelinev2.Worker)
 				workerModel.Name = core.StringPtr("testString")
 				workerModel.Type = core.StringPtr("private")
-				workerModel.ID = core.StringPtr("5df804a4-9d7b-44e1-874f-3810866fb80b")
+				workerModel.ID = core.StringPtr("public")
 
 				// Construct an instance of the GenericSecret model
 				genericSecretModel := new(cdtektonpipelinev2.GenericSecret)
 				genericSecretModel.Type = core.StringPtr("token_matches")
-				genericSecretModel.Value = core.StringPtr("secret")
-				genericSecretModel.Source = core.StringPtr("query")
-				genericSecretModel.KeyName = core.StringPtr("auth")
+				genericSecretModel.Value = core.StringPtr("testString")
+				genericSecretModel.Source = core.StringPtr("header")
+				genericSecretModel.KeyName = core.StringPtr("testString")
 				genericSecretModel.Algorithm = core.StringPtr("md4")
 
-				// Construct an instance of the TriggerGenericTrigger model
-				triggerModel := new(cdtektonpipelinev2.TriggerGenericTrigger)
-				triggerModel.Type = core.StringPtr("generic")
-				triggerModel.Name = core.StringPtr("Generic Webhook Trigger")
-				triggerModel.Href = core.StringPtr("testString")
-				triggerModel.EventListener = core.StringPtr("pr-listener")
-				triggerModel.ID = core.StringPtr("testString")
-				triggerModel.Properties = []cdtektonpipelinev2.TriggerGenericTriggerPropertiesItem{*triggerGenericTriggerPropertiesItemModel}
-				triggerModel.Tags = []string{"prod", "dev"}
-				triggerModel.Worker = workerModel
-				triggerModel.MaxConcurrentRuns = core.Int64Ptr(int64(4))
-				triggerModel.Disabled = core.BoolPtr(false)
-				triggerModel.Secret = genericSecretModel
+				// Construct an instance of the TriggerScmSource model
+				triggerScmSourceModel := new(cdtektonpipelinev2.TriggerScmSource)
+				triggerScmSourceModel.URL = core.StringPtr("testString")
+				triggerScmSourceModel.Branch = core.StringPtr("testString")
+				triggerScmSourceModel.Pattern = core.StringPtr("testString")
+				triggerScmSourceModel.BlindConnection = core.BoolPtr(true)
+				triggerScmSourceModel.HookID = core.StringPtr("testString")
+				triggerScmSourceModel.ServiceInstanceID = core.StringPtr("testString")
+
+				// Construct an instance of the Events model
+				eventsModel := new(cdtektonpipelinev2.Events)
+				eventsModel.Push = core.BoolPtr(true)
+				eventsModel.PullRequestClosed = core.BoolPtr(true)
+				eventsModel.PullRequest = core.BoolPtr(true)
 
 				// Construct an instance of the CreateTektonPipelineTriggerOptions model
 				createTektonPipelineTriggerOptionsModel := new(cdtektonpipelinev2.CreateTektonPipelineTriggerOptions)
 				createTektonPipelineTriggerOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
-				createTektonPipelineTriggerOptionsModel.Trigger = triggerModel
+				createTektonPipelineTriggerOptionsModel.Type = core.StringPtr("manual")
+				createTektonPipelineTriggerOptionsModel.Name = core.StringPtr("Manual Trigger")
+				createTektonPipelineTriggerOptionsModel.EventListener = core.StringPtr("pr-listener")
+				createTektonPipelineTriggerOptionsModel.Tags = []string{"testString"}
+				createTektonPipelineTriggerOptionsModel.Worker = workerModel
+				createTektonPipelineTriggerOptionsModel.MaxConcurrentRuns = core.Int64Ptr(int64(3))
+				createTektonPipelineTriggerOptionsModel.Disabled = core.BoolPtr(false)
+				createTektonPipelineTriggerOptionsModel.Secret = genericSecretModel
+				createTektonPipelineTriggerOptionsModel.Cron = core.StringPtr("testString")
+				createTektonPipelineTriggerOptionsModel.Timezone = core.StringPtr("testString")
+				createTektonPipelineTriggerOptionsModel.ScmSource = triggerScmSourceModel
+				createTektonPipelineTriggerOptionsModel.Events = eventsModel
 				createTektonPipelineTriggerOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
 				err := cdTektonPipelineService.SetServiceURL("")
@@ -5694,47 +5706,50 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(serviceErr).To(BeNil())
 				Expect(cdTektonPipelineService).ToNot(BeNil())
 
-				// Construct an instance of the TriggerGenericTriggerPropertiesItem model
-				triggerGenericTriggerPropertiesItemModel := new(cdtektonpipelinev2.TriggerGenericTriggerPropertiesItem)
-				triggerGenericTriggerPropertiesItemModel.Name = core.StringPtr("testString")
-				triggerGenericTriggerPropertiesItemModel.Value = core.StringPtr("testString")
-				triggerGenericTriggerPropertiesItemModel.Enum = []string{"testString"}
-				triggerGenericTriggerPropertiesItemModel.Type = core.StringPtr("secure")
-				triggerGenericTriggerPropertiesItemModel.Path = core.StringPtr("testString")
-				triggerGenericTriggerPropertiesItemModel.Href = core.StringPtr("testString")
-
 				// Construct an instance of the Worker model
 				workerModel := new(cdtektonpipelinev2.Worker)
 				workerModel.Name = core.StringPtr("testString")
 				workerModel.Type = core.StringPtr("private")
-				workerModel.ID = core.StringPtr("5df804a4-9d7b-44e1-874f-3810866fb80b")
+				workerModel.ID = core.StringPtr("public")
 
 				// Construct an instance of the GenericSecret model
 				genericSecretModel := new(cdtektonpipelinev2.GenericSecret)
 				genericSecretModel.Type = core.StringPtr("token_matches")
-				genericSecretModel.Value = core.StringPtr("secret")
-				genericSecretModel.Source = core.StringPtr("query")
-				genericSecretModel.KeyName = core.StringPtr("auth")
+				genericSecretModel.Value = core.StringPtr("testString")
+				genericSecretModel.Source = core.StringPtr("header")
+				genericSecretModel.KeyName = core.StringPtr("testString")
 				genericSecretModel.Algorithm = core.StringPtr("md4")
 
-				// Construct an instance of the TriggerGenericTrigger model
-				triggerModel := new(cdtektonpipelinev2.TriggerGenericTrigger)
-				triggerModel.Type = core.StringPtr("generic")
-				triggerModel.Name = core.StringPtr("Generic Webhook Trigger")
-				triggerModel.Href = core.StringPtr("testString")
-				triggerModel.EventListener = core.StringPtr("pr-listener")
-				triggerModel.ID = core.StringPtr("testString")
-				triggerModel.Properties = []cdtektonpipelinev2.TriggerGenericTriggerPropertiesItem{*triggerGenericTriggerPropertiesItemModel}
-				triggerModel.Tags = []string{"prod", "dev"}
-				triggerModel.Worker = workerModel
-				triggerModel.MaxConcurrentRuns = core.Int64Ptr(int64(4))
-				triggerModel.Disabled = core.BoolPtr(false)
-				triggerModel.Secret = genericSecretModel
+				// Construct an instance of the TriggerScmSource model
+				triggerScmSourceModel := new(cdtektonpipelinev2.TriggerScmSource)
+				triggerScmSourceModel.URL = core.StringPtr("testString")
+				triggerScmSourceModel.Branch = core.StringPtr("testString")
+				triggerScmSourceModel.Pattern = core.StringPtr("testString")
+				triggerScmSourceModel.BlindConnection = core.BoolPtr(true)
+				triggerScmSourceModel.HookID = core.StringPtr("testString")
+				triggerScmSourceModel.ServiceInstanceID = core.StringPtr("testString")
+
+				// Construct an instance of the Events model
+				eventsModel := new(cdtektonpipelinev2.Events)
+				eventsModel.Push = core.BoolPtr(true)
+				eventsModel.PullRequestClosed = core.BoolPtr(true)
+				eventsModel.PullRequest = core.BoolPtr(true)
 
 				// Construct an instance of the CreateTektonPipelineTriggerOptions model
 				createTektonPipelineTriggerOptionsModel := new(cdtektonpipelinev2.CreateTektonPipelineTriggerOptions)
 				createTektonPipelineTriggerOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
-				createTektonPipelineTriggerOptionsModel.Trigger = triggerModel
+				createTektonPipelineTriggerOptionsModel.Type = core.StringPtr("manual")
+				createTektonPipelineTriggerOptionsModel.Name = core.StringPtr("Manual Trigger")
+				createTektonPipelineTriggerOptionsModel.EventListener = core.StringPtr("pr-listener")
+				createTektonPipelineTriggerOptionsModel.Tags = []string{"testString"}
+				createTektonPipelineTriggerOptionsModel.Worker = workerModel
+				createTektonPipelineTriggerOptionsModel.MaxConcurrentRuns = core.Int64Ptr(int64(3))
+				createTektonPipelineTriggerOptionsModel.Disabled = core.BoolPtr(false)
+				createTektonPipelineTriggerOptionsModel.Secret = genericSecretModel
+				createTektonPipelineTriggerOptionsModel.Cron = core.StringPtr("testString")
+				createTektonPipelineTriggerOptionsModel.Timezone = core.StringPtr("testString")
+				createTektonPipelineTriggerOptionsModel.ScmSource = triggerScmSourceModel
+				createTektonPipelineTriggerOptionsModel.Events = eventsModel
 				createTektonPipelineTriggerOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation
@@ -7974,65 +7989,87 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(createTektonPipelineRunOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewCreateTektonPipelineTriggerOptions successfully`, func() {
-				// Construct an instance of the TriggerManualTriggerPropertiesItem model
-				triggerManualTriggerPropertiesItemModel := new(cdtektonpipelinev2.TriggerManualTriggerPropertiesItem)
-				Expect(triggerManualTriggerPropertiesItemModel).ToNot(BeNil())
-				triggerManualTriggerPropertiesItemModel.Name = core.StringPtr("testString")
-				triggerManualTriggerPropertiesItemModel.Value = core.StringPtr("testString")
-				triggerManualTriggerPropertiesItemModel.Enum = []string{"testString"}
-				triggerManualTriggerPropertiesItemModel.Type = core.StringPtr("secure")
-				triggerManualTriggerPropertiesItemModel.Path = core.StringPtr("testString")
-				triggerManualTriggerPropertiesItemModel.Href = core.StringPtr("testString")
-				Expect(triggerManualTriggerPropertiesItemModel.Name).To(Equal(core.StringPtr("testString")))
-				Expect(triggerManualTriggerPropertiesItemModel.Value).To(Equal(core.StringPtr("testString")))
-				Expect(triggerManualTriggerPropertiesItemModel.Enum).To(Equal([]string{"testString"}))
-				Expect(triggerManualTriggerPropertiesItemModel.Type).To(Equal(core.StringPtr("secure")))
-				Expect(triggerManualTriggerPropertiesItemModel.Path).To(Equal(core.StringPtr("testString")))
-				Expect(triggerManualTriggerPropertiesItemModel.Href).To(Equal(core.StringPtr("testString")))
-
 				// Construct an instance of the Worker model
 				workerModel := new(cdtektonpipelinev2.Worker)
 				Expect(workerModel).ToNot(BeNil())
 				workerModel.Name = core.StringPtr("testString")
 				workerModel.Type = core.StringPtr("private")
-				workerModel.ID = core.StringPtr("testString")
+				workerModel.ID = core.StringPtr("public")
 				Expect(workerModel.Name).To(Equal(core.StringPtr("testString")))
 				Expect(workerModel.Type).To(Equal(core.StringPtr("private")))
-				Expect(workerModel.ID).To(Equal(core.StringPtr("testString")))
+				Expect(workerModel.ID).To(Equal(core.StringPtr("public")))
 
-				// Construct an instance of the TriggerManualTrigger model
-				triggerModel := new(cdtektonpipelinev2.TriggerManualTrigger)
-				Expect(triggerModel).ToNot(BeNil())
-				triggerModel.Type = core.StringPtr("testString")
-				triggerModel.Name = core.StringPtr("start-deploy")
-				triggerModel.Href = core.StringPtr("testString")
-				triggerModel.EventListener = core.StringPtr("testString")
-				triggerModel.ID = core.StringPtr("testString")
-				triggerModel.Properties = []cdtektonpipelinev2.TriggerManualTriggerPropertiesItem{*triggerManualTriggerPropertiesItemModel}
-				triggerModel.Tags = []string{"testString"}
-				triggerModel.Worker = workerModel
-				triggerModel.MaxConcurrentRuns = core.Int64Ptr(int64(4))
-				triggerModel.Disabled = core.BoolPtr(true)
-				Expect(triggerModel.Type).To(Equal(core.StringPtr("testString")))
-				Expect(triggerModel.Name).To(Equal(core.StringPtr("start-deploy")))
-				Expect(triggerModel.Href).To(Equal(core.StringPtr("testString")))
-				Expect(triggerModel.EventListener).To(Equal(core.StringPtr("testString")))
-				Expect(triggerModel.ID).To(Equal(core.StringPtr("testString")))
-				Expect(triggerModel.Properties).To(Equal([]cdtektonpipelinev2.TriggerManualTriggerPropertiesItem{*triggerManualTriggerPropertiesItemModel}))
-				Expect(triggerModel.Tags).To(Equal([]string{"testString"}))
-				Expect(triggerModel.Worker).To(Equal(workerModel))
-				Expect(triggerModel.MaxConcurrentRuns).To(Equal(core.Int64Ptr(int64(4))))
-				Expect(triggerModel.Disabled).To(Equal(core.BoolPtr(true)))
+				// Construct an instance of the GenericSecret model
+				genericSecretModel := new(cdtektonpipelinev2.GenericSecret)
+				Expect(genericSecretModel).ToNot(BeNil())
+				genericSecretModel.Type = core.StringPtr("token_matches")
+				genericSecretModel.Value = core.StringPtr("testString")
+				genericSecretModel.Source = core.StringPtr("header")
+				genericSecretModel.KeyName = core.StringPtr("testString")
+				genericSecretModel.Algorithm = core.StringPtr("md4")
+				Expect(genericSecretModel.Type).To(Equal(core.StringPtr("token_matches")))
+				Expect(genericSecretModel.Value).To(Equal(core.StringPtr("testString")))
+				Expect(genericSecretModel.Source).To(Equal(core.StringPtr("header")))
+				Expect(genericSecretModel.KeyName).To(Equal(core.StringPtr("testString")))
+				Expect(genericSecretModel.Algorithm).To(Equal(core.StringPtr("md4")))
+
+				// Construct an instance of the TriggerScmSource model
+				triggerScmSourceModel := new(cdtektonpipelinev2.TriggerScmSource)
+				Expect(triggerScmSourceModel).ToNot(BeNil())
+				triggerScmSourceModel.URL = core.StringPtr("testString")
+				triggerScmSourceModel.Branch = core.StringPtr("testString")
+				triggerScmSourceModel.Pattern = core.StringPtr("testString")
+				triggerScmSourceModel.BlindConnection = core.BoolPtr(true)
+				triggerScmSourceModel.HookID = core.StringPtr("testString")
+				triggerScmSourceModel.ServiceInstanceID = core.StringPtr("testString")
+				Expect(triggerScmSourceModel.URL).To(Equal(core.StringPtr("testString")))
+				Expect(triggerScmSourceModel.Branch).To(Equal(core.StringPtr("testString")))
+				Expect(triggerScmSourceModel.Pattern).To(Equal(core.StringPtr("testString")))
+				Expect(triggerScmSourceModel.BlindConnection).To(Equal(core.BoolPtr(true)))
+				Expect(triggerScmSourceModel.HookID).To(Equal(core.StringPtr("testString")))
+				Expect(triggerScmSourceModel.ServiceInstanceID).To(Equal(core.StringPtr("testString")))
+
+				// Construct an instance of the Events model
+				eventsModel := new(cdtektonpipelinev2.Events)
+				Expect(eventsModel).ToNot(BeNil())
+				eventsModel.Push = core.BoolPtr(true)
+				eventsModel.PullRequestClosed = core.BoolPtr(true)
+				eventsModel.PullRequest = core.BoolPtr(true)
+				Expect(eventsModel.Push).To(Equal(core.BoolPtr(true)))
+				Expect(eventsModel.PullRequestClosed).To(Equal(core.BoolPtr(true)))
+				Expect(eventsModel.PullRequest).To(Equal(core.BoolPtr(true)))
 
 				// Construct an instance of the CreateTektonPipelineTriggerOptions model
 				pipelineID := "94619026-912b-4d92-8f51-6c74f0692d90"
 				createTektonPipelineTriggerOptionsModel := cdTektonPipelineService.NewCreateTektonPipelineTriggerOptions(pipelineID)
 				createTektonPipelineTriggerOptionsModel.SetPipelineID("94619026-912b-4d92-8f51-6c74f0692d90")
-				createTektonPipelineTriggerOptionsModel.SetTrigger(triggerModel)
+				createTektonPipelineTriggerOptionsModel.SetType("manual")
+				createTektonPipelineTriggerOptionsModel.SetName("Manual Trigger")
+				createTektonPipelineTriggerOptionsModel.SetEventListener("pr-listener")
+				createTektonPipelineTriggerOptionsModel.SetTags([]string{"testString"})
+				createTektonPipelineTriggerOptionsModel.SetWorker(workerModel)
+				createTektonPipelineTriggerOptionsModel.SetMaxConcurrentRuns(int64(3))
+				createTektonPipelineTriggerOptionsModel.SetDisabled(false)
+				createTektonPipelineTriggerOptionsModel.SetSecret(genericSecretModel)
+				createTektonPipelineTriggerOptionsModel.SetCron("testString")
+				createTektonPipelineTriggerOptionsModel.SetTimezone("testString")
+				createTektonPipelineTriggerOptionsModel.SetScmSource(triggerScmSourceModel)
+				createTektonPipelineTriggerOptionsModel.SetEvents(eventsModel)
 				createTektonPipelineTriggerOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(createTektonPipelineTriggerOptionsModel).ToNot(BeNil())
 				Expect(createTektonPipelineTriggerOptionsModel.PipelineID).To(Equal(core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")))
-				Expect(createTektonPipelineTriggerOptionsModel.Trigger).To(Equal(triggerModel))
+				Expect(createTektonPipelineTriggerOptionsModel.Type).To(Equal(core.StringPtr("manual")))
+				Expect(createTektonPipelineTriggerOptionsModel.Name).To(Equal(core.StringPtr("Manual Trigger")))
+				Expect(createTektonPipelineTriggerOptionsModel.EventListener).To(Equal(core.StringPtr("pr-listener")))
+				Expect(createTektonPipelineTriggerOptionsModel.Tags).To(Equal([]string{"testString"}))
+				Expect(createTektonPipelineTriggerOptionsModel.Worker).To(Equal(workerModel))
+				Expect(createTektonPipelineTriggerOptionsModel.MaxConcurrentRuns).To(Equal(core.Int64Ptr(int64(3))))
+				Expect(createTektonPipelineTriggerOptionsModel.Disabled).To(Equal(core.BoolPtr(false)))
+				Expect(createTektonPipelineTriggerOptionsModel.Secret).To(Equal(genericSecretModel))
+				Expect(createTektonPipelineTriggerOptionsModel.Cron).To(Equal(core.StringPtr("testString")))
+				Expect(createTektonPipelineTriggerOptionsModel.Timezone).To(Equal(core.StringPtr("testString")))
+				Expect(createTektonPipelineTriggerOptionsModel.ScmSource).To(Equal(triggerScmSourceModel))
+				Expect(createTektonPipelineTriggerOptionsModel.Events).To(Equal(eventsModel))
 				Expect(createTektonPipelineTriggerOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewCreateTektonPipelineTriggerPropertiesOptions successfully`, func() {
@@ -8452,44 +8489,9 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(rerunTektonPipelineRunOptionsModel.ID).To(Equal(core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")))
 				Expect(rerunTektonPipelineRunOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
-			It(`Invoke NewTriggerGenericTriggerPropertiesItem successfully`, func() {
-				name := "testString"
-				typeVar := "secure"
-				_model, err := cdTektonPipelineService.NewTriggerGenericTriggerPropertiesItem(name, typeVar)
-				Expect(_model).ToNot(BeNil())
-				Expect(err).To(BeNil())
-			})
-			It(`Invoke NewTriggerManualTriggerPropertiesItem successfully`, func() {
-				name := "testString"
-				typeVar := "secure"
-				_model, err := cdTektonPipelineService.NewTriggerManualTriggerPropertiesItem(name, typeVar)
-				Expect(_model).ToNot(BeNil())
-				Expect(err).To(BeNil())
-			})
-			It(`Invoke NewTriggerPropertiesItem successfully`, func() {
-				name := "testString"
-				typeVar := "secure"
-				_model, err := cdTektonPipelineService.NewTriggerPropertiesItem(name, typeVar)
-				Expect(_model).ToNot(BeNil())
-				Expect(err).To(BeNil())
-			})
 			It(`Invoke NewTriggerScmSource successfully`, func() {
 				url := "testString"
 				_model, err := cdTektonPipelineService.NewTriggerScmSource(url)
-				Expect(_model).ToNot(BeNil())
-				Expect(err).To(BeNil())
-			})
-			It(`Invoke NewTriggerScmTriggerPropertiesItem successfully`, func() {
-				name := "testString"
-				typeVar := "secure"
-				_model, err := cdTektonPipelineService.NewTriggerScmTriggerPropertiesItem(name, typeVar)
-				Expect(_model).ToNot(BeNil())
-				Expect(err).To(BeNil())
-			})
-			It(`Invoke NewTriggerTimerTriggerPropertiesItem successfully`, func() {
-				name := "testString"
-				typeVar := "secure"
-				_model, err := cdTektonPipelineService.NewTriggerTimerTriggerPropertiesItem(name, typeVar)
 				Expect(_model).ToNot(BeNil())
 				Expect(err).To(BeNil())
 			})
@@ -8529,42 +8531,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 			It(`Invoke NewWorkerWithID successfully`, func() {
 				id := "testString"
 				_model, err := cdTektonPipelineService.NewWorkerWithID(id)
-				Expect(_model).ToNot(BeNil())
-				Expect(err).To(BeNil())
-			})
-			It(`Invoke NewTriggerGenericTrigger successfully`, func() {
-				typeVar := "testString"
-				name := "start-deploy"
-				eventListener := "testString"
-				disabled := true
-				_model, err := cdTektonPipelineService.NewTriggerGenericTrigger(typeVar, name, eventListener, disabled)
-				Expect(_model).ToNot(BeNil())
-				Expect(err).To(BeNil())
-			})
-			It(`Invoke NewTriggerManualTrigger successfully`, func() {
-				typeVar := "testString"
-				name := "start-deploy"
-				eventListener := "testString"
-				disabled := true
-				_model, err := cdTektonPipelineService.NewTriggerManualTrigger(typeVar, name, eventListener, disabled)
-				Expect(_model).ToNot(BeNil())
-				Expect(err).To(BeNil())
-			})
-			It(`Invoke NewTriggerScmTrigger successfully`, func() {
-				typeVar := "testString"
-				name := "start-deploy"
-				eventListener := "testString"
-				disabled := true
-				_model, err := cdTektonPipelineService.NewTriggerScmTrigger(typeVar, name, eventListener, disabled)
-				Expect(_model).ToNot(BeNil())
-				Expect(err).To(BeNil())
-			})
-			It(`Invoke NewTriggerTimerTrigger successfully`, func() {
-				typeVar := "testString"
-				name := "start-deploy"
-				eventListener := "testString"
-				disabled := true
-				_model, err := cdTektonPipelineService.NewTriggerTimerTrigger(typeVar, name, eventListener, disabled)
 				Expect(_model).ToNot(BeNil())
 				Expect(err).To(BeNil())
 			})


### PR DESCRIPTION
Signed-off-by: Brian Gleeson <brian.gleeson@ie.ibm.com>

## PR summary
- Update a large amount of Strings as we prepare for GA of Tekton V2 API Spec
- Response object altered for PipelineRun(s)
- **Breaking**: Change `concurrency` object property to `max_concurrent_runs` integer property
- **Breaking**: Reshape property types to use snake case: `text`, `single_select`, `integration`, `secure`, `appconfig`, instead of the previous uppercase types
- **Breaking**: Reshape secret types to use snake case: `token_matches`, `digest_matches`, `internal_validation`, instead of the previous camelcase types
- Add support for the `preview` worker option in v2 APIs, when supported in that region. Falls back to `public` if not supported
- **Breaking**: Reshape scm source object in v2 API output, to include service_instance_id 
- Change patch requests to use JSON merge-patch content-type
- Rename `html_url` to `runs_url` and `run_url` for pipeline and pipelineRun resources respectively
- Refactor Log and Logs schema
- Add support for `enable_slack_notifications` and `enable_partial_cloning` settings
- **Breaking**: Reshape enum value to remove the `default` option in favour of `value` instead
- **Breaking**: Refactored Trigger into separate request and response shapes

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [X] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring
- [ ] New tests
- [ ] Build/CI related changes
- [X] Documentation content changes
- [ ] Other (please describe)