### PR TITLE
fix(toolchain): remove offset pagination parameter

### DIFF
--- a/cdtoolchainv2/cd_toolchain_v2.go
+++ b/cdtoolchainv2/cd_toolchain_v2.go
@@ -15,7 +15,7 @@
  */
 
 /*
- * IBM OpenAPI SDK Code Generator Version: 3.56.0-9d92579f-20220914-180148
+ * IBM OpenAPI SDK Code Generator Version: 3.60.0-13f6e1ba-20221019-164457
  */
 
 // Package cdtoolchainv2 : Operations and models for the CdToolchainV2 service
@@ -217,9 +217,6 @@ func (cdToolchain *CdToolchainV2) ListToolchainsWithContext(ctx context.Context,
 	builder.AddQuery("resource_group_id", fmt.Sprint(*listToolchainsOptions.ResourceGroupID))
 	if listToolchainsOptions.Limit != nil {
 		builder.AddQuery("limit", fmt.Sprint(*listToolchainsOptions.Limit))
-	}
-	if listToolchainsOptions.Offset != nil {
-		builder.AddQuery("offset", fmt.Sprint(*listToolchainsOptions.Offset))
 	}
 	if listToolchainsOptions.Start != nil {
 		builder.AddQuery("start", fmt.Sprint(*listToolchainsOptions.Start))
@@ -535,9 +532,6 @@ func (cdToolchain *CdToolchainV2) ListToolsWithContext(ctx context.Context, list
 	if listToolsOptions.Limit != nil {
 		builder.AddQuery("limit", fmt.Sprint(*listToolsOptions.Limit))
 	}
-	if listToolsOptions.Offset != nil {
-		builder.AddQuery("offset", fmt.Sprint(*listToolsOptions.Offset))
-	}
 	if listToolsOptions.Start != nil {
 		builder.AddQuery("start", fmt.Sprint(*listToolsOptions.Start))
 	}
@@ -821,13 +815,19 @@ type CreateToolOptions struct {
 	// ID of the toolchain to bind the tool to.
 	ToolchainID *string `json:"toolchain_id" validate:"required,ne="`
 
-	// The unique short name of the tool that should be provisioned.
+	// The unique short name of the tool that should be provisioned. A table of `tool_type_id` values corresponding to each
+	// tool integration can be found in the <a
+	// href="https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-integrations">Configuring tool
+	// integrations page</a>.
 	ToolTypeID *string `json:"tool_type_id" validate:"required"`
 
-	// Name of tool.
+	// Name of the tool.
 	Name *string `json:"name,omitempty"`
 
-	// Unique key-value pairs representing parameters to be used to create the tool.
+	// Unique key-value pairs representing parameters to be used to create the tool. A list of parameters for each tool
+	// integration can be found in the <a
+	// href="https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-integrations">Configuring tool
+	// integrations page</a>.
 	Parameters map[string]interface{} `json:"parameters,omitempty"`
 
 	// Allows users to set headers on API requests
@@ -1059,10 +1059,7 @@ type ListToolchainsOptions struct {
 	// Limit the number of results.
 	Limit *int64 `json:"limit,omitempty"`
 
-	// Offset the results from the beginning of the list. Cannot be used if 'start' is provided.
-	Offset *int64 `json:"offset,omitempty"`
-
-	// Pagination token. Cannot be used if 'offset' is provided.
+	// Pagination token.
 	Start *string `json:"start,omitempty"`
 
 	// Allows users to set headers on API requests
@@ -1088,12 +1085,6 @@ func (_options *ListToolchainsOptions) SetLimit(limit int64) *ListToolchainsOpti
 	return _options
 }
 
-// SetOffset : Allow user to set Offset
-func (_options *ListToolchainsOptions) SetOffset(offset int64) *ListToolchainsOptions {
-	_options.Offset = core.Int64Ptr(offset)
-	return _options
-}
-
 // SetStart : Allow user to set Start
 func (_options *ListToolchainsOptions) SetStart(start string) *ListToolchainsOptions {
 	_options.Start = core.StringPtr(start)
@@ -1114,10 +1105,7 @@ type ListToolsOptions struct {
 	// Limit the number of results.
 	Limit *int64 `json:"limit,omitempty"`
 
-	// Offset the number of results from the beginning of the list. Cannot be used if 'start' is provided.
-	Offset *int64 `json:"offset,omitempty"`
-
-	// Pagination token. Cannot be used if 'offset' is provided.
+	// Pagination token.
 	Start *string `json:"start,omitempty"`
 
 	// Allows users to set headers on API requests
@@ -1143,12 +1131,6 @@ func (_options *ListToolsOptions) SetLimit(limit int64) *ListToolsOptions {
 	return _options
 }
 
-// SetOffset : Allow user to set Offset
-func (_options *ListToolsOptions) SetOffset(offset int64) *ListToolsOptions {
-	_options.Offset = core.Int64Ptr(offset)
-	return _options
-}
-
 // SetStart : Allow user to set Start
 func (_options *ListToolsOptions) SetStart(start string) *ListToolsOptions {
 	_options.Start = core.StringPtr(start)
@@ -1166,13 +1148,16 @@ type ToolModel struct {
 	// Tool ID.
 	ID *string `json:"id" validate:"required"`
 
-	// Resource group where tool can be found.
+	// Resource group where the tool is located.
 	ResourceGroupID *string `json:"resource_group_id" validate:"required"`
 
 	// Tool CRN.
 	CRN *string `json:"crn" validate:"required"`
 
-	// The unique name of the provisioned tool.
+	// The unique name of the provisioned tool. A table of `tool_type_id` values corresponding to each tool integration can
+	// be found in the <a
+	// href="https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-integrations">Configuring tool
+	// integrations page</a>.
 	ToolTypeID *string `json:"tool_type_id" validate:"required"`
 
 	// ID of toolchain which the tool is bound to.
@@ -1193,7 +1178,10 @@ type ToolModel struct {
 	// Latest tool update timestamp.
 	UpdatedAt *strfmt.DateTime `json:"updated_at" validate:"required"`
 
-	// Unique key-value pairs representing parameters to be used to create the tool.
+	// Unique key-value pairs representing parameters to be used to create the tool. A list of parameters for each tool
+	// integration can be found in the <a
+	// href="https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-integrations">Configuring tool
+	// integrations page</a>.
 	Parameters map[string]interface{} `json:"parameters" validate:"required"`
 
 	// Current configuration state of the tool.
@@ -1266,10 +1254,10 @@ func UnmarshalToolModel(m map[string]json.RawMessage, result interface{}) (err e
 
 // ToolModelReferent : Information on URIs to access this resource through the UI or API.
 type ToolModelReferent struct {
-	// URI representing the this resource through the UI.
+	// URI representing this resource through the UI.
 	UIHref *string `json:"ui_href,omitempty"`
 
-	// URI representing the this resource through an API.
+	// URI representing this resource through an API.
 	APIHref *string `json:"api_href,omitempty"`
 }
 
@@ -1305,7 +1293,7 @@ type Toolchain struct {
 	// Toolchain region.
 	Location *string `json:"location" validate:"required"`
 
-	// Resource group where toolchain can be found.
+	// Resource group where the toolchain is located.
 	ResourceGroupID *string `json:"resource_group_id" validate:"required"`
 
 	// Toolchain CRN.
@@ -1397,9 +1385,6 @@ type ToolchainCollection struct {
 	// Maximum number of toolchains returned from collection.
 	Limit *int64 `json:"limit" validate:"required"`
 
-	// Offset applied to toolchains collection. Returned only if 'offset' query parameter is used.
-	Offset *int64 `json:"offset,omitempty"`
-
 	// Information about retrieving first toolchain results from the collection.
 	First *ToolchainCollectionFirst `json:"first" validate:"required"`
 
@@ -1424,10 +1409,6 @@ func UnmarshalToolchainCollection(m map[string]json.RawMessage, result interface
 		return
 	}
 	err = core.UnmarshalPrimitive(m, "limit", &obj.Limit)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "offset", &obj.Offset)
 	if err != nil {
 		return
 	}
@@ -1569,7 +1550,7 @@ type ToolchainModel struct {
 	// Toolchain region.
 	Location *string `json:"location" validate:"required"`
 
-	// Resource group where toolchain can be found.
+	// Resource group where the toolchain is located.
 	ResourceGroupID *string `json:"resource_group_id" validate:"required"`
 
 	// Toolchain CRN.
@@ -1670,7 +1651,7 @@ type ToolchainPatch struct {
 	// Toolchain region.
 	Location *string `json:"location" validate:"required"`
 
-	// Resource group where toolchain can be found.
+	// Resource group where the toolchain is located.
 	ResourceGroupID *string `json:"resource_group_id" validate:"required"`
 
 	// Toolchain CRN.
@@ -1771,7 +1752,7 @@ type ToolchainPost struct {
 	// Toolchain region.
 	Location *string `json:"location" validate:"required"`
 
-	// Resource group where toolchain can be found.
+	// Resource group where the toolchain is located.
 	ResourceGroupID *string `json:"resource_group_id" validate:"required"`
 
 	// Toolchain CRN.
@@ -1894,13 +1875,16 @@ type ToolchainTool struct {
 	// Tool ID.
 	ID *string `json:"id" validate:"required"`
 
-	// Resource group where tool can be found.
+	// Resource group where the tool is located.
 	ResourceGroupID *string `json:"resource_group_id" validate:"required"`
 
 	// Tool CRN.
 	CRN *string `json:"crn" validate:"required"`
 
-	// The unique name of the provisioned tool.
+	// The unique name of the provisioned tool. A table of `tool_type_id` values corresponding to each tool integration can
+	// be found in the <a
+	// href="https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-integrations">Configuring tool
+	// integrations page</a>.
 	ToolTypeID *string `json:"tool_type_id" validate:"required"`
 
 	// ID of toolchain which the tool is bound to.
@@ -1921,7 +1905,10 @@ type ToolchainTool struct {
 	// Latest tool update timestamp.
 	UpdatedAt *strfmt.DateTime `json:"updated_at" validate:"required"`
 
-	// Unique key-value pairs representing parameters to be used to create the tool.
+	// Unique key-value pairs representing parameters to be used to create the tool. A list of parameters for each tool
+	// integration can be found in the <a
+	// href="https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-integrations">Configuring tool
+	// integrations page</a>.
 	Parameters map[string]interface{} `json:"parameters" validate:"required"`
 
 	// Current configuration state of the tool.
@@ -2000,9 +1987,6 @@ type ToolchainToolCollection struct {
 	// Total number of tools found in collection.
 	TotalCount *int64 `json:"total_count" validate:"required"`
 
-	// Offset applied to tools collection.
-	Offset *int64 `json:"offset,omitempty"`
-
 	// Information about retrieving first tool results from the collection.
 	First *ToolchainToolCollectionFirst `json:"first" validate:"required"`
 
@@ -2027,10 +2011,6 @@ func UnmarshalToolchainToolCollection(m map[string]json.RawMessage, result inter
 		return
 	}
 	err = core.UnmarshalPrimitive(m, "total_count", &obj.TotalCount)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "offset", &obj.Offset)
 	if err != nil {
 		return
 	}
@@ -2160,13 +2140,16 @@ type ToolchainToolPatch struct {
 	// Tool ID.
 	ID *string `json:"id" validate:"required"`
 
-	// Resource group where tool can be found.
+	// Resource group where the tool is located.
 	ResourceGroupID *string `json:"resource_group_id" validate:"required"`
 
 	// Tool CRN.
 	CRN *string `json:"crn" validate:"required"`
 
-	// The unique name of the provisioned tool.
+	// The unique name of the provisioned tool. A table of `tool_type_id` values corresponding to each tool integration can
+	// be found in the <a
+	// href="https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-integrations">Configuring tool
+	// integrations page</a>.
 	ToolTypeID *string `json:"tool_type_id" validate:"required"`
 
 	// ID of toolchain which the tool is bound to.
@@ -2187,7 +2170,10 @@ type ToolchainToolPatch struct {
 	// Latest tool update timestamp.
 	UpdatedAt *strfmt.DateTime `json:"updated_at" validate:"required"`
 
-	// Unique key-value pairs representing parameters to be used to create the tool.
+	// Unique key-value pairs representing parameters to be used to create the tool. A list of parameters for each tool
+	// integration can be found in the <a
+	// href="https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-integrations">Configuring tool
+	// integrations page</a>.
 	Parameters map[string]interface{} `json:"parameters" validate:"required"`
 
 	// Current configuration state of the tool.
@@ -2263,13 +2249,16 @@ type ToolchainToolPost struct {
 	// Tool ID.
 	ID *string `json:"id" validate:"required"`
 
-	// Resource group where tool can be found.
+	// Resource group where the tool is located.
 	ResourceGroupID *string `json:"resource_group_id" validate:"required"`
 
 	// Tool CRN.
 	CRN *string `json:"crn" validate:"required"`
 
-	// The unique name of the provisioned tool.
+	// The unique name of the provisioned tool. A table of `tool_type_id` values corresponding to each tool integration can
+	// be found in the <a
+	// href="https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-integrations">Configuring tool
+	// integrations page</a>.
 	ToolTypeID *string `json:"tool_type_id" validate:"required"`
 
 	// ID of toolchain which the tool is bound to.
@@ -2290,7 +2279,10 @@ type ToolchainToolPost struct {
 	// Latest tool update timestamp.
 	UpdatedAt *strfmt.DateTime `json:"updated_at" validate:"required"`
 
-	// Unique key-value pairs representing parameters to be used to create the tool.
+	// Unique key-value pairs representing parameters to be used to create the tool. A list of parameters for each tool
+	// integration can be found in the <a
+	// href="https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-integrations">Configuring tool
+	// integrations page</a>.
 	Parameters map[string]interface{} `json:"parameters" validate:"required"`
 
 	// Current configuration state of the tool.
@@ -2363,13 +2355,19 @@ func UnmarshalToolchainToolPost(m map[string]json.RawMessage, result interface{}
 
 // ToolchainToolPrototypePatch : Details on the new tool.
 type ToolchainToolPrototypePatch struct {
-	// Name of tool.
+	// Name of the tool.
 	Name *string `json:"name,omitempty"`
 
-	// The unique short name of the tool that should be provisioned or updated.
+	// The unique short name of the tool that should be provisioned or updated. A table of `tool_type_id` values
+	// corresponding to each tool integration can be found in the <a
+	// href="https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-integrations">Configuring tool
+	// integrations page</a>.
 	ToolTypeID *string `json:"tool_type_id,omitempty"`
 
-	// Unique key-value pairs representing parameters to be used to create the tool.
+	// Unique key-value pairs representing parameters to be used to create the tool. A list of parameters for each tool
+	// integration can be found in the <a
+	// href="https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-integrations">Configuring tool
+	// integrations page</a>.
 	Parameters map[string]interface{} `json:"parameters,omitempty"`
 }
 

--- a/cdtoolchainv2/cd_toolchain_v2_examples_test.go
+++ b/cdtoolchainv2/cd_toolchain_v2_examples_test.go
@@ -38,7 +38,8 @@ import (
 // CD_TOOLCHAIN_APIKEY=<IAM apikey>
 //
 // These configuration properties can be exported as environment variables, or stored
-// in the "../cd_toolchain_v2.env" configuration file as defined above
+// in a configuration file and then:
+// export IBM_CREDENTIALS_FILE=<name of configuration file>
 //
 var _ = Describe(`CdToolchainV2 Examples Tests`, func() {
 
@@ -49,7 +50,7 @@ var _ = Describe(`CdToolchainV2 Examples Tests`, func() {
 		config       map[string]string
 
 		// Variables to hold link values
-		toolIDLink      string
+		toolIDLink string
 		toolchainIDLink string
 	)
 
@@ -198,7 +199,6 @@ var _ = Describe(`CdToolchainV2 Examples Tests`, func() {
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
 			Expect(toolchain).ToNot(BeNil())
-
 		})
 		It(`UpdateToolchain request example`, func() {
 			fmt.Println("\nUpdateToolchain() result:")
@@ -226,7 +226,6 @@ var _ = Describe(`CdToolchainV2 Examples Tests`, func() {
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
 			Expect(toolchainPatch).ToNot(BeNil())
-
 		})
 		It(`ListTools request example`, func() {
 			fmt.Println("\nListTools() result:")
@@ -273,7 +272,6 @@ var _ = Describe(`CdToolchainV2 Examples Tests`, func() {
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
 			Expect(toolchainTool).ToNot(BeNil())
-
 		})
 		It(`UpdateTool request example`, func() {
 			fmt.Println("\nUpdateTool() result:")
@@ -302,7 +300,6 @@ var _ = Describe(`CdToolchainV2 Examples Tests`, func() {
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
 			Expect(toolchainToolPatch).ToNot(BeNil())
-
 		})
 		It(`DeleteTool request example`, func() {
 			// begin-delete_tool
@@ -324,7 +321,6 @@ var _ = Describe(`CdToolchainV2 Examples Tests`, func() {
 
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(204))
-
 		})
 		It(`DeleteToolchain request example`, func() {
 			// begin-delete_toolchain
@@ -345,7 +341,6 @@ var _ = Describe(`CdToolchainV2 Examples Tests`, func() {
 
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(204))
-
 		})
 	})
 })

--- a/cdtoolchainv2/cd_toolchain_v2_integration_test.go
+++ b/cdtoolchainv2/cd_toolchain_v2_integration_test.go
@@ -125,7 +125,7 @@ var _ = Describe(`CdToolchainV2 Integration Tests`, func() {
 				ToolchainID: &toolchainIDLink,
 				ToolTypeID: core.StringPtr("draservicebroker"),
 				Name: core.StringPtr("testString"),
-				Parameters: make(map[string]interface{}),
+				Parameters: map[string]interface{}{"anyKey": "anyValue"},
 			}
 
 			toolchainToolPost, response, err := cdToolchainService.CreateTool(createToolOptions)
@@ -146,7 +146,6 @@ var _ = Describe(`CdToolchainV2 Integration Tests`, func() {
 			listToolchainsOptions := &cdtoolchainv2.ListToolchainsOptions{
 				ResourceGroupID: core.StringPtr("testString"),
 				Limit: core.Int64Ptr(int64(10)),
-				Offset: core.Int64Ptr(int64(0)),
 				Start: core.StringPtr("testString"),
 			}
 
@@ -174,7 +173,6 @@ var _ = Describe(`CdToolchainV2 Integration Tests`, func() {
 			listToolchainsOptions := &cdtoolchainv2.ListToolchainsOptions{
 				ResourceGroupID: core.StringPtr("testString"),
 				Limit: core.Int64Ptr(int64(10)),
-				Offset: core.Int64Ptr(int64(0)),
 			}
 
 			// Test GetNext().
@@ -252,7 +250,6 @@ var _ = Describe(`CdToolchainV2 Integration Tests`, func() {
 			listToolsOptions := &cdtoolchainv2.ListToolsOptions{
 				ToolchainID: &toolchainIDLink,
 				Limit: core.Int64Ptr(int64(10)),
-				Offset: core.Int64Ptr(int64(0)),
 				Start: core.StringPtr("testString"),
 			}
 
@@ -280,7 +277,6 @@ var _ = Describe(`CdToolchainV2 Integration Tests`, func() {
 			listToolsOptions := &cdtoolchainv2.ListToolsOptions{
 				ToolchainID: &toolchainIDLink,
 				Limit: core.Int64Ptr(int64(10)),
-				Offset: core.Int64Ptr(int64(0)),
 			}
 
 			// Test GetNext().
@@ -335,7 +331,7 @@ var _ = Describe(`CdToolchainV2 Integration Tests`, func() {
 			toolchainToolPrototypePatchModel := &cdtoolchainv2.ToolchainToolPrototypePatch{
 				Name: core.StringPtr("MyTool"),
 				ToolTypeID: core.StringPtr("draservicebroker"),
-				Parameters: make(map[string]interface{}),
+				Parameters: map[string]interface{}{"anyKey": "anyValue"},
 			}
 			toolchainToolPrototypePatchModelAsPatch, asPatchErr := toolchainToolPrototypePatchModel.AsPatch()
 			Expect(asPatchErr).To(BeNil())

--- a/cdtoolchainv2/cd_toolchain_v2_test.go
+++ b/cdtoolchainv2/cd_toolchain_v2_test.go
@@ -211,7 +211,6 @@ var _ = Describe(`CdToolchainV2`, func() {
 					Expect(req.Method).To(Equal("GET"))
 					Expect(req.URL.Query()["resource_group_id"]).To(Equal([]string{"testString"}))
 					Expect(req.URL.Query()["limit"]).To(Equal([]string{fmt.Sprint(int64(10))}))
-					Expect(req.URL.Query()["offset"]).To(Equal([]string{fmt.Sprint(int64(0))}))
 					Expect(req.URL.Query()["start"]).To(Equal([]string{"testString"}))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
@@ -230,7 +229,6 @@ var _ = Describe(`CdToolchainV2`, func() {
 				listToolchainsOptionsModel := new(cdtoolchainv2.ListToolchainsOptions)
 				listToolchainsOptionsModel.ResourceGroupID = core.StringPtr("testString")
 				listToolchainsOptionsModel.Limit = core.Int64Ptr(int64(10))
-				listToolchainsOptionsModel.Offset = core.Int64Ptr(int64(0))
 				listToolchainsOptionsModel.Start = core.StringPtr("testString")
 				listToolchainsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
@@ -264,7 +262,6 @@ var _ = Describe(`CdToolchainV2`, func() {
 
 					Expect(req.URL.Query()["resource_group_id"]).To(Equal([]string{"testString"}))
 					Expect(req.URL.Query()["limit"]).To(Equal([]string{fmt.Sprint(int64(10))}))
-					Expect(req.URL.Query()["offset"]).To(Equal([]string{fmt.Sprint(int64(0))}))
 					Expect(req.URL.Query()["start"]).To(Equal([]string{"testString"}))
 					// Sleep a short time to support a timeout test
 					time.Sleep(100 * time.Millisecond)
@@ -272,7 +269,7 @@ var _ = Describe(`CdToolchainV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"total_count": 10, "limit": 5, "offset": 6, "first": {"href": "Href"}, "previous": {"start": "Start", "href": "Href"}, "next": {"start": "Start", "href": "Href"}, "last": {"start": "Start", "href": "Href"}, "toolchains": [{"id": "ID", "name": "Name", "description": "Description", "account_id": "AccountID", "location": "Location", "resource_group_id": "ResourceGroupID", "crn": "CRN", "href": "Href", "ui_href": "UIHref", "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "tags": ["Tags"]}]}`)
+					fmt.Fprintf(res, "%s", `{"total_count": 10, "limit": 5, "first": {"href": "Href"}, "previous": {"start": "Start", "href": "Href"}, "next": {"start": "Start", "href": "Href"}, "last": {"start": "Start", "href": "Href"}, "toolchains": [{"id": "ID", "name": "Name", "description": "Description", "account_id": "AccountID", "location": "Location", "resource_group_id": "ResourceGroupID", "crn": "CRN", "href": "Href", "ui_href": "UIHref", "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "tags": ["Tags"]}]}`)
 				}))
 			})
 			It(`Invoke ListToolchains successfully with retries`, func() {
@@ -288,7 +285,6 @@ var _ = Describe(`CdToolchainV2`, func() {
 				listToolchainsOptionsModel := new(cdtoolchainv2.ListToolchainsOptions)
 				listToolchainsOptionsModel.ResourceGroupID = core.StringPtr("testString")
 				listToolchainsOptionsModel.Limit = core.Int64Ptr(int64(10))
-				listToolchainsOptionsModel.Offset = core.Int64Ptr(int64(0))
 				listToolchainsOptionsModel.Start = core.StringPtr("testString")
 				listToolchainsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -328,12 +324,11 @@ var _ = Describe(`CdToolchainV2`, func() {
 
 					Expect(req.URL.Query()["resource_group_id"]).To(Equal([]string{"testString"}))
 					Expect(req.URL.Query()["limit"]).To(Equal([]string{fmt.Sprint(int64(10))}))
-					Expect(req.URL.Query()["offset"]).To(Equal([]string{fmt.Sprint(int64(0))}))
 					Expect(req.URL.Query()["start"]).To(Equal([]string{"testString"}))
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"total_count": 10, "limit": 5, "offset": 6, "first": {"href": "Href"}, "previous": {"start": "Start", "href": "Href"}, "next": {"start": "Start", "href": "Href"}, "last": {"start": "Start", "href": "Href"}, "toolchains": [{"id": "ID", "name": "Name", "description": "Description", "account_id": "AccountID", "location": "Location", "resource_group_id": "ResourceGroupID", "crn": "CRN", "href": "Href", "ui_href": "UIHref", "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "tags": ["Tags"]}]}`)
+					fmt.Fprintf(res, "%s", `{"total_count": 10, "limit": 5, "first": {"href": "Href"}, "previous": {"start": "Start", "href": "Href"}, "next": {"start": "Start", "href": "Href"}, "last": {"start": "Start", "href": "Href"}, "toolchains": [{"id": "ID", "name": "Name", "description": "Description", "account_id": "AccountID", "location": "Location", "resource_group_id": "ResourceGroupID", "crn": "CRN", "href": "Href", "ui_href": "UIHref", "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "tags": ["Tags"]}]}`)
 				}))
 			})
 			It(`Invoke ListToolchains successfully`, func() {
@@ -354,7 +349,6 @@ var _ = Describe(`CdToolchainV2`, func() {
 				listToolchainsOptionsModel := new(cdtoolchainv2.ListToolchainsOptions)
 				listToolchainsOptionsModel.ResourceGroupID = core.StringPtr("testString")
 				listToolchainsOptionsModel.Limit = core.Int64Ptr(int64(10))
-				listToolchainsOptionsModel.Offset = core.Int64Ptr(int64(0))
 				listToolchainsOptionsModel.Start = core.StringPtr("testString")
 				listToolchainsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -377,7 +371,6 @@ var _ = Describe(`CdToolchainV2`, func() {
 				listToolchainsOptionsModel := new(cdtoolchainv2.ListToolchainsOptions)
 				listToolchainsOptionsModel.ResourceGroupID = core.StringPtr("testString")
 				listToolchainsOptionsModel.Limit = core.Int64Ptr(int64(10))
-				listToolchainsOptionsModel.Offset = core.Int64Ptr(int64(0))
 				listToolchainsOptionsModel.Start = core.StringPtr("testString")
 				listToolchainsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
@@ -421,7 +414,6 @@ var _ = Describe(`CdToolchainV2`, func() {
 				listToolchainsOptionsModel := new(cdtoolchainv2.ListToolchainsOptions)
 				listToolchainsOptionsModel.ResourceGroupID = core.StringPtr("testString")
 				listToolchainsOptionsModel.Limit = core.Int64Ptr(int64(10))
-				listToolchainsOptionsModel.Offset = core.Int64Ptr(int64(0))
 				listToolchainsOptionsModel.Start = core.StringPtr("testString")
 				listToolchainsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -490,7 +482,6 @@ var _ = Describe(`CdToolchainV2`, func() {
 				listToolchainsOptionsModel := &cdtoolchainv2.ListToolchainsOptions{
 					ResourceGroupID: core.StringPtr("testString"),
 					Limit: core.Int64Ptr(int64(10)),
-					Offset: core.Int64Ptr(int64(0)),
 				}
 
 				pager, err := cdToolchainService.NewToolchainsPager(listToolchainsOptionsModel)
@@ -517,7 +508,6 @@ var _ = Describe(`CdToolchainV2`, func() {
 				listToolchainsOptionsModel := &cdtoolchainv2.ListToolchainsOptions{
 					ResourceGroupID: core.StringPtr("testString"),
 					Limit: core.Int64Ptr(int64(10)),
-					Offset: core.Int64Ptr(int64(0)),
 				}
 
 				pager, err := cdToolchainService.NewToolchainsPager(listToolchainsOptionsModel)
@@ -1360,7 +1350,6 @@ var _ = Describe(`CdToolchainV2`, func() {
 					Expect(req.URL.EscapedPath()).To(Equal(listToolsPath))
 					Expect(req.Method).To(Equal("GET"))
 					Expect(req.URL.Query()["limit"]).To(Equal([]string{fmt.Sprint(int64(10))}))
-					Expect(req.URL.Query()["offset"]).To(Equal([]string{fmt.Sprint(int64(0))}))
 					Expect(req.URL.Query()["start"]).To(Equal([]string{"testString"}))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
@@ -1379,7 +1368,6 @@ var _ = Describe(`CdToolchainV2`, func() {
 				listToolsOptionsModel := new(cdtoolchainv2.ListToolsOptions)
 				listToolsOptionsModel.ToolchainID = core.StringPtr("testString")
 				listToolsOptionsModel.Limit = core.Int64Ptr(int64(10))
-				listToolsOptionsModel.Offset = core.Int64Ptr(int64(0))
 				listToolsOptionsModel.Start = core.StringPtr("testString")
 				listToolsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
@@ -1412,7 +1400,6 @@ var _ = Describe(`CdToolchainV2`, func() {
 					Expect(req.Method).To(Equal("GET"))
 
 					Expect(req.URL.Query()["limit"]).To(Equal([]string{fmt.Sprint(int64(10))}))
-					Expect(req.URL.Query()["offset"]).To(Equal([]string{fmt.Sprint(int64(0))}))
 					Expect(req.URL.Query()["start"]).To(Equal([]string{"testString"}))
 					// Sleep a short time to support a timeout test
 					time.Sleep(100 * time.Millisecond)
@@ -1420,7 +1407,7 @@ var _ = Describe(`CdToolchainV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"limit": 5, "total_count": 10, "offset": 6, "first": {"href": "Href"}, "previous": {"start": "Start", "href": "Href"}, "next": {"start": "Start", "href": "Href"}, "last": {"start": "Start", "href": "Href"}, "tools": [{"id": "ID", "resource_group_id": "ResourceGroupID", "crn": "CRN", "tool_type_id": "ToolTypeID", "toolchain_id": "ToolchainID", "toolchain_crn": "ToolchainCRN", "href": "Href", "referent": {"ui_href": "UIHref", "api_href": "APIHref"}, "name": "Name", "updated_at": "2019-01-01T12:00:00.000Z", "parameters": {"anyKey": "anyValue"}, "state": "configured"}]}`)
+					fmt.Fprintf(res, "%s", `{"limit": 5, "total_count": 10, "first": {"href": "Href"}, "previous": {"start": "Start", "href": "Href"}, "next": {"start": "Start", "href": "Href"}, "last": {"start": "Start", "href": "Href"}, "tools": [{"id": "ID", "resource_group_id": "ResourceGroupID", "crn": "CRN", "tool_type_id": "ToolTypeID", "toolchain_id": "ToolchainID", "toolchain_crn": "ToolchainCRN", "href": "Href", "referent": {"ui_href": "UIHref", "api_href": "APIHref"}, "name": "Name", "updated_at": "2019-01-01T12:00:00.000Z", "parameters": {"anyKey": "anyValue"}, "state": "configured"}]}`)
 				}))
 			})
 			It(`Invoke ListTools successfully with retries`, func() {
@@ -1436,7 +1423,6 @@ var _ = Describe(`CdToolchainV2`, func() {
 				listToolsOptionsModel := new(cdtoolchainv2.ListToolsOptions)
 				listToolsOptionsModel.ToolchainID = core.StringPtr("testString")
 				listToolsOptionsModel.Limit = core.Int64Ptr(int64(10))
-				listToolsOptionsModel.Offset = core.Int64Ptr(int64(0))
 				listToolsOptionsModel.Start = core.StringPtr("testString")
 				listToolsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -1475,12 +1461,11 @@ var _ = Describe(`CdToolchainV2`, func() {
 					Expect(req.Method).To(Equal("GET"))
 
 					Expect(req.URL.Query()["limit"]).To(Equal([]string{fmt.Sprint(int64(10))}))
-					Expect(req.URL.Query()["offset"]).To(Equal([]string{fmt.Sprint(int64(0))}))
 					Expect(req.URL.Query()["start"]).To(Equal([]string{"testString"}))
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"limit": 5, "total_count": 10, "offset": 6, "first": {"href": "Href"}, "previous": {"start": "Start", "href": "Href"}, "next": {"start": "Start", "href": "Href"}, "last": {"start": "Start", "href": "Href"}, "tools": [{"id": "ID", "resource_group_id": "ResourceGroupID", "crn": "CRN", "tool_type_id": "ToolTypeID", "toolchain_id": "ToolchainID", "toolchain_crn": "ToolchainCRN", "href": "Href", "referent": {"ui_href": "UIHref", "api_href": "APIHref"}, "name": "Name", "updated_at": "2019-01-01T12:00:00.000Z", "parameters": {"anyKey": "anyValue"}, "state": "configured"}]}`)
+					fmt.Fprintf(res, "%s", `{"limit": 5, "total_count": 10, "first": {"href": "Href"}, "previous": {"start": "Start", "href": "Href"}, "next": {"start": "Start", "href": "Href"}, "last": {"start": "Start", "href": "Href"}, "tools": [{"id": "ID", "resource_group_id": "ResourceGroupID", "crn": "CRN", "tool_type_id": "ToolTypeID", "toolchain_id": "ToolchainID", "toolchain_crn": "ToolchainCRN", "href": "Href", "referent": {"ui_href": "UIHref", "api_href": "APIHref"}, "name": "Name", "updated_at": "2019-01-01T12:00:00.000Z", "parameters": {"anyKey": "anyValue"}, "state": "configured"}]}`)
 				}))
 			})
 			It(`Invoke ListTools successfully`, func() {
@@ -1501,7 +1486,6 @@ var _ = Describe(`CdToolchainV2`, func() {
 				listToolsOptionsModel := new(cdtoolchainv2.ListToolsOptions)
 				listToolsOptionsModel.ToolchainID = core.StringPtr("testString")
 				listToolsOptionsModel.Limit = core.Int64Ptr(int64(10))
-				listToolsOptionsModel.Offset = core.Int64Ptr(int64(0))
 				listToolsOptionsModel.Start = core.StringPtr("testString")
 				listToolsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -1524,7 +1508,6 @@ var _ = Describe(`CdToolchainV2`, func() {
 				listToolsOptionsModel := new(cdtoolchainv2.ListToolsOptions)
 				listToolsOptionsModel.ToolchainID = core.StringPtr("testString")
 				listToolsOptionsModel.Limit = core.Int64Ptr(int64(10))
-				listToolsOptionsModel.Offset = core.Int64Ptr(int64(0))
 				listToolsOptionsModel.Start = core.StringPtr("testString")
 				listToolsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
@@ -1568,7 +1551,6 @@ var _ = Describe(`CdToolchainV2`, func() {
 				listToolsOptionsModel := new(cdtoolchainv2.ListToolsOptions)
 				listToolsOptionsModel.ToolchainID = core.StringPtr("testString")
 				listToolsOptionsModel.Limit = core.Int64Ptr(int64(10))
-				listToolsOptionsModel.Offset = core.Int64Ptr(int64(0))
 				listToolsOptionsModel.Start = core.StringPtr("testString")
 				listToolsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -1637,7 +1619,6 @@ var _ = Describe(`CdToolchainV2`, func() {
 				listToolsOptionsModel := &cdtoolchainv2.ListToolsOptions{
 					ToolchainID: core.StringPtr("testString"),
 					Limit: core.Int64Ptr(int64(10)),
-					Offset: core.Int64Ptr(int64(0)),
 				}
 
 				pager, err := cdToolchainService.NewToolsPager(listToolsOptionsModel)
@@ -1664,7 +1645,6 @@ var _ = Describe(`CdToolchainV2`, func() {
 				listToolsOptionsModel := &cdtoolchainv2.ListToolsOptions{
 					ToolchainID: core.StringPtr("testString"),
 					Limit: core.Int64Ptr(int64(10)),
-					Offset: core.Int64Ptr(int64(0)),
 				}
 
 				pager, err := cdToolchainService.NewToolsPager(listToolsOptionsModel)
@@ -1704,7 +1684,7 @@ var _ = Describe(`CdToolchainV2`, func() {
 				// Construct an instance of the CreateToolOptions model
 				createToolOptionsModel := new(cdtoolchainv2.CreateToolOptions)
 				createToolOptionsModel.ToolchainID = core.StringPtr("testString")
-				createToolOptionsModel.ToolTypeID = core.StringPtr("slack")
+				createToolOptionsModel.ToolTypeID = core.StringPtr("draservicebroker")
 				createToolOptionsModel.Name = core.StringPtr("testString")
 				createToolOptionsModel.Parameters = map[string]interface{}{"anyKey": "anyValue"}
 				createToolOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1774,7 +1754,7 @@ var _ = Describe(`CdToolchainV2`, func() {
 				// Construct an instance of the CreateToolOptions model
 				createToolOptionsModel := new(cdtoolchainv2.CreateToolOptions)
 				createToolOptionsModel.ToolchainID = core.StringPtr("testString")
-				createToolOptionsModel.ToolTypeID = core.StringPtr("slack")
+				createToolOptionsModel.ToolTypeID = core.StringPtr("draservicebroker")
 				createToolOptionsModel.Name = core.StringPtr("testString")
 				createToolOptionsModel.Parameters = map[string]interface{}{"anyKey": "anyValue"}
 				createToolOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1852,7 +1832,7 @@ var _ = Describe(`CdToolchainV2`, func() {
 				// Construct an instance of the CreateToolOptions model
 				createToolOptionsModel := new(cdtoolchainv2.CreateToolOptions)
 				createToolOptionsModel.ToolchainID = core.StringPtr("testString")
-				createToolOptionsModel.ToolTypeID = core.StringPtr("slack")
+				createToolOptionsModel.ToolTypeID = core.StringPtr("draservicebroker")
 				createToolOptionsModel.Name = core.StringPtr("testString")
 				createToolOptionsModel.Parameters = map[string]interface{}{"anyKey": "anyValue"}
 				createToolOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1875,7 +1855,7 @@ var _ = Describe(`CdToolchainV2`, func() {
 				// Construct an instance of the CreateToolOptions model
 				createToolOptionsModel := new(cdtoolchainv2.CreateToolOptions)
 				createToolOptionsModel.ToolchainID = core.StringPtr("testString")
-				createToolOptionsModel.ToolTypeID = core.StringPtr("slack")
+				createToolOptionsModel.ToolTypeID = core.StringPtr("draservicebroker")
 				createToolOptionsModel.Name = core.StringPtr("testString")
 				createToolOptionsModel.Parameters = map[string]interface{}{"anyKey": "anyValue"}
 				createToolOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1919,7 +1899,7 @@ var _ = Describe(`CdToolchainV2`, func() {
 				// Construct an instance of the CreateToolOptions model
 				createToolOptionsModel := new(cdtoolchainv2.CreateToolOptions)
 				createToolOptionsModel.ToolchainID = core.StringPtr("testString")
-				createToolOptionsModel.ToolTypeID = core.StringPtr("slack")
+				createToolOptionsModel.ToolTypeID = core.StringPtr("draservicebroker")
 				createToolOptionsModel.Name = core.StringPtr("testString")
 				createToolOptionsModel.Parameters = map[string]interface{}{"anyKey": "anyValue"}
 				createToolOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -2250,7 +2230,7 @@ var _ = Describe(`CdToolchainV2`, func() {
 				// Construct an instance of the ToolchainToolPrototypePatch model
 				toolchainToolPrototypePatchModel := new(cdtoolchainv2.ToolchainToolPrototypePatch)
 				toolchainToolPrototypePatchModel.Name = core.StringPtr("MyTool")
-				toolchainToolPrototypePatchModel.ToolTypeID = core.StringPtr("todolist")
+				toolchainToolPrototypePatchModel.ToolTypeID = core.StringPtr("draservicebroker")
 				toolchainToolPrototypePatchModel.Parameters = map[string]interface{}{"anyKey": "anyValue"}
 				toolchainToolPrototypePatchModelAsPatch, asPatchErr := toolchainToolPrototypePatchModel.AsPatch()
 				Expect(asPatchErr).To(BeNil())
@@ -2327,7 +2307,7 @@ var _ = Describe(`CdToolchainV2`, func() {
 				// Construct an instance of the ToolchainToolPrototypePatch model
 				toolchainToolPrototypePatchModel := new(cdtoolchainv2.ToolchainToolPrototypePatch)
 				toolchainToolPrototypePatchModel.Name = core.StringPtr("MyTool")
-				toolchainToolPrototypePatchModel.ToolTypeID = core.StringPtr("todolist")
+				toolchainToolPrototypePatchModel.ToolTypeID = core.StringPtr("draservicebroker")
 				toolchainToolPrototypePatchModel.Parameters = map[string]interface{}{"anyKey": "anyValue"}
 				toolchainToolPrototypePatchModelAsPatch, asPatchErr := toolchainToolPrototypePatchModel.AsPatch()
 				Expect(asPatchErr).To(BeNil())
@@ -2412,7 +2392,7 @@ var _ = Describe(`CdToolchainV2`, func() {
 				// Construct an instance of the ToolchainToolPrototypePatch model
 				toolchainToolPrototypePatchModel := new(cdtoolchainv2.ToolchainToolPrototypePatch)
 				toolchainToolPrototypePatchModel.Name = core.StringPtr("MyTool")
-				toolchainToolPrototypePatchModel.ToolTypeID = core.StringPtr("todolist")
+				toolchainToolPrototypePatchModel.ToolTypeID = core.StringPtr("draservicebroker")
 				toolchainToolPrototypePatchModel.Parameters = map[string]interface{}{"anyKey": "anyValue"}
 				toolchainToolPrototypePatchModelAsPatch, asPatchErr := toolchainToolPrototypePatchModel.AsPatch()
 				Expect(asPatchErr).To(BeNil())
@@ -2442,7 +2422,7 @@ var _ = Describe(`CdToolchainV2`, func() {
 				// Construct an instance of the ToolchainToolPrototypePatch model
 				toolchainToolPrototypePatchModel := new(cdtoolchainv2.ToolchainToolPrototypePatch)
 				toolchainToolPrototypePatchModel.Name = core.StringPtr("MyTool")
-				toolchainToolPrototypePatchModel.ToolTypeID = core.StringPtr("todolist")
+				toolchainToolPrototypePatchModel.ToolTypeID = core.StringPtr("draservicebroker")
 				toolchainToolPrototypePatchModel.Parameters = map[string]interface{}{"anyKey": "anyValue"}
 				toolchainToolPrototypePatchModelAsPatch, asPatchErr := toolchainToolPrototypePatchModel.AsPatch()
 				Expect(asPatchErr).To(BeNil())
@@ -2493,7 +2473,7 @@ var _ = Describe(`CdToolchainV2`, func() {
 				// Construct an instance of the ToolchainToolPrototypePatch model
 				toolchainToolPrototypePatchModel := new(cdtoolchainv2.ToolchainToolPrototypePatch)
 				toolchainToolPrototypePatchModel.Name = core.StringPtr("MyTool")
-				toolchainToolPrototypePatchModel.ToolTypeID = core.StringPtr("todolist")
+				toolchainToolPrototypePatchModel.ToolTypeID = core.StringPtr("draservicebroker")
 				toolchainToolPrototypePatchModel.Parameters = map[string]interface{}{"anyKey": "anyValue"}
 				toolchainToolPrototypePatchModelAsPatch, asPatchErr := toolchainToolPrototypePatchModel.AsPatch()
 				Expect(asPatchErr).To(BeNil())
@@ -2527,16 +2507,16 @@ var _ = Describe(`CdToolchainV2`, func() {
 			It(`Invoke NewCreateToolOptions successfully`, func() {
 				// Construct an instance of the CreateToolOptions model
 				toolchainID := "testString"
-				createToolOptionsToolTypeID := "slack"
+				createToolOptionsToolTypeID := "draservicebroker"
 				createToolOptionsModel := cdToolchainService.NewCreateToolOptions(toolchainID, createToolOptionsToolTypeID)
 				createToolOptionsModel.SetToolchainID("testString")
-				createToolOptionsModel.SetToolTypeID("slack")
+				createToolOptionsModel.SetToolTypeID("draservicebroker")
 				createToolOptionsModel.SetName("testString")
 				createToolOptionsModel.SetParameters(map[string]interface{}{"anyKey": "anyValue"})
 				createToolOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(createToolOptionsModel).ToNot(BeNil())
 				Expect(createToolOptionsModel.ToolchainID).To(Equal(core.StringPtr("testString")))
-				Expect(createToolOptionsModel.ToolTypeID).To(Equal(core.StringPtr("slack")))
+				Expect(createToolOptionsModel.ToolTypeID).To(Equal(core.StringPtr("draservicebroker")))
 				Expect(createToolOptionsModel.Name).To(Equal(core.StringPtr("testString")))
 				Expect(createToolOptionsModel.Parameters).To(Equal(map[string]interface{}{"anyKey": "anyValue"}))
 				Expect(createToolOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
@@ -2608,13 +2588,11 @@ var _ = Describe(`CdToolchainV2`, func() {
 				listToolchainsOptionsModel := cdToolchainService.NewListToolchainsOptions(resourceGroupID)
 				listToolchainsOptionsModel.SetResourceGroupID("testString")
 				listToolchainsOptionsModel.SetLimit(int64(10))
-				listToolchainsOptionsModel.SetOffset(int64(0))
 				listToolchainsOptionsModel.SetStart("testString")
 				listToolchainsOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(listToolchainsOptionsModel).ToNot(BeNil())
 				Expect(listToolchainsOptionsModel.ResourceGroupID).To(Equal(core.StringPtr("testString")))
 				Expect(listToolchainsOptionsModel.Limit).To(Equal(core.Int64Ptr(int64(10))))
-				Expect(listToolchainsOptionsModel.Offset).To(Equal(core.Int64Ptr(int64(0))))
 				Expect(listToolchainsOptionsModel.Start).To(Equal(core.StringPtr("testString")))
 				Expect(listToolchainsOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
@@ -2624,13 +2602,11 @@ var _ = Describe(`CdToolchainV2`, func() {
 				listToolsOptionsModel := cdToolchainService.NewListToolsOptions(toolchainID)
 				listToolsOptionsModel.SetToolchainID("testString")
 				listToolsOptionsModel.SetLimit(int64(10))
-				listToolsOptionsModel.SetOffset(int64(0))
 				listToolsOptionsModel.SetStart("testString")
 				listToolsOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(listToolsOptionsModel).ToNot(BeNil())
 				Expect(listToolsOptionsModel.ToolchainID).To(Equal(core.StringPtr("testString")))
 				Expect(listToolsOptionsModel.Limit).To(Equal(core.Int64Ptr(int64(10))))
-				Expect(listToolsOptionsModel.Offset).To(Equal(core.Int64Ptr(int64(0))))
 				Expect(listToolsOptionsModel.Start).To(Equal(core.StringPtr("testString")))
 				Expect(listToolsOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})


### PR DESCRIPTION
Signed-off-by: Omar Al Bastami <omar.albastami@ibm.com>

## PR summary
Synced with latest API changes, where `offset` query parameter has been removed from list operations.

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
<!-- Please describe the current behavior that you are modifying. -->
Users can query toolchains or tools by providing an `offset`.

## What is the new behavior?  
<!-- Please describe the new behavior after your change. -->
Users must use `start` parameter to query tools and toolchains.

## Does this PR introduce a breaking change?    
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Apps must no longer call list operations using `offset`, and must use `start` instead.

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->