### PR TITLE
fix(tekton): fix for empty tags and events

### DIFF
--- a/cdtektonpipelinev2/cd_tekton_pipeline_v2.go
+++ b/cdtektonpipelinev2/cd_tekton_pipeline_v2.go
@@ -2748,7 +2748,7 @@ type CreateTektonPipelineTriggerOptions struct {
 	EventListener *string `json:"event_listener" validate:"required"`
 
 	// Trigger tags array.
-	Tags []string `json:"tags,omitempty"`
+	Tags []string `json:"tags"`
 
 	// Worker used to run the trigger. If not specified the trigger will use the default pipeline worker.
 	Worker *WorkerIdentity `json:"worker,omitempty"`
@@ -2781,7 +2781,7 @@ type CreateTektonPipelineTriggerOptions struct {
 	// Only needed for Git triggers. List of events to which a Git trigger listens. Choose one or more from: 'push',
 	// 'pull_request' and 'pull_request_closed'. For SCM repositories that use 'merge request' events, such events map to
 	// the equivalent 'pull request' events.
-	Events []string `json:"events,omitempty"`
+	Events []string `json:"events"`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -5264,7 +5264,7 @@ type Trigger struct {
 	Properties []TriggerProperty `json:"properties,omitempty"`
 
 	// Optional trigger tags array.
-	Tags []string `json:"tags,omitempty"`
+	Tags []string `json:"tags"`
 
 	// Worker used to run the trigger. If not specified the trigger will use the default pipeline worker.
 	Worker *Worker `json:"worker,omitempty"`
@@ -5284,7 +5284,7 @@ type Trigger struct {
 	// Only needed for Git triggers. List of events to which a Git trigger listens. Choose one or more from: 'push',
 	// 'pull_request' and 'pull_request_closed'. For SCM repositories that use 'merge request' events, such events map to
 	// the equivalent 'pull request' events.
-	Events []string `json:"events,omitempty"`
+	Events []string `json:"events"`
 
 	// Only needed for timer triggers. Cron expression that indicates when this trigger will activate. Maximum frequency is
 	// every 5 minutes. The string is based on UNIX crontab syntax: minute, hour, day of month, month, day of week.
@@ -5403,7 +5403,7 @@ type TriggerPatch struct {
 	EventListener *string `json:"event_listener,omitempty"`
 
 	// Trigger tags array. Optional tags for the trigger.
-	Tags []string `json:"tags,omitempty"`
+	Tags []string `json:"tags"`
 
 	// Worker used to run the trigger. If not specified the trigger will use the default pipeline worker.
 	Worker *WorkerIdentity `json:"worker,omitempty"`
@@ -5436,7 +5436,7 @@ type TriggerPatch struct {
 	// Only needed for Git triggers. List of events to which a Git trigger listens. Choose one or more from: 'push',
 	// 'pull_request' and 'pull_request_closed'. For SCM repositories that use 'merge request' events, such events map to
 	// the equivalent 'pull request' events.
-	Events []string `json:"events,omitempty"`
+	Events []string `json:"events"`
 }
 
 // Constants associated with the TriggerPatch.Type property.
@@ -5968,7 +5968,7 @@ type TriggerGenericTrigger struct {
 	Properties []TriggerProperty `json:"properties,omitempty"`
 
 	// Optional trigger tags array.
-	Tags []string `json:"tags,omitempty"`
+	Tags []string `json:"tags"`
 
 	// Worker used to run the trigger. If not specified the trigger will use the default pipeline worker.
 	Worker *Worker `json:"worker,omitempty"`
@@ -6069,7 +6069,7 @@ type TriggerManualTrigger struct {
 	Properties []TriggerProperty `json:"properties,omitempty"`
 
 	// Optional trigger tags array.
-	Tags []string `json:"tags,omitempty"`
+	Tags []string `json:"tags"`
 
 	// Worker used to run the trigger. If not specified the trigger will use the default pipeline worker.
 	Worker *Worker `json:"worker,omitempty"`
@@ -6157,7 +6157,7 @@ type TriggerScmTrigger struct {
 	Properties []TriggerProperty `json:"properties,omitempty"`
 
 	// Optional trigger tags array.
-	Tags []string `json:"tags,omitempty"`
+	Tags []string `json:"tags"`
 
 	// Worker used to run the trigger. If not specified the trigger will use the default pipeline worker.
 	Worker *Worker `json:"worker,omitempty"`
@@ -6177,7 +6177,7 @@ type TriggerScmTrigger struct {
 	// Only needed for Git triggers. List of events to which a Git trigger listens. Choose one or more from: 'push',
 	// 'pull_request' and 'pull_request_closed'. For SCM repositories that use 'merge request' events, such events map to
 	// the equivalent 'pull request' events.
-	Events []string `json:"events,omitempty"`
+	Events []string `json:"events"`
 }
 
 // Constants associated with the TriggerScmTrigger.Events property.
@@ -6271,7 +6271,7 @@ type TriggerTimerTrigger struct {
 	Properties []TriggerProperty `json:"properties,omitempty"`
 
 	// Optional trigger tags array.
-	Tags []string `json:"tags,omitempty"`
+	Tags []string `json:"tags"`
 
 	// Worker used to run the trigger. If not specified the trigger will use the default pipeline worker.
 	Worker *Worker `json:"worker,omitempty"`


### PR DESCRIPTION
Signed-off-by: Brian Gleeson <brian.gleeson@ie.ibm.com>

## PR summary
Related issue: https://github.ibm.com/one-pipeline/adoption-issues/issues/1110

When attempting to remove a `tags: ["tag1","tag2"]` property from a Trigger, or an `events: ["push"]` property from a SCM Trigger, the removal would fail and the tags/events left in place in the trigger. This was because of the `omitempty` tag included for those proeprties in the generated Go SDK. By adding the `x-sdk-go-serialize-empty` annotation for the Tags and Events properties in the openAPI spec, the `omitempty` is excluded for these properties and the issue is fixed


## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->