### PR TITLE
fix(tekton): Fix PipelineRun trigger properties

### DIFF
--- a/cdtektonpipelinev2/cd_tekton_pipeline_v2.go
+++ b/cdtektonpipelinev2/cd_tekton_pipeline_v2.go
@@ -2673,11 +2673,11 @@ type CreateTektonPipelineRunOptions struct {
 
 	// An object containing string values only that provides additional `text` properties, or overrides existing
 	// pipeline/trigger properties, to use for the created run.
-	TriggerProperties []Property `json:"trigger_properties,omitempty"`
+	TriggerProperties map[string]interface{} `json:"trigger_properties,omitempty"`
 
 	// An object containing string values only that provides additional `secure` properties, or overrides existing `secure`
 	// pipeline/trigger properties, to use for the created run.
-	SecureTriggerProperties []Property `json:"secure_trigger_properties,omitempty"`
+	SecureTriggerProperties map[string]interface{} `json:"secure_trigger_properties,omitempty"`
 
 	// An object containing string values only that provides the request headers. Use `$(header.header_key_name)` to access
 	// it in a TriggerBinding. Most commonly used as part of a Generic Webhook to provide a verification token or signature
@@ -2715,13 +2715,13 @@ func (_options *CreateTektonPipelineRunOptions) SetTriggerName(triggerName strin
 }
 
 // SetTriggerProperties : Allow user to set TriggerProperties
-func (_options *CreateTektonPipelineRunOptions) SetTriggerProperties(triggerProperties []Property) *CreateTektonPipelineRunOptions {
+func (_options *CreateTektonPipelineRunOptions) SetTriggerProperties(triggerProperties map[string]interface{}) *CreateTektonPipelineRunOptions {
 	_options.TriggerProperties = triggerProperties
 	return _options
 }
 
 // SetSecureTriggerProperties : Allow user to set SecureTriggerProperties
-func (_options *CreateTektonPipelineRunOptions) SetSecureTriggerProperties(secureTriggerProperties []Property) *CreateTektonPipelineRunOptions {
+func (_options *CreateTektonPipelineRunOptions) SetSecureTriggerProperties(secureTriggerProperties map[string]interface{}) *CreateTektonPipelineRunOptions {
 	_options.SecureTriggerProperties = secureTriggerProperties
 	return _options
 }
@@ -4377,11 +4377,11 @@ type PipelineRunTrigger struct {
 
 	// An object containing string values only that provides additional `text` properties, or overrides existing
 	// pipeline/trigger properties, to use for the created run.
-	Properties []Property `json:"properties,omitempty"`
+	Properties map[string]interface{} `json:"properties,omitempty"`
 
 	// An object containing string values only that provides additional `secure` properties, or overrides existing `secure`
 	// pipeline/trigger properties, to use for the created run.
-	SecureProperties []Property `json:"secure_properties,omitempty"`
+	SecureProperties map[string]interface{} `json:"secure_properties,omitempty"`
 
 	// An object containing string values only that provides the request headers. Use `$(header.header_key_name)` to access
 	// it in a TriggerBinding. Most commonly used as part of a Generic Webhook to provide a verification token or signature
@@ -4409,11 +4409,11 @@ func UnmarshalPipelineRunTrigger(m map[string]json.RawMessage, result interface{
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalModel(m, "properties", &obj.Properties, UnmarshalProperty)
+	err = core.UnmarshalPrimitive(m, "properties", &obj.Properties)
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalModel(m, "secure_properties", &obj.SecureProperties, UnmarshalProperty)
+	err = core.UnmarshalPrimitive(m, "secure_properties", &obj.SecureProperties)
 	if err != nil {
 		return
 	}
@@ -4574,16 +4574,6 @@ const (
 	PropertyTypeSingleSelectConst = "single_select"
 	PropertyTypeTextConst = "text"
 )
-
-// NewProperty : Instantiate Property (Generic Model Constructor)
-func (*CdTektonPipelineV2) NewProperty(name string, typeVar string) (_model *Property, err error) {
-	_model = &Property{
-		Name: core.StringPtr(name),
-		Type: core.StringPtr(typeVar),
-	}
-	err = core.ValidateStruct(_model, "required parameters")
-	return
-}
 
 // UnmarshalProperty unmarshals an instance of Property from the specified map of raw messages.
 func UnmarshalProperty(m map[string]json.RawMessage, result interface{}) (err error) {

--- a/cdtektonpipelinev2/cd_tekton_pipeline_v2_examples_test.go
+++ b/cdtektonpipelinev2/cd_tekton_pipeline_v2_examples_test.go
@@ -212,15 +212,8 @@ var _ = Describe(`CdTektonPipelineV2 Examples Tests`, func() {
 			fmt.Println("\nCreateTektonPipelineRun() result:")
 			// begin-create_tekton_pipeline_run
 
-			propertyModel := &cdtektonpipelinev2.Property{
-				Name: core.StringPtr("testString"),
-				Type: core.StringPtr("secure"),
-			}
-
 			pipelineRunTriggerModel := &cdtektonpipelinev2.PipelineRunTrigger{
 				Name: core.StringPtr("Manual Trigger 1"),
-				Properties: []cdtektonpipelinev2.Property{*propertyModel},
-				SecureProperties: []cdtektonpipelinev2.Property{*propertyModel},
 			}
 
 			createTektonPipelineRunOptions := cdTektonPipelineService.NewCreateTektonPipelineRunOptions(

--- a/cdtektonpipelinev2/cd_tekton_pipeline_v2_test.go
+++ b/cdtektonpipelinev2/cd_tekton_pipeline_v2_test.go
@@ -1449,20 +1449,11 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(serviceErr).To(BeNil())
 				Expect(cdTektonPipelineService).ToNot(BeNil())
 
-				// Construct an instance of the Property model
-				propertyModel := new(cdtektonpipelinev2.Property)
-				propertyModel.Name = core.StringPtr("testString")
-				propertyModel.Value = core.StringPtr("testString")
-				propertyModel.Href = core.StringPtr("testString")
-				propertyModel.Enum = []string{"testString"}
-				propertyModel.Type = core.StringPtr("secure")
-				propertyModel.Path = core.StringPtr("testString")
-
 				// Construct an instance of the PipelineRunTrigger model
 				pipelineRunTriggerModel := new(cdtektonpipelinev2.PipelineRunTrigger)
 				pipelineRunTriggerModel.Name = core.StringPtr("Manual Trigger 1")
-				pipelineRunTriggerModel.Properties = []cdtektonpipelinev2.Property{*propertyModel}
-				pipelineRunTriggerModel.SecureProperties = []cdtektonpipelinev2.Property{*propertyModel}
+				pipelineRunTriggerModel.Properties = map[string]interface{}{"anyKey": "anyValue"}
+				pipelineRunTriggerModel.SecureProperties = map[string]interface{}{"anyKey": "anyValue"}
 				pipelineRunTriggerModel.HeadersVar = map[string]interface{}{"anyKey": "anyValue"}
 				pipelineRunTriggerModel.Body = map[string]interface{}{"anyKey": "anyValue"}
 
@@ -1470,8 +1461,8 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelineRunOptionsModel := new(cdtektonpipelinev2.CreateTektonPipelineRunOptions)
 				createTektonPipelineRunOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				createTektonPipelineRunOptionsModel.TriggerName = core.StringPtr("testString")
-				createTektonPipelineRunOptionsModel.TriggerProperties = []cdtektonpipelinev2.Property{*propertyModel}
-				createTektonPipelineRunOptionsModel.SecureTriggerProperties = []cdtektonpipelinev2.Property{*propertyModel}
+				createTektonPipelineRunOptionsModel.TriggerProperties = map[string]interface{}{"anyKey": "anyValue"}
+				createTektonPipelineRunOptionsModel.SecureTriggerProperties = map[string]interface{}{"anyKey": "anyValue"}
 				createTektonPipelineRunOptionsModel.TriggerHeaders = map[string]interface{}{"anyKey": "anyValue"}
 				createTektonPipelineRunOptionsModel.TriggerBody = map[string]interface{}{"anyKey": "anyValue"}
 				createTektonPipelineRunOptionsModel.Trigger = pipelineRunTriggerModel
@@ -1539,20 +1530,11 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(cdTektonPipelineService).ToNot(BeNil())
 				cdTektonPipelineService.EnableRetries(0, 0)
 
-				// Construct an instance of the Property model
-				propertyModel := new(cdtektonpipelinev2.Property)
-				propertyModel.Name = core.StringPtr("testString")
-				propertyModel.Value = core.StringPtr("testString")
-				propertyModel.Href = core.StringPtr("testString")
-				propertyModel.Enum = []string{"testString"}
-				propertyModel.Type = core.StringPtr("secure")
-				propertyModel.Path = core.StringPtr("testString")
-
 				// Construct an instance of the PipelineRunTrigger model
 				pipelineRunTriggerModel := new(cdtektonpipelinev2.PipelineRunTrigger)
 				pipelineRunTriggerModel.Name = core.StringPtr("Manual Trigger 1")
-				pipelineRunTriggerModel.Properties = []cdtektonpipelinev2.Property{*propertyModel}
-				pipelineRunTriggerModel.SecureProperties = []cdtektonpipelinev2.Property{*propertyModel}
+				pipelineRunTriggerModel.Properties = map[string]interface{}{"anyKey": "anyValue"}
+				pipelineRunTriggerModel.SecureProperties = map[string]interface{}{"anyKey": "anyValue"}
 				pipelineRunTriggerModel.HeadersVar = map[string]interface{}{"anyKey": "anyValue"}
 				pipelineRunTriggerModel.Body = map[string]interface{}{"anyKey": "anyValue"}
 
@@ -1560,8 +1542,8 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelineRunOptionsModel := new(cdtektonpipelinev2.CreateTektonPipelineRunOptions)
 				createTektonPipelineRunOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				createTektonPipelineRunOptionsModel.TriggerName = core.StringPtr("testString")
-				createTektonPipelineRunOptionsModel.TriggerProperties = []cdtektonpipelinev2.Property{*propertyModel}
-				createTektonPipelineRunOptionsModel.SecureTriggerProperties = []cdtektonpipelinev2.Property{*propertyModel}
+				createTektonPipelineRunOptionsModel.TriggerProperties = map[string]interface{}{"anyKey": "anyValue"}
+				createTektonPipelineRunOptionsModel.SecureTriggerProperties = map[string]interface{}{"anyKey": "anyValue"}
 				createTektonPipelineRunOptionsModel.TriggerHeaders = map[string]interface{}{"anyKey": "anyValue"}
 				createTektonPipelineRunOptionsModel.TriggerBody = map[string]interface{}{"anyKey": "anyValue"}
 				createTektonPipelineRunOptionsModel.Trigger = pipelineRunTriggerModel
@@ -1637,20 +1619,11 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(response).To(BeNil())
 				Expect(result).To(BeNil())
 
-				// Construct an instance of the Property model
-				propertyModel := new(cdtektonpipelinev2.Property)
-				propertyModel.Name = core.StringPtr("testString")
-				propertyModel.Value = core.StringPtr("testString")
-				propertyModel.Href = core.StringPtr("testString")
-				propertyModel.Enum = []string{"testString"}
-				propertyModel.Type = core.StringPtr("secure")
-				propertyModel.Path = core.StringPtr("testString")
-
 				// Construct an instance of the PipelineRunTrigger model
 				pipelineRunTriggerModel := new(cdtektonpipelinev2.PipelineRunTrigger)
 				pipelineRunTriggerModel.Name = core.StringPtr("Manual Trigger 1")
-				pipelineRunTriggerModel.Properties = []cdtektonpipelinev2.Property{*propertyModel}
-				pipelineRunTriggerModel.SecureProperties = []cdtektonpipelinev2.Property{*propertyModel}
+				pipelineRunTriggerModel.Properties = map[string]interface{}{"anyKey": "anyValue"}
+				pipelineRunTriggerModel.SecureProperties = map[string]interface{}{"anyKey": "anyValue"}
 				pipelineRunTriggerModel.HeadersVar = map[string]interface{}{"anyKey": "anyValue"}
 				pipelineRunTriggerModel.Body = map[string]interface{}{"anyKey": "anyValue"}
 
@@ -1658,8 +1631,8 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelineRunOptionsModel := new(cdtektonpipelinev2.CreateTektonPipelineRunOptions)
 				createTektonPipelineRunOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				createTektonPipelineRunOptionsModel.TriggerName = core.StringPtr("testString")
-				createTektonPipelineRunOptionsModel.TriggerProperties = []cdtektonpipelinev2.Property{*propertyModel}
-				createTektonPipelineRunOptionsModel.SecureTriggerProperties = []cdtektonpipelinev2.Property{*propertyModel}
+				createTektonPipelineRunOptionsModel.TriggerProperties = map[string]interface{}{"anyKey": "anyValue"}
+				createTektonPipelineRunOptionsModel.SecureTriggerProperties = map[string]interface{}{"anyKey": "anyValue"}
 				createTektonPipelineRunOptionsModel.TriggerHeaders = map[string]interface{}{"anyKey": "anyValue"}
 				createTektonPipelineRunOptionsModel.TriggerBody = map[string]interface{}{"anyKey": "anyValue"}
 				createTektonPipelineRunOptionsModel.Trigger = pipelineRunTriggerModel
@@ -1680,20 +1653,11 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(serviceErr).To(BeNil())
 				Expect(cdTektonPipelineService).ToNot(BeNil())
 
-				// Construct an instance of the Property model
-				propertyModel := new(cdtektonpipelinev2.Property)
-				propertyModel.Name = core.StringPtr("testString")
-				propertyModel.Value = core.StringPtr("testString")
-				propertyModel.Href = core.StringPtr("testString")
-				propertyModel.Enum = []string{"testString"}
-				propertyModel.Type = core.StringPtr("secure")
-				propertyModel.Path = core.StringPtr("testString")
-
 				// Construct an instance of the PipelineRunTrigger model
 				pipelineRunTriggerModel := new(cdtektonpipelinev2.PipelineRunTrigger)
 				pipelineRunTriggerModel.Name = core.StringPtr("Manual Trigger 1")
-				pipelineRunTriggerModel.Properties = []cdtektonpipelinev2.Property{*propertyModel}
-				pipelineRunTriggerModel.SecureProperties = []cdtektonpipelinev2.Property{*propertyModel}
+				pipelineRunTriggerModel.Properties = map[string]interface{}{"anyKey": "anyValue"}
+				pipelineRunTriggerModel.SecureProperties = map[string]interface{}{"anyKey": "anyValue"}
 				pipelineRunTriggerModel.HeadersVar = map[string]interface{}{"anyKey": "anyValue"}
 				pipelineRunTriggerModel.Body = map[string]interface{}{"anyKey": "anyValue"}
 
@@ -1701,8 +1665,8 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelineRunOptionsModel := new(cdtektonpipelinev2.CreateTektonPipelineRunOptions)
 				createTektonPipelineRunOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				createTektonPipelineRunOptionsModel.TriggerName = core.StringPtr("testString")
-				createTektonPipelineRunOptionsModel.TriggerProperties = []cdtektonpipelinev2.Property{*propertyModel}
-				createTektonPipelineRunOptionsModel.SecureTriggerProperties = []cdtektonpipelinev2.Property{*propertyModel}
+				createTektonPipelineRunOptionsModel.TriggerProperties = map[string]interface{}{"anyKey": "anyValue"}
+				createTektonPipelineRunOptionsModel.SecureTriggerProperties = map[string]interface{}{"anyKey": "anyValue"}
 				createTektonPipelineRunOptionsModel.TriggerHeaders = map[string]interface{}{"anyKey": "anyValue"}
 				createTektonPipelineRunOptionsModel.TriggerBody = map[string]interface{}{"anyKey": "anyValue"}
 				createTektonPipelineRunOptionsModel.Trigger = pipelineRunTriggerModel
@@ -1744,20 +1708,11 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(serviceErr).To(BeNil())
 				Expect(cdTektonPipelineService).ToNot(BeNil())
 
-				// Construct an instance of the Property model
-				propertyModel := new(cdtektonpipelinev2.Property)
-				propertyModel.Name = core.StringPtr("testString")
-				propertyModel.Value = core.StringPtr("testString")
-				propertyModel.Href = core.StringPtr("testString")
-				propertyModel.Enum = []string{"testString"}
-				propertyModel.Type = core.StringPtr("secure")
-				propertyModel.Path = core.StringPtr("testString")
-
 				// Construct an instance of the PipelineRunTrigger model
 				pipelineRunTriggerModel := new(cdtektonpipelinev2.PipelineRunTrigger)
 				pipelineRunTriggerModel.Name = core.StringPtr("Manual Trigger 1")
-				pipelineRunTriggerModel.Properties = []cdtektonpipelinev2.Property{*propertyModel}
-				pipelineRunTriggerModel.SecureProperties = []cdtektonpipelinev2.Property{*propertyModel}
+				pipelineRunTriggerModel.Properties = map[string]interface{}{"anyKey": "anyValue"}
+				pipelineRunTriggerModel.SecureProperties = map[string]interface{}{"anyKey": "anyValue"}
 				pipelineRunTriggerModel.HeadersVar = map[string]interface{}{"anyKey": "anyValue"}
 				pipelineRunTriggerModel.Body = map[string]interface{}{"anyKey": "anyValue"}
 
@@ -1765,8 +1720,8 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelineRunOptionsModel := new(cdtektonpipelinev2.CreateTektonPipelineRunOptions)
 				createTektonPipelineRunOptionsModel.PipelineID = core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")
 				createTektonPipelineRunOptionsModel.TriggerName = core.StringPtr("testString")
-				createTektonPipelineRunOptionsModel.TriggerProperties = []cdtektonpipelinev2.Property{*propertyModel}
-				createTektonPipelineRunOptionsModel.SecureTriggerProperties = []cdtektonpipelinev2.Property{*propertyModel}
+				createTektonPipelineRunOptionsModel.TriggerProperties = map[string]interface{}{"anyKey": "anyValue"}
+				createTektonPipelineRunOptionsModel.SecureTriggerProperties = map[string]interface{}{"anyKey": "anyValue"}
 				createTektonPipelineRunOptionsModel.TriggerHeaders = map[string]interface{}{"anyKey": "anyValue"}
 				createTektonPipelineRunOptionsModel.TriggerBody = map[string]interface{}{"anyKey": "anyValue"}
 				createTektonPipelineRunOptionsModel.Trigger = pipelineRunTriggerModel
@@ -8114,33 +8069,17 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(createTektonPipelinePropertiesOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewCreateTektonPipelineRunOptions successfully`, func() {
-				// Construct an instance of the Property model
-				propertyModel := new(cdtektonpipelinev2.Property)
-				Expect(propertyModel).ToNot(BeNil())
-				propertyModel.Name = core.StringPtr("testString")
-				propertyModel.Value = core.StringPtr("testString")
-				propertyModel.Href = core.StringPtr("testString")
-				propertyModel.Enum = []string{"testString"}
-				propertyModel.Type = core.StringPtr("secure")
-				propertyModel.Path = core.StringPtr("testString")
-				Expect(propertyModel.Name).To(Equal(core.StringPtr("testString")))
-				Expect(propertyModel.Value).To(Equal(core.StringPtr("testString")))
-				Expect(propertyModel.Href).To(Equal(core.StringPtr("testString")))
-				Expect(propertyModel.Enum).To(Equal([]string{"testString"}))
-				Expect(propertyModel.Type).To(Equal(core.StringPtr("secure")))
-				Expect(propertyModel.Path).To(Equal(core.StringPtr("testString")))
-
 				// Construct an instance of the PipelineRunTrigger model
 				pipelineRunTriggerModel := new(cdtektonpipelinev2.PipelineRunTrigger)
 				Expect(pipelineRunTriggerModel).ToNot(BeNil())
 				pipelineRunTriggerModel.Name = core.StringPtr("Manual Trigger 1")
-				pipelineRunTriggerModel.Properties = []cdtektonpipelinev2.Property{*propertyModel}
-				pipelineRunTriggerModel.SecureProperties = []cdtektonpipelinev2.Property{*propertyModel}
+				pipelineRunTriggerModel.Properties = map[string]interface{}{"anyKey": "anyValue"}
+				pipelineRunTriggerModel.SecureProperties = map[string]interface{}{"anyKey": "anyValue"}
 				pipelineRunTriggerModel.HeadersVar = map[string]interface{}{"anyKey": "anyValue"}
 				pipelineRunTriggerModel.Body = map[string]interface{}{"anyKey": "anyValue"}
 				Expect(pipelineRunTriggerModel.Name).To(Equal(core.StringPtr("Manual Trigger 1")))
-				Expect(pipelineRunTriggerModel.Properties).To(Equal([]cdtektonpipelinev2.Property{*propertyModel}))
-				Expect(pipelineRunTriggerModel.SecureProperties).To(Equal([]cdtektonpipelinev2.Property{*propertyModel}))
+				Expect(pipelineRunTriggerModel.Properties).To(Equal(map[string]interface{}{"anyKey": "anyValue"}))
+				Expect(pipelineRunTriggerModel.SecureProperties).To(Equal(map[string]interface{}{"anyKey": "anyValue"}))
 				Expect(pipelineRunTriggerModel.HeadersVar).To(Equal(map[string]interface{}{"anyKey": "anyValue"}))
 				Expect(pipelineRunTriggerModel.Body).To(Equal(map[string]interface{}{"anyKey": "anyValue"}))
 
@@ -8149,8 +8088,8 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				createTektonPipelineRunOptionsModel := cdTektonPipelineService.NewCreateTektonPipelineRunOptions(pipelineID)
 				createTektonPipelineRunOptionsModel.SetPipelineID("94619026-912b-4d92-8f51-6c74f0692d90")
 				createTektonPipelineRunOptionsModel.SetTriggerName("testString")
-				createTektonPipelineRunOptionsModel.SetTriggerProperties([]cdtektonpipelinev2.Property{*propertyModel})
-				createTektonPipelineRunOptionsModel.SetSecureTriggerProperties([]cdtektonpipelinev2.Property{*propertyModel})
+				createTektonPipelineRunOptionsModel.SetTriggerProperties(map[string]interface{}{"anyKey": "anyValue"})
+				createTektonPipelineRunOptionsModel.SetSecureTriggerProperties(map[string]interface{}{"anyKey": "anyValue"})
 				createTektonPipelineRunOptionsModel.SetTriggerHeaders(map[string]interface{}{"anyKey": "anyValue"})
 				createTektonPipelineRunOptionsModel.SetTriggerBody(map[string]interface{}{"anyKey": "anyValue"})
 				createTektonPipelineRunOptionsModel.SetTrigger(pipelineRunTriggerModel)
@@ -8158,8 +8097,8 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 				Expect(createTektonPipelineRunOptionsModel).ToNot(BeNil())
 				Expect(createTektonPipelineRunOptionsModel.PipelineID).To(Equal(core.StringPtr("94619026-912b-4d92-8f51-6c74f0692d90")))
 				Expect(createTektonPipelineRunOptionsModel.TriggerName).To(Equal(core.StringPtr("testString")))
-				Expect(createTektonPipelineRunOptionsModel.TriggerProperties).To(Equal([]cdtektonpipelinev2.Property{*propertyModel}))
-				Expect(createTektonPipelineRunOptionsModel.SecureTriggerProperties).To(Equal([]cdtektonpipelinev2.Property{*propertyModel}))
+				Expect(createTektonPipelineRunOptionsModel.TriggerProperties).To(Equal(map[string]interface{}{"anyKey": "anyValue"}))
+				Expect(createTektonPipelineRunOptionsModel.SecureTriggerProperties).To(Equal(map[string]interface{}{"anyKey": "anyValue"}))
 				Expect(createTektonPipelineRunOptionsModel.TriggerHeaders).To(Equal(map[string]interface{}{"anyKey": "anyValue"}))
 				Expect(createTektonPipelineRunOptionsModel.TriggerBody).To(Equal(map[string]interface{}{"anyKey": "anyValue"}))
 				Expect(createTektonPipelineRunOptionsModel.Trigger).To(Equal(pipelineRunTriggerModel))
@@ -8573,13 +8512,6 @@ var _ = Describe(`CdTektonPipelineV2`, func() {
 			It(`Invoke NewPipelineRunTrigger successfully`, func() {
 				name := "start-deploy"
 				_model, err := cdTektonPipelineService.NewPipelineRunTrigger(name)
-				Expect(_model).ToNot(BeNil())
-				Expect(err).To(BeNil())
-			})
-			It(`Invoke NewProperty successfully`, func() {
-				name := "testString"
-				typeVar := "secure"
-				_model, err := cdTektonPipelineService.NewProperty(name, typeVar)
 				Expect(_model).ToNot(BeNil())
 				Expect(err).To(BeNil())
 			})


### PR DESCRIPTION
## PR summary
Attempting to trigger a PipelineRun with additional `properties` or `secureProperties` supplied results in an error creating the PipelineRun. Fix the format being used for the properties.

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
Attempting to trigger a PipelineRun with additional `properties` or `secureProperties` supplied will result in an error creating the PipelineRun. This is due to the wrong format being used for the properties, sending an Array instead of an Object.

## What is the new behavior?  
- Fix PipelineRun creation when supplying additional `properties` or `secureProperties`
- Update the integration test to account for this use case

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->