### PR TITLE
chore: v0.1.1 version bump

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.1.1
 commit = True
 message = Update version {current_version} -> {new_version} [skip ci]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# [0.1.1](https://github.com/IBM/continuous-delivery-go-sdk/compare/v0.1.0...v0.1.1) (2022-09-09)
+
+### Bug Fixes
+
+* **tekton:** fix validator warnings ([#13](https://github.com/IBM/continuous-delivery-go-sdk/pull/13)) ([dfda869](https://github.com/IBM/continuous-delivery-go-sdk/commit/dfda869446493414aef36a616d5755d73a9274fc))
+
+### Features
+
+* **tekton:** add webhookUrl to generic trigger data ([#13](https://github.com/IBM/continuous-delivery-go-sdk/pull/13)) ([dfda869](https://github.com/IBM/continuous-delivery-go-sdk/commit/dfda869446493414aef36a616d5755d73a9274fc))
+
+
 # [0.1.0](https://github.com/IBM/continuous-delivery-go-sdk/compare/v0.0.8...v0.1.0) (2022-09-05)
 
 

--- a/common/version.go
+++ b/common/version.go
@@ -17,4 +17,4 @@
 package common
 
 // Version of the SDK
-const Version = "0.1.0"
+const Version = "0.1.1"


### PR DESCRIPTION
Signed-off-by: Brian Gleeson <brian.gleeson@ie.ibm.com>

## PR summary
Bump version of the SDK to v0.1.1 in order to cut a new release

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [X] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).