### PR TITLE
Fix format of bumpversion file

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,7 +1,7 @@
 [tool.bumpversion]
-current_version = 1.6.0
-commit = True
-message = Update version {current_version} -> {new_version} [skip ci]
+current_version = "1.6.0"
+commit = true
+message = "Update version {current_version} -> {new_version} [skip ci]"
 
 [[tool.bumpversion.files]]
 filename = "common/version.go"


### PR DESCRIPTION
## PR summary
The go-sdk build was failing on the semantic-release step. This appears to be due to bad formatting in the `.bumpversions.toml` file. Fixing that file should resolve the build issue

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?  
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->